### PR TITLE
fix: initial priority causing null pointer exception

### DIFF
--- a/app/src/main/java/com/android/purebilibili/feature/list/ListViewModel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/list/ListViewModel.kt
@@ -32,10 +32,7 @@ abstract class BaseListViewModel(application: Application, private val pageTitle
     protected val _uiState = MutableStateFlow(ListUiState(title = pageTitle, isLoading = true))
     val uiState = _uiState.asStateFlow()
 
-    init {
-        loadData()
-    }
-
+    // 应当在子类初始化完成后调用
     fun loadData() {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, error = null)
@@ -432,6 +429,10 @@ class HistoryViewModel(application: Application) : BaseListViewModel(application
         private const val HISTORY_DELETE_MAX_ATTEMPTS = 3
         private const val HISTORY_DELETE_RETRY_BASE_DELAY_MS = 300L
     }
+
+    init {
+        loadData()
+    }
 }
 
 // --- 收藏 ViewModel (支持分页加载所有收藏夹) ---
@@ -757,5 +758,9 @@ class FavoriteViewModel(application: Application) : BaseListViewModel(applicatio
                  _uiState.value = _uiState.value.copy(error = message)
             }
         }
+    }
+
+    init {
+        loadData()
     }
 }

--- a/app/src/main/java/com/android/purebilibili/feature/space/SeasonSeriesDetailViewModel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/space/SeasonSeriesDetailViewModel.kt
@@ -213,4 +213,8 @@ class SeasonSeriesDetailViewModel(application: Application) : BaseListViewModel(
             }
         }
     }
+
+    init {
+        loadData()
+    }
 }


### PR DESCRIPTION
目的在修复偶发的
`private val _historyItemsMap = mutableMapOf<String, com.android.purebilibili.data.model.response.HistoryItem>()`
在 init 时调用 clear 会报错：
java.lang.NullPointerException: Attempt to invoke interface method 'void java.util.Map.clear()' on a null object reference

父类的初始化永远早于子类。当你执行父类的 init 时，子类的成员变量还没有被分配内存空间（处于 uninitialized 状态），此时调用子类方法访问该变量，必然会抛出 NullPointerException。