### PR TITLE
refactor: 平板 UI 和动画调整和一些其他调整

### DIFF
--- a/app/src/main/java/com/android/purebilibili/feature/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/onboarding/OnboardingScreen.kt
@@ -58,23 +58,100 @@ fun OnboardingScreen(
             .fillMaxSize()
             .testTag("onboarding_root")
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .systemBarsPadding() 
-        ) {
-            
-            // --- Top Content (Pager) ---
+        Scaffold(
+            bottomBar = {
+                // --- Bottom Control Area ---
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 32.dp)
+                        .padding(bottom = 48.dp)
+                        .navigationBarsPadding(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(32.dp)
+                ) {
+                    // iOS-style Page Indicator
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        repeat(4) { iteration ->
+                            val isSelected = pagerState.currentPage == iteration
+                            // Animate width for the selected indicator
+                            val width by animateDpAsState(
+                                targetValue = if (isSelected) 24.dp else 8.dp,
+                                label = "indicatorWidth"
+                            )
+                            val color = if (isSelected)
+                                MaterialTheme.colorScheme.primary
+                            else
+                                MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)
+
+                            Box(
+                                modifier = Modifier
+                                    .height(8.dp)
+                                    .width(width)
+                                    .clip(CircleShape)
+                                    .background(color)
+                            )
+                        }
+                    }
+
+                    // Action Button Area (Keeps layout stable)
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(56.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        androidx.compose.animation.AnimatedVisibility(
+                            visible = pagerState.currentPage == 3,
+                            enter = fadeIn() + scaleIn(),
+                            exit = fadeOut() + scaleOut()
+                        ) {
+                            val isLastPage = pagerState.currentPage == lastPage
+                            val actionColors =
+                                com.android.purebilibili.core.theme.resolveAdaptivePrimaryAccentColors(
+                                    MaterialTheme.colorScheme
+                                )
+                            Button(
+                                onClick = advanceOrFinish,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .testTag("onboarding_action_button"),
+                                shape = RoundedCornerShape(28.dp), // Squircle-ish
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = actionColors.backgroundColor,
+                                    contentColor = actionColors.contentColor
+                                ),
+                                elevation = ButtonDefaults.buttonElevation(
+                                    defaultElevation = 0.dp,
+                                    pressedElevation = 0.dp
+                                )
+                            ) {
+                                Text(
+                                    text = if (isLastPage) "开始体验" else "下一步",
+                                    fontSize = 18.sp,
+                                    fontWeight = FontWeight.SemiBold
+                                )
+                            }
+                        }
+                    }
+                }
+
+            }
+        ) { innerPadding ->
             HorizontalPager(
                 state = pagerState,
                 modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth(),
+                    .fillMaxSize(),
                 userScrollEnabled = true
             ) { page ->
+                // --- Top Content (Pager) ---
                 // Basic Parallax/Scale Effect
-                val pageOffset = (pagerState.currentPage - page) + pagerState.currentPageOffsetFraction
-                
+                val pageOffset =
+                    (pagerState.currentPage - page) + pagerState.currentPageOffsetFraction
+
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
@@ -85,6 +162,7 @@ fun OnboardingScreen(
                             scaleY = scale
                             alpha = lerp(1f, 0.3f, pageOffset.absoluteValue)
                         }
+                        .padding(innerPadding)
                         .padding(horizontal = 32.dp),
                     contentAlignment = Alignment.Center
                 ) {
@@ -97,82 +175,6 @@ fun OnboardingScreen(
                 }
             }
 
-            // --- Bottom Control Area ---
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 32.dp, vertical = 48.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(32.dp)
-            ) {
-                
-                // iOS-style Page Indicator
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    repeat(4) { iteration ->
-                        val isSelected = pagerState.currentPage == iteration
-                        // Animate width for the selected indicator
-                        val width by animateDpAsState(
-                            targetValue = if (isSelected) 24.dp else 8.dp,
-                            label = "indicatorWidth"
-                        )
-                        val color = if (isSelected) 
-                            MaterialTheme.colorScheme.primary 
-                        else 
-                            MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)
-
-                        Box(
-                            modifier = Modifier
-                                .height(8.dp)
-                                .width(width)
-                                .clip(CircleShape)
-                                .background(color)
-                        )
-                    }
-                }
-
-                // Action Button Area (Keeps layout stable)
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(56.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    androidx.compose.animation.AnimatedVisibility(
-                        visible = pagerState.currentPage == 3,
-                        enter = fadeIn() + scaleIn(),
-                        exit = fadeOut() + scaleOut()
-                    ) {
-                        val isLastPage = pagerState.currentPage == lastPage
-                        val actionColors = com.android.purebilibili.core.theme.resolveAdaptivePrimaryAccentColors(
-                            MaterialTheme.colorScheme
-                        )
-                        Button(
-                            onClick = advanceOrFinish,
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .testTag("onboarding_action_button"),
-                            shape = RoundedCornerShape(28.dp), // Squircle-ish
-                            colors = ButtonDefaults.buttonColors(
-                                containerColor = actionColors.backgroundColor,
-                                contentColor = actionColors.contentColor
-                            ),
-                            elevation = ButtonDefaults.buttonElevation(
-                                defaultElevation = 0.dp,
-                                pressedElevation = 0.dp
-                            )
-                        ) {
-                            Text(
-                                text = if (isLastPage) "开始体验" else "下一步",
-                                fontSize = 18.sp,
-                                fontWeight = FontWeight.SemiBold
-                            )
-                        }
-                    }
-                }
-            }
         }
     }
 }

--- a/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletCinemaLayout.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletCinemaLayout.kt
@@ -198,14 +198,7 @@ fun TabletCinemaLayout(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(
-                brush = Brush.verticalGradient(
-                    colors = listOf(
-                        MaterialTheme.colorScheme.surfaceContainerLowest,
-                        MaterialTheme.colorScheme.surfaceContainer
-                    )
-                )
-            )
+            .background(MaterialTheme.colorScheme.surfaceContainer)
     ) {
         Row(
             modifier = Modifier

--- a/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletCinemaLayout.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletCinemaLayout.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -60,6 +61,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -507,7 +509,6 @@ private fun CinemaMetaPanel(
             success.info.pages.size
         ) {
             resolveCinemaMetaPanelBlocks(
-                hasOwner = success.info.owner.mid > 0L || success.info.owner.name.isNotBlank(),
                 hasCollection = success.info.ugc_season != null,
                 hasMultiplePages = success.info.pages.size > 1
             )
@@ -525,38 +526,82 @@ private fun CinemaMetaPanel(
             ) { block ->
                 when (block) {
                     CinemaMetaPanelBlock.ACTIONS -> {
-                        ActionButtonsRow(
-                            info = success.info,
-                            isFavorited = success.isFavorited,
-                            isLiked = success.isLiked,
-                            coinCount = success.coinCount,
-                            downloadProgress = downloadProgress,
-                            isInWatchLater = success.isInWatchLater,
-                            onFavoriteClick = onFavoriteClick,
-                            onLikeClick = onLikeClick,
-                            onCoinClick = onCoinClick,
-                            onTripleClick = onTripleClick,
-                            onDownloadClick = onDownloadClick,
-                            onWatchLaterClick = onWatchLaterClick,
-                            onCommentClick = onOpenComments,
-                            onShareClick = {
-                                ShareUtils.shareVideo(
-                                    context,
-                                    success.info.title,
-                                    success.info.bvid
+                        val actions = remember {
+                            movableContentOf<Modifier> { modifier ->
+                                ActionButtonsRow(
+                                    info = success.info,
+                                    isFavorited = success.isFavorited,
+                                    isLiked = success.isLiked,
+                                    coinCount = success.coinCount,
+                                    downloadProgress = downloadProgress,
+                                    isInWatchLater = success.isInWatchLater,
+                                    onFavoriteClick = onFavoriteClick,
+                                    onLikeClick = onLikeClick,
+                                    onCoinClick = onCoinClick,
+                                    onTripleClick = onTripleClick,
+                                    onDownloadClick = onDownloadClick,
+                                    onWatchLaterClick = onWatchLaterClick,
+                                    onCommentClick = onOpenComments,
+                                    onShareClick = {
+                                        ShareUtils.shareVideo(
+                                            context,
+                                            success.info.title,
+                                            success.info.bvid
+                                        )
+                                    },
+                                    modifier = modifier
                                 )
                             }
-                        )
-                    }
-                    CinemaMetaPanelBlock.UP_INFO -> {
-                        UpInfoSection(
-                            info = success.info,
-                            isFollowing = success.isFollowing,
-                            onFollowClick = onFollowClick,
-                            onUpClick = onUpClick,
-                            followerCount = success.ownerFollowerCount,
-                            videoCount = success.ownerVideoCount
-                        )
+                        }
+                        val upInfo = remember {
+                            movableContentOf<Modifier> { modifier ->
+                                UpInfoSection(
+                                    info = success.info,
+                                    isFollowing = success.isFollowing,
+                                    onFollowClick = onFollowClick,
+                                    onUpClick = onUpClick,
+                                    followerCount = success.ownerFollowerCount,
+                                    videoCount = success.ownerVideoCount,
+                                    modifier = modifier
+                                )
+                            }
+                        }
+                        if (success.info.owner.mid > 0L || success.info.owner.name.isNotBlank()) { // hasOwner
+                            BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+                                val isWide = maxWidth >= 600.dp
+
+                                AnimatedContent(
+                                    targetState = isWide,
+                                    transitionSpec = {
+                                        // 动画配置：淡入淡出 (Fade) + 尺寸平滑变换 (SizeTransform)
+                                        (fadeIn(animationSpec = tween(400)) togetherWith fadeOut(
+                                            animationSpec = tween(400)
+                                        ))
+                                            .using(SizeTransform(clip = false))
+                                    },
+                                    label = "ActionUpInfoTransition"
+                                ) { targetIsWide ->
+                                    if (targetIsWide) {
+                                        // 宽度足够，横排
+                                        Row(
+                                            Modifier.fillMaxWidth(),
+                                            horizontalArrangement = Arrangement.SpaceBetween
+                                        ) {
+                                            upInfo(Modifier.weight(1f))
+                                            actions(Modifier.weight(1f))
+                                        }
+                                    } else {
+                                        // 宽度不足，竖排
+                                        Column(Modifier.fillMaxWidth()) {
+                                            actions(Modifier.fillMaxWidth())
+                                            upInfo(Modifier.fillMaxWidth())
+                                        }
+                                    }
+                                }
+                            }
+                        } else {
+                            actions(Modifier.fillMaxWidth())
+                        }
                     }
                     CinemaMetaPanelBlock.INTRO -> {
                         CinemaVideoIntroSection(
@@ -607,7 +652,7 @@ private fun CinemaVideoIntroSection(
         Surface(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(8.dp),
+                .padding(horizontal = 12.dp, vertical = 6.dp),
             shape = RoundedCornerShape(16.dp),
             color = resolveCinemaIntroCardContainerColor(
                 isDarkTheme = isDarkTheme,
@@ -635,14 +680,12 @@ private fun CinemaVideoIntroSection(
             )
         ) {
             AiSummaryCard(
-                aiSummary = success.aiSummary,
-                modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp)
+                aiSummary = success.aiSummary
             )
         } else if (videoAiSummaryEntryEnabled && success.aiSummaryPrompt != null) {
             AiSummaryPromptCard(
                 promptState = success.aiSummaryPrompt,
-                onActionClick = onRetryAiSummary,
-                modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp)
+                onActionClick = onRetryAiSummary
             )
         }
     }

--- a/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletCinemaLayout.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletCinemaLayout.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.updateTransition
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
@@ -359,7 +360,6 @@ private fun CinemaStagePlayer(
             Modifier.sharedBounds(
                 sharedContentState = rememberSharedContentState(key = "video_cover_$bvid"),
                 animatedVisibilityScope = requireNotNull(animatedVisibilityScope),
-                boundsTransform = { _, _ -> com.android.purebilibili.core.theme.AnimationSpecs.BiliPaiSpringSpec },
                 clipInOverlayDuringTransition = OverlayClip(
                     RoundedCornerShape(12.dp)
                 )
@@ -368,85 +368,80 @@ private fun CinemaStagePlayer(
     } else {
         Modifier
     }
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(24.dp),
-        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.94f),
-        tonalElevation = 4.dp
+    BoxWithConstraints(
+        modifier = Modifier
+            .fillMaxWidth()
     ) {
-        BoxWithConstraints(
-            modifier = Modifier
-                .fillMaxWidth()
+        val playerWidth = minOf(maxWidth, playerMaxWidth)
+        val videoHeight = if (forceCoverOnlyOnReturn) {
+            playerWidth / VIDEO_SHARED_COVER_ASPECT_RATIO
+        } else {
+            playerWidth * 9f / 16f
+        }
+        Surface(
+            modifier = playerContainerModifier
+                .width(playerWidth)
+                .height(videoHeight)
+                .aspectRatio(playerWidth / videoHeight),
+            shape = RoundedCornerShape(24.dp),
+            color = MaterialTheme.colorScheme.surface.copy(alpha = 0.94f),
+            tonalElevation = 4.dp
         ) {
-            val playerWidth = minOf(maxWidth, playerMaxWidth)
-            val videoHeight = if (forceCoverOnlyOnReturn) {
-                playerWidth / VIDEO_SHARED_COVER_ASPECT_RATIO
-            } else {
-                playerWidth * 9f / 16f
-            }
-            Box(
-                modifier = playerContainerModifier
-                    .width(playerWidth)
-                    .height(videoHeight)
-                    .align(Alignment.Center)
-                    .background(Color.Black)
-            ) {
-                VideoPlayerSection(
-                    playerState = playerState,
-                    uiState = uiState,
-                    isFullscreen = false,
-                    isInPipMode = isInPipMode,
-                    onToggleFullscreen = onToggleFullscreen,
-                    onQualityChange = { qid -> viewModel.changeQuality(qid) },
-                    onBack = onBack,
-                    bvid = bvid,
-                    coverUrl = coverUrl,
-                    onDoubleTapLike = { viewModel.toggleLike() },
-                    onReloadVideo = { viewModel.reloadVideo() },
-                    currentCdnIndex = success?.currentCdnIndex ?: 0,
-                    cdnCount = success?.cdnCount ?: 1,
-                    onSwitchCdn = { viewModel.switchCdn() },
-                    onSwitchCdnTo = { viewModel.switchCdnTo(it) },
-                    isAudioOnly = false,
-                    onAudioOnlyToggle = {
-                        viewModel.setAudioMode(true)
-                        onNavigateToAudioMode()
-                    },
-                    sleepTimerMinutes = sleepTimerMinutes,
-                    onSleepTimerChange = { viewModel.setSleepTimer(it) },
-                    videoshotData = success?.videoshotData,
-                    viewPoints = viewPoints,
-                    isVerticalVideo = isVerticalVideo,
-                    onPortraitFullscreen = { playerState.setPortraitFullscreen(true) },
-                    isPortraitFullscreen = isPortraitFullscreen,
-                    onPipClick = onPipClick,
-                    currentCodec = currentCodec,
-                    onCodecChange = onCodecChange,
-                    currentSecondCodec = currentSecondCodec,
-                    onSecondCodecChange = onSecondCodecChange,
-                    currentAudioQuality = currentAudioQuality,
-                    onAudioQualityChange = onAudioQualityChange,
-                    onPlaybackSpeedChange = { viewModel.applyPlaybackSpeedFromUi(it) },
-                    onSaveCover = { viewModel.saveCover(context) },
-                    onDownloadAudio = { viewModel.downloadAudio(context) },
-                    currentPlayMode = currentPlayMode,
-                    onPlayModeClick = onPlayModeClick,
-                    onRelatedVideoClick = onRelatedVideoClick,
-                    relatedVideos = success?.related ?: emptyList(),
-                    forceCoverOnly = forceCoverOnlyOnReturn,
-                    ugcSeason = success?.info?.ugc_season,
-                    isFollowed = success?.isFollowing ?: false,
-                    isLiked = success?.isLiked ?: false,
-                    isCoined = success?.coinCount?.let { it > 0 } ?: false,
-                    isFavorited = success?.isFavorited ?: false,
-                    onToggleFollow = { viewModel.toggleFollow() },
-                    onToggleLike = { viewModel.toggleLike() },
-                    onDislike = { viewModel.markVideoNotInterested() },
-                    onCoin = { viewModel.showCoinDialog() },
-                    onToggleFavorite = { viewModel.toggleFavorite() },
-                    onTriple = { viewModel.doTripleAction() }
-                )
-            }
+            VideoPlayerSection(
+                playerState = playerState,
+                uiState = uiState,
+                isFullscreen = false,
+                isInPipMode = isInPipMode,
+                onToggleFullscreen = onToggleFullscreen,
+                onQualityChange = { qid -> viewModel.changeQuality(qid) },
+                onBack = onBack,
+                bvid = bvid,
+                coverUrl = coverUrl,
+                onDoubleTapLike = { viewModel.toggleLike() },
+                onReloadVideo = { viewModel.reloadVideo() },
+                currentCdnIndex = success?.currentCdnIndex ?: 0,
+                cdnCount = success?.cdnCount ?: 1,
+                onSwitchCdn = { viewModel.switchCdn() },
+                onSwitchCdnTo = { viewModel.switchCdnTo(it) },
+                isAudioOnly = false,
+                onAudioOnlyToggle = {
+                    viewModel.setAudioMode(true)
+                    onNavigateToAudioMode()
+                },
+                sleepTimerMinutes = sleepTimerMinutes,
+                onSleepTimerChange = { viewModel.setSleepTimer(it) },
+                videoshotData = success?.videoshotData,
+                viewPoints = viewPoints,
+                isVerticalVideo = isVerticalVideo,
+                onPortraitFullscreen = { playerState.setPortraitFullscreen(true) },
+                isPortraitFullscreen = isPortraitFullscreen,
+                onPipClick = onPipClick,
+                currentCodec = currentCodec,
+                onCodecChange = onCodecChange,
+                currentSecondCodec = currentSecondCodec,
+                onSecondCodecChange = onSecondCodecChange,
+                currentAudioQuality = currentAudioQuality,
+                onAudioQualityChange = onAudioQualityChange,
+                onPlaybackSpeedChange = { viewModel.applyPlaybackSpeedFromUi(it) },
+                onSaveCover = { viewModel.saveCover(context) },
+                onDownloadAudio = { viewModel.downloadAudio(context) },
+                currentPlayMode = currentPlayMode,
+                onPlayModeClick = onPlayModeClick,
+                onRelatedVideoClick = onRelatedVideoClick,
+                relatedVideos = success?.related ?: emptyList(),
+                forceCoverOnly = forceCoverOnlyOnReturn,
+                ugcSeason = success?.info?.ugc_season,
+                isFollowed = success?.isFollowing ?: false,
+                isLiked = success?.isLiked ?: false,
+                isCoined = success?.coinCount?.let { it > 0 } ?: false,
+                isFavorited = success?.isFavorited ?: false,
+                onToggleFollow = { viewModel.toggleFollow() },
+                onToggleLike = { viewModel.toggleLike() },
+                onDislike = { viewModel.markVideoNotInterested() },
+                onCoin = { viewModel.showCoinDialog() },
+                onToggleFavorite = { viewModel.toggleFavorite() },
+                onTriple = { viewModel.doTripleAction() }
+            )
         }
     }
 }
@@ -572,13 +567,6 @@ private fun CinemaMetaPanel(
 
                                 AnimatedContent(
                                     targetState = isWide,
-                                    transitionSpec = {
-                                        // 动画配置：淡入淡出 (Fade) + 尺寸平滑变换 (SizeTransform)
-                                        (fadeIn(animationSpec = tween(400)) togetherWith fadeOut(
-                                            animationSpec = tween(400)
-                                        ))
-                                            .using(SizeTransform(clip = false))
-                                    },
                                     label = "ActionUpInfoTransition"
                                 ) { targetIsWide ->
                                     if (targetIsWide) {
@@ -665,14 +653,6 @@ private fun CinemaVideoIntroSection(
                 bgmInfo = success.bgmInfo,
                 bgmInfoList = success.bgmInfoList
             )
-            if (success.info.desc.isBlank()) {
-                Text(
-                    text = "暂无简介",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 6.dp)
-                )
-            }
         }
         if (shouldShowAiSummaryEntry(
                 aiSummary = success.aiSummary,
@@ -710,28 +690,23 @@ private fun CinemaSideCurtain(
     showUpBadge: Boolean,
     onSearchKeywordClick: (String) -> Unit
 ) {
-    val scope = androidx.compose.runtime.rememberCoroutineScope()
     val subReplyState by commentViewModel.subReplyState.collectAsState()
+    val transition = updateTransition(targetState = state, label = "SideCurtainAnimation")
     LaunchedEffect(subReplyState.visible) {
         if (subReplyState.visible) {
             onTabSelected(0)
-            if (pagerState.currentPage != 0) {
-                pagerState.animateScrollToPage(0)
+        }
+    }
+    LaunchedEffect(selectedTab) {
+        if (pagerState.currentPage != selectedTab) {
+            if (transition.currentState == TabletSideCurtainState.OPEN) {
+                pagerState.animateScrollToPage(selectedTab)
+            } else {    // 动画中或关闭状态停用动画，避免卡动画
+                pagerState.scrollToPage(selectedTab)
             }
         }
     }
-    AnimatedContent(
-        targetState = state,
-        transitionSpec = {
-            // 使用 fadeIn + scaleIn 与 fadeOut 组合，避免尺寸变化时的布局生硬
-            (fadeIn(animationSpec = tween(220, delayMillis = 90)))
-                .togetherWith(fadeOut(animationSpec = tween(90)))
-                .using(
-                    // 关键：SizeTransform 决定了容器尺寸如何变化
-                    SizeTransform(clip = true)
-                )
-        },
-        label = "SideCurtainAnimation",
+    transition.AnimatedContent(
         modifier = Modifier.fillMaxHeight()
     ) { targetState ->
         Row(
@@ -805,9 +780,6 @@ private fun CinemaSideCurtain(
                                     selected = pagerState.currentPage == 0,
                                     onClick = {
                                         onTabSelected(0)
-                                        scope.launch {
-                                            pagerState.animateScrollToPage(0)
-                                        }
                                     },
                                     text = {
                                         Text(
@@ -819,9 +791,6 @@ private fun CinemaSideCurtain(
                                     selected = pagerState.currentPage == 1,
                                     onClick = {
                                         onTabSelected(1)
-                                        scope.launch {
-                                            pagerState.animateScrollToPage(1)
-                                        }
                                     },
                                     text = { Text("相关推荐") }
                                 )

--- a/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletVideoLayoutPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletVideoLayoutPolicy.kt
@@ -17,7 +17,6 @@ data class TabletCinemaLayoutPolicy(
 
 internal enum class CinemaMetaPanelBlock {
     ACTIONS,
-    UP_INFO,
     INTRO,
     COLLECTION,
     PAGES
@@ -210,15 +209,11 @@ internal fun resolveCinemaIntroCardContainerColor(
 }
 
 internal fun resolveCinemaMetaPanelBlocks(
-    hasOwner: Boolean,
     hasCollection: Boolean,
     hasMultiplePages: Boolean
 ): List<CinemaMetaPanelBlock> {
     return buildList {
         add(CinemaMetaPanelBlock.ACTIONS)
-        if (hasOwner) {
-            add(CinemaMetaPanelBlock.UP_INFO)
-        }
         add(CinemaMetaPanelBlock.INTRO)
         if (hasCollection) {
             add(CinemaMetaPanelBlock.COLLECTION)

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoActionSection.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoActionSection.kt
@@ -93,7 +93,8 @@ fun ActionButtonsRow(
     onDownloadClick: () -> Unit = {},  //  下载点击
     onWatchLaterClick: () -> Unit = {},  //  稍后再看点击
     onFavoriteLongClick: () -> Unit = {}, // [New] 长按收藏
-    onShareClick: () -> Unit = {}
+    onShareClick: () -> Unit = {},
+    modifier: Modifier = Modifier
 ) {
     val primaryActionColor = MaterialTheme.colorScheme.primary
     val haptic = rememberHapticFeedback()
@@ -130,8 +131,7 @@ fun ActionButtonsRow(
     }
 
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
+        modifier = modifier
             .animateContentSize() // 🚀 [优化] 使布局变化更平滑
             .padding(horizontal = 4.dp, vertical = 6.dp),
         horizontalArrangement = Arrangement.spacedBy(2.dp),

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
@@ -2,6 +2,8 @@
 package com.android.purebilibili.feature.video.ui.section
 
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
@@ -34,6 +36,7 @@ import com.android.purebilibili.data.model.response.ViewInfo
 import com.android.purebilibili.data.model.response.VideoTag
 import com.android.purebilibili.core.ui.common.copyOnLongPress
 import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.ui.draw.rotate
 import com.android.purebilibili.core.ui.common.copyOnClick
 import com.android.purebilibili.core.ui.components.resolveUpStatsText
 import com.android.purebilibili.core.ui.components.UserUpBadge
@@ -224,40 +227,48 @@ fun VideoTitleWithDesc(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.Top
         ) {
-                //  共享元素过渡 - 标题
-                var titleModifier = if (animateLayout) Modifier.animateContentSize() else Modifier
-                
-                //  注意：使用 ExperimentalSharedTransitionApi 注解需要上下文
-                if (metadataSharedEnabled) {
-                    with(requireNotNull(sharedTransitionScope)) {
-                         titleModifier = titleModifier.sharedBounds(
-                            sharedContentState = rememberSharedContentState(key = "video_title_${info.bvid}"),
-                            animatedVisibilityScope = requireNotNull(animatedVisibilityScope),
-                            boundsTransform = { _, _ ->
-                                androidx.compose.animation.core.spring(dampingRatio = 0.8f, stiffness = 200f)
-                            }
-                        )
-                    }
-                }
+            //  共享元素过渡 - 标题
+            var titleModifier = if (animateLayout) Modifier.animateContentSize() else Modifier
 
-                Text(
-                    text = info.title,
-                    style = MaterialTheme.typography.titleMedium.copy(
-                        fontSize = 15.sp,
-                        lineHeight = 21.sp,
-                        fontWeight = FontWeight.SemiBold
-                    ),
-                    maxLines = if (expanded) Int.MAX_VALUE else 1,
-                    overflow = TextOverflow.Ellipsis,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    modifier = titleModifier
-                )
-            Spacer(Modifier.width(4.dp))
+            //  注意：使用 ExperimentalSharedTransitionApi 注解需要上下文
+            if (metadataSharedEnabled) {
+                with(requireNotNull(sharedTransitionScope)) {
+                     titleModifier = titleModifier.sharedBounds(
+                        sharedContentState = rememberSharedContentState(key = "video_title_${info.bvid}"),
+                        animatedVisibilityScope = requireNotNull(animatedVisibilityScope),
+                        boundsTransform = { _, _ ->
+                            androidx.compose.animation.core.spring(dampingRatio = 0.8f, stiffness = 200f)
+                        }
+                    )
+                }
+            }
+
+            Text(
+                text = info.title,
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontSize = 16.sp,
+                    lineHeight = 21.sp,
+                    fontWeight = FontWeight.SemiBold
+                ),
+                maxLines = if (expanded) Int.MAX_VALUE else 1,
+                overflow = TextOverflow.Ellipsis,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = titleModifier.weight(1f)
+            )
+
+            val rotateAngle by animateFloatAsState(
+                targetValue = if (expanded) 180f else 0f, // 展开时旋转180度
+                animationSpec = tween(durationMillis = 300), // 设置动画时长和曲线
+                label = "IconRotation"
+            )
             Icon(
-                imageVector = if (expanded) CupertinoIcons.Default.ChevronUp else CupertinoIcons.Default.ChevronDown,
+                imageVector = CupertinoIcons.Default.ChevronDown,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
-                modifier = Modifier.size(16.dp)
+                modifier = Modifier
+                    .rotate(rotateAngle)
+                    .size(20.dp)
+                    .padding(4.dp)
             )
         }
         

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
@@ -517,7 +517,8 @@ fun UpInfoSection(
     showOwnerAvatar: Boolean = true,
     followerCount: Int? = null,
     videoCount: Int? = null,
-    transitionEnabled: Boolean = false  // 🔗 共享元素过渡开关
+    transitionEnabled: Boolean = false,  // 🔗 共享元素过渡开关
+    modifier: Modifier = Modifier
 ) {
     //  尝试获取共享元素作用域
     val sharedTransitionScope = com.android.purebilibili.core.ui.LocalSharedTransitionScope.current
@@ -537,8 +538,7 @@ fun UpInfoSection(
     )
     val showInlineOwnerIdentity = shouldShowInlineOwnerIdentity(showOwnerAvatar = showOwnerAvatar)
     Column(
-        modifier = Modifier
-            .fillMaxWidth()
+        modifier = modifier
     ) {
         Row(
             modifier = Modifier


### PR DESCRIPTION
* 优化平板 UI，在宽度足够时 action 和 upinfo 会在同一行显示
* 统一平板 UI 的动画
* 优化了视频简介的样式
  * 展开指示器会固定在右侧，而且有动画
  * 稍微调大了一点标题字体
* 优化了首次使用体验
  * 原先只有上半部分可以滑动，现在全屏都可以滑动了