### PR TITLE
在视频详情页内联“发现音乐”UI，减少网页跳转割裂感

### DIFF
--- a/app/src/main/java/com/android/purebilibili/core/network/ApiClient.kt
+++ b/app/src/main/java/com/android/purebilibili/core/network/ApiClient.kt
@@ -529,7 +529,7 @@ interface BilibiliApi {
         @Query("aid") aid: Long,
         @Query("cid") cid: Long,
         @Query("pn") pn: Int = 1,
-        @Query("ps") ps: Int = 6
+        @Query("ps") ps: Int = 5
     ): com.android.purebilibili.data.model.response.BgmRecommendListResponse
 
     @GET("x/stein/edgeinfo_v2")

--- a/app/src/main/java/com/android/purebilibili/core/network/ApiClient.kt
+++ b/app/src/main/java/com/android/purebilibili/core/network/ApiClient.kt
@@ -516,6 +516,22 @@ interface BilibiliApi {
         @Query("cid") cid: Long
     ): com.android.purebilibili.data.model.response.BgmMultipleMusicResponse
 
+    @GET("x/copyright-music-publicity/bgm/detail")
+    suspend fun getBgmDetail(
+        @Query("music_id") musicId: String,
+        @Query("aid") aid: Long,
+        @Query("cid") cid: Long
+    ): com.android.purebilibili.data.model.response.BgmDetailResponse
+
+    @GET("x/copyright-music-publicity/bgm/recommend_list")
+    suspend fun getBgmRecommendList(
+        @Query("music_id") musicId: String,
+        @Query("aid") aid: Long,
+        @Query("cid") cid: Long,
+        @Query("pn") pn: Int = 1,
+        @Query("ps") ps: Int = 6
+    ): com.android.purebilibili.data.model.response.BgmRecommendListResponse
+
     @GET("x/stein/edgeinfo_v2")
     suspend fun getInteractEdgeInfo(
         @Query("bvid") bvid: String,

--- a/app/src/main/java/com/android/purebilibili/data/model/response/PlayerInfoResponse.kt
+++ b/app/src/main/java/com/android/purebilibili/data/model/response/PlayerInfoResponse.kt
@@ -73,9 +73,85 @@ data class BgmMultipleMusicData(
     val list: List<BgmInfo> = emptyList()
 )
 
+@Serializable
+data class BgmDetailResponse(
+    val code: Int = 0,
+    val message: String = "",
+    val data: BgmDetailData? = null
+)
+
+@Serializable
+data class BgmDetailData(
+    @SerialName("music_title")
+    val musicTitle: String = "",
+    @SerialName("origin_artist")
+    val originArtist: String = "",
+    @SerialName("mv_cover")
+    val mvCover: String = "",
+    @SerialName("wish_count")
+    val wishCount: Int = 0,
+    @SerialName("music_shares")
+    val musicShares: Int = 0,
+    @SerialName("listen_pv")
+    val listenPv: Long = 0,
+    @SerialName("music_hot")
+    val musicHot: Long = 0,
+    @SerialName("music_relation")
+    val musicRelation: Int = 0,
+    @SerialName("music_comment")
+    val musicComment: BgmCommentInfo? = null,
+    @SerialName("flow_attr")
+    val flowAttr: BgmFlowAttr? = null
+)
+
+@Serializable
+data class BgmCommentInfo(
+    val state: Int = 0,
+    val nums: Int = 0,
+    val oid: Long = 0,
+    @SerialName("page_type")
+    val pageType: Int = 0
+)
+
+@Serializable
+data class BgmFlowAttr(
+    @SerialName("no_share")
+    val noShare: Boolean = false,
+    @SerialName("no_comment")
+    val noComment: Boolean = false
+)
+
+@Serializable
+data class BgmRecommendListResponse(
+    val code: Int = 0,
+    val message: String = "",
+    val data: BgmRecommendListData? = null
+)
+
+@Serializable
+data class BgmRecommendListData(
+    val list: List<BgmRecommendVideo> = emptyList()
+)
+
+@Serializable
+data class BgmRecommendVideo(
+    val aid: Long = 0,
+    val bvid: String = "",
+    val cid: Long = 0,
+    val cover: String = "",
+    val title: String = "",
+    val mid: Long = 0,
+    @SerialName("up_nick_name")
+    val upNickName: String = "",
+    val play: Int = 0,
+    val danmu: Int = 0,
+    val duration: Int = 0,
+    val label: String = ""
+)
+
 /**
  * 视频章节/看点信息
- * 
+ *
  * 用于在进度条上显示章节标记
  */
 @Serializable

--- a/app/src/main/java/com/android/purebilibili/data/repository/ViewGrpcRepository.kt
+++ b/app/src/main/java/com/android/purebilibili/data/repository/ViewGrpcRepository.kt
@@ -43,13 +43,21 @@ internal object ViewGrpcRepository {
             }
         }
 
-    suspend fun getBgmRecommendVideos(musicId: String, aid: Long, cid: Long): Result<List<BgmRecommendVideo>> =
+    suspend fun getBgmRecommendVideos(
+        musicId: String,
+        aid: Long,
+        cid: Long,
+        page: Int = 1,
+        pageSize: Int = 5
+    ): Result<List<BgmRecommendVideo>> =
         withContext(Dispatchers.IO) {
             runCatching {
                 NetworkModule.api.getBgmRecommendList(
                     musicId = musicId,
                     aid = aid,
-                    cid = cid
+                    cid = cid,
+                    pn = page,
+                    ps = pageSize
                 ).data?.list.orEmpty()
             }.onFailure { e ->
                 Logger.w(TAG, "BGM recommend API failed: ${e.message}")

--- a/app/src/main/java/com/android/purebilibili/data/repository/ViewGrpcRepository.kt
+++ b/app/src/main/java/com/android/purebilibili/data/repository/ViewGrpcRepository.kt
@@ -2,7 +2,9 @@ package com.android.purebilibili.data.repository
 
 import com.android.purebilibili.core.network.NetworkModule
 import com.android.purebilibili.core.util.Logger
+import com.android.purebilibili.data.model.response.BgmDetailData
 import com.android.purebilibili.data.model.response.BgmInfo
+import com.android.purebilibili.data.model.response.BgmRecommendVideo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -14,11 +16,10 @@ internal object ViewGrpcRepository {
             runCatching {
                 val response = NetworkModule.api.getBgmMultipleMusic(aid = aid, cid = cid)
                 val list = response.data?.list.orEmpty().map { bgm ->
-                    // API returns music_id but no jump_url, construct it
                     if (bgm.jumpUrl.isBlank() && bgm.musicId.isNotBlank()) {
                         bgm.copy(
-                            jumpUrl = "https://music.bilibili.com/h5-music-detail" +
-                                "?music_id=${bgm.musicId}&cid=$cid&aid=$aid&na_close_hide=1"
+                            jumpUrl = "https://music.bilibili.com/h5/music-detail" +
+                                "?music_id=${bgm.musicId}&cid=$cid&aid=$aid&na_close_hide=1&isMulti=1"
                         )
                     } else bgm
                 }
@@ -26,6 +27,32 @@ internal object ViewGrpcRepository {
                 list
             }.onFailure { e ->
                 Logger.w(TAG, "BGM list API failed: ${e.message}")
+            }
+        }
+
+    suspend fun getBgmDetail(musicId: String, aid: Long, cid: Long): Result<BgmDetailData?> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                NetworkModule.api.getBgmDetail(
+                    musicId = musicId,
+                    aid = aid,
+                    cid = cid
+                ).data
+            }.onFailure { e ->
+                Logger.w(TAG, "BGM detail API failed: ${e.message}")
+            }
+        }
+
+    suspend fun getBgmRecommendVideos(musicId: String, aid: Long, cid: Long): Result<List<BgmRecommendVideo>> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                NetworkModule.api.getBgmRecommendList(
+                    musicId = musicId,
+                    aid = aid,
+                    cid = cid
+                ).data?.list.orEmpty()
+            }.onFailure { e ->
+                Logger.w(TAG, "BGM recommend API failed: ${e.message}")
             }
         }
 }

--- a/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletCinemaLayout.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletCinemaLayout.kt
@@ -110,6 +110,7 @@ import com.android.purebilibili.feature.video.ui.components.rememberVideoComment
 import com.android.purebilibili.feature.video.ui.components.resolveReplyItemContentType
 import com.android.purebilibili.feature.video.ui.components.shouldShowReplyTopAction
 import com.android.purebilibili.feature.video.ui.section.ActionButtonsRow
+import com.android.purebilibili.feature.video.ui.section.resolveDisplayBgmList
 import com.android.purebilibili.feature.video.ui.section.UpInfoSection
 import com.android.purebilibili.feature.video.ui.section.VideoTitleWithDesc
 import com.android.purebilibili.feature.video.ui.section.VideoPlayerSection
@@ -766,10 +767,11 @@ private fun CinemaVideoIntroSection(
             VideoTitleWithDesc(
                 info = success.info,
                 videoTags = success.videoTags,
-                bgmInfo = success.bgmInfo,
-                bgmInfoList = success.bgmInfoList,
                 onDescriptionUrlClick = onOpenBilibiliLink,
-                relatedVideos = success.related,
+                bgmList = resolveDisplayBgmList(
+                    bgmInfo = success.bgmInfo,
+                    bgmInfoList = success.bgmInfoList
+                ),
                 onBgmClick = onBgmClick,
                 onRelatedVideoClick = onRelatedVideoClick
             )

--- a/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletCinemaLayout.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletCinemaLayout.kt
@@ -298,6 +298,7 @@ fun TabletCinemaLayout(
                         onPageSelect = { pageIndex -> viewModel.switchPage(pageIndex) },
                         onOpenBilibiliLink = onOpenBilibiliLink,
                         onBgmClick = onBgmClick,
+                        onRelatedVideoClick = onRelatedVideoClick,
                         onRetryAiSummary = viewModel::retryAiSummary
                     )
                 } else {
@@ -504,7 +505,7 @@ private fun CinemaMetaPanel(
     onPageSelect: (Int) -> Unit,
     onOpenBilibiliLink: ((String) -> Unit)?,
     onBgmClick: (BgmInfo) -> Unit = {},
-    onOpenBilibiliLink: ((String) -> Unit)?,
+    onRelatedVideoClick: (String, android.os.Bundle?) -> Unit = { _, _ -> },
     onRetryAiSummary: () -> Unit
 ) {
     val context = LocalContext.current
@@ -645,6 +646,7 @@ private fun CinemaMetaPanel(
                             success = success,
                             onOpenBilibiliLink = onOpenBilibiliLink,
                             onBgmClick = onBgmClick,
+                            onRelatedVideoClick = onRelatedVideoClick,
                             onRetryAiSummary = onRetryAiSummary
                         )
                     }
@@ -736,6 +738,7 @@ private fun CinemaVideoIntroSection(
     success: PlayerUiState.Success,
     onBgmClick: (BgmInfo) -> Unit = {},
     onOpenBilibiliLink: ((String) -> Unit)? = null,
+    onRelatedVideoClick: (String, android.os.Bundle?) -> Unit = { _, _ -> },
     onRetryAiSummary: () -> Unit = {}
 ) {
     val context = LocalContext.current
@@ -766,7 +769,9 @@ private fun CinemaVideoIntroSection(
                 bgmInfo = success.bgmInfo,
                 bgmInfoList = success.bgmInfoList,
                 onDescriptionUrlClick = onOpenBilibiliLink,
-                onBgmClick = onBgmClick
+                relatedVideos = success.related,
+                onBgmClick = onBgmClick,
+                onRelatedVideoClick = onRelatedVideoClick
             )
         }
         if (shouldShowAiSummaryEntry(

--- a/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletCinemaLayout.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletCinemaLayout.kt
@@ -297,6 +297,7 @@ fun TabletCinemaLayout(
                         onCollectionEpisodeClick = onRelatedVideoClick,
                         onPageSelect = { pageIndex -> viewModel.switchPage(pageIndex) },
                         onOpenBilibiliLink = onOpenBilibiliLink,
+                        onBgmClick = onBgmClick,
                         onRetryAiSummary = viewModel::retryAiSummary
                     )
                 } else {
@@ -501,6 +502,8 @@ private fun CinemaMetaPanel(
     onOpenComments: () -> Unit,
     onCollectionEpisodeClick: (String, android.os.Bundle?) -> Unit,
     onPageSelect: (Int) -> Unit,
+    onOpenBilibiliLink: ((String) -> Unit)?,
+    onBgmClick: (BgmInfo) -> Unit = {},
     onOpenBilibiliLink: ((String) -> Unit)?,
     onRetryAiSummary: () -> Unit
 ) {
@@ -731,7 +734,6 @@ private fun CinemaMetaUpInfo(
 @Composable
 private fun CinemaVideoIntroSection(
     success: PlayerUiState.Success,
-    onOpenBilibiliLink: ((String) -> Unit)? = null,
     onBgmClick: (BgmInfo) -> Unit = {},
     onOpenBilibiliLink: ((String) -> Unit)? = null,
     onRetryAiSummary: () -> Unit = {}

--- a/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletCinemaLayout.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletCinemaLayout.kt
@@ -92,6 +92,7 @@ import com.android.purebilibili.core.store.SettingsManager
 import com.android.purebilibili.core.store.TabletCommentPanelWidthPreset
 import com.android.purebilibili.core.ui.transition.VIDEO_SHARED_COVER_ASPECT_RATIO
 import com.android.purebilibili.core.util.ShareUtils
+import com.android.purebilibili.data.model.response.BgmInfo
 import com.android.purebilibili.data.model.response.ViewPoint
 import com.android.purebilibili.feature.common.resolveIndexedVideoLazyKey
 import com.android.purebilibili.feature.dynamic.components.ImagePreviewDialog
@@ -140,6 +141,7 @@ fun TabletCinemaLayout(
     coverUrl: String = "",
     onBack: () -> Unit,
     onUpClick: (Long) -> Unit,
+    onBgmClick: (BgmInfo) -> Unit = {},
     onNavigateToAudioMode: () -> Unit,
     onToggleFullscreen: () -> Unit,
     isInPipMode: Boolean,
@@ -639,6 +641,7 @@ private fun CinemaMetaPanel(
                         CinemaVideoIntroSection(
                             success = success,
                             onOpenBilibiliLink = onOpenBilibiliLink,
+                            onBgmClick = onBgmClick,
                             onRetryAiSummary = onRetryAiSummary
                         )
                     }
@@ -729,6 +732,8 @@ private fun CinemaMetaUpInfo(
 private fun CinemaVideoIntroSection(
     success: PlayerUiState.Success,
     onOpenBilibiliLink: ((String) -> Unit)? = null,
+    onBgmClick: (BgmInfo) -> Unit = {},
+    onOpenBilibiliLink: ((String) -> Unit)? = null,
     onRetryAiSummary: () -> Unit = {}
 ) {
     val context = LocalContext.current
@@ -758,7 +763,8 @@ private fun CinemaVideoIntroSection(
                 videoTags = success.videoTags,
                 bgmInfo = success.bgmInfo,
                 bgmInfoList = success.bgmInfoList,
-                onDescriptionUrlClick = onOpenBilibiliLink
+                onDescriptionUrlClick = onOpenBilibiliLink,
+                onBgmClick = onBgmClick
             )
         }
         if (shouldShowAiSummaryEntry(

--- a/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletVideoLayout.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletVideoLayout.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import com.android.purebilibili.core.ui.AdaptiveSplitLayout
 import com.android.purebilibili.core.util.ShareUtils
+import com.android.purebilibili.data.model.response.BgmInfo
 import com.android.purebilibili.data.model.response.ViewPoint
 import com.android.purebilibili.feature.common.resolveIndexedVideoLazyKey
 import com.android.purebilibili.feature.dynamic.components.ImagePreviewDialog
@@ -96,6 +97,7 @@ fun TabletVideoLayout(
     onAudioQualityChange: (Int) -> Unit = {},
     transitionEnabled: Boolean = false, //  卡片过渡动画开关
     onRelatedVideoClick: (String, android.os.Bundle?) -> Unit,
+    onBgmClick: (BgmInfo) -> Unit = {},
     showUpBadge: Boolean = true,
     onSearchKeywordClick: (String) -> Unit = {},
     onOpenBilibiliLink: ((String) -> Unit)? = null,
@@ -249,9 +251,12 @@ fun TabletVideoLayout(
                         downloadProgress = downloadProgress,
                         isInWatchLater = success.isInWatchLater,
                         videoTags = success.videoTags,
-                        relatedVideos = success.related,
                         ownerFollowerCount = success.ownerFollowerCount,
                         ownerVideoCount = success.ownerVideoCount,
+                        bgmInfo = success.bgmInfo,
+                        bgmInfoList = success.bgmInfoList,
+                        onBgmClick = onBgmClick,
+                        relatedVideos = success.related,
                         onFollowClick = { viewModel.toggleFollow() },
                         onFavoriteClick = { viewModel.toggleFavorite() },
                         onLikeClick = { viewModel.toggleLike() },
@@ -763,6 +768,9 @@ private fun ScrollableVideoInfoSection(
     videoTags: List<com.android.purebilibili.data.model.response.VideoTag>,
     ownerFollowerCount: Int?,
     ownerVideoCount: Int?,
+    bgmInfo: BgmInfo? = null,
+    bgmInfoList: List<BgmInfo> = emptyList(),
+    onBgmClick: (BgmInfo) -> Unit = {},
     onFollowClick: () -> Unit,
     onFavoriteClick: () -> Unit,
     onLikeClick: () -> Unit,
@@ -814,6 +822,11 @@ private fun ScrollableVideoInfoSection(
             VideoTitleWithDesc(
                 info = info,
                 videoTags = videoTags,
+                bgmInfo = bgmInfo,
+                bgmInfoList = bgmInfoList,
+                relatedVideos = relatedVideos,
+                onBgmClick = onBgmClick,
+                onRelatedVideoClick = onRelatedVideoClick
                 onDescriptionUrlClick = onOpenBilibiliLink
             )
             Spacer(modifier = Modifier.height(12.dp))

--- a/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletVideoLayout.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletVideoLayout.kt
@@ -37,6 +37,7 @@ import com.android.purebilibili.feature.dynamic.components.ImagePreviewTextConte
 import com.android.purebilibili.feature.video.state.VideoPlayerState
 import com.android.purebilibili.feature.video.ui.components.*
 import com.android.purebilibili.feature.video.ui.section.ActionButtonsRow
+import com.android.purebilibili.feature.video.ui.section.resolveDisplayBgmList
 import com.android.purebilibili.feature.video.ui.section.UpInfoSection
 import com.android.purebilibili.feature.video.ui.section.VideoPlayerSection
 import com.android.purebilibili.feature.video.ui.section.VideoTitleWithDesc
@@ -822,9 +823,10 @@ private fun ScrollableVideoInfoSection(
             VideoTitleWithDesc(
                 info = info,
                 videoTags = videoTags,
-                bgmInfo = bgmInfo,
-                bgmInfoList = bgmInfoList,
-                relatedVideos = relatedVideos,
+                bgmList = resolveDisplayBgmList(
+                    bgmInfo = bgmInfo,
+                    bgmInfoList = bgmInfoList
+                ),
                 onBgmClick = onBgmClick,
                 onRelatedVideoClick = onRelatedVideoClick
                 onDescriptionUrlClick = onOpenBilibiliLink

--- a/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletVideoLayout.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/screen/TabletVideoLayout.kt
@@ -828,7 +828,7 @@ private fun ScrollableVideoInfoSection(
                     bgmInfoList = bgmInfoList
                 ),
                 onBgmClick = onBgmClick,
-                onRelatedVideoClick = onRelatedVideoClick
+                onRelatedVideoClick = onRelatedVideoClick,
                 onDescriptionUrlClick = onOpenBilibiliLink
             )
             Spacer(modifier = Modifier.height(12.dp))

--- a/app/src/main/java/com/android/purebilibili/feature/video/screen/VideoContentSection.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/screen/VideoContentSection.kt
@@ -67,6 +67,7 @@ import com.android.purebilibili.feature.home.components.BottomBarLiquidSegmented
 import com.android.purebilibili.feature.video.ui.section.VideoTitleWithDesc
 import com.android.purebilibili.feature.video.ui.section.UpInfoSection
 import com.android.purebilibili.feature.video.ui.section.ActionButtonsRow
+import com.android.purebilibili.feature.video.ui.section.resolveDisplayBgmList
 import com.android.purebilibili.feature.video.ui.section.shouldShowAiSummaryEntry
 import com.android.purebilibili.feature.video.ui.section.resolveVideoDetailMotionBudget
 import com.android.purebilibili.feature.video.ui.section.shouldAnimateVideoDetailLayout
@@ -988,9 +989,10 @@ private fun VideoHeaderContent(
             info = info,
             videoTags = videoTags,
             transitionEnabled = transitionEnabled,  // 🔗 传递共享元素开关
-            bgmInfo = bgmInfo,
-            bgmInfoList = bgmInfoList,
-            relatedVideos = relatedVideos,
+            bgmList = resolveDisplayBgmList(
+                bgmInfo = bgmInfo,
+                bgmInfoList = bgmInfoList
+            ),
             onlineCount = onlineCount,
             showOnlineCount = showOnlineCount,
             onBgmClick = onBgmClick,

--- a/app/src/main/java/com/android/purebilibili/feature/video/screen/VideoContentSection.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/screen/VideoContentSection.kt
@@ -633,11 +633,13 @@ private fun VideoIntroTab(
                 onRetryAiSummary = onRetryAiSummary,
                 bgmInfo = bgmInfo,
                 bgmInfoList = bgmInfoList,
+                relatedVideos = relatedVideos,
                 onlineCount = onlineCount,
                 showOnlineCount = showOnlineCount,
                 onTimestampClick = onTimestampClick,
                 onBgmClick = onBgmClick,
                 onDescriptionUrlClick = onDescriptionUrlClick,
+                onRelatedVideoClick = onRelatedVideoClick,
                 showInteractionActions = showInteractionActions,
                 animateVideoDetailLayout = animateVideoDetailLayout
             )
@@ -946,9 +948,11 @@ private fun VideoHeaderContent(
     onRetryAiSummary: () -> Unit = {},
     bgmInfo: BgmInfo? = null,
     bgmInfoList: List<BgmInfo> = emptyList(),
+    relatedVideos: List<RelatedVideo> = emptyList(),
     onTimestampClick: ((Long) -> Unit)? = null,
     onBgmClick: (BgmInfo) -> Unit = {},
     onDescriptionUrlClick: ((String) -> Unit)? = null,
+    onRelatedVideoClick: (String, android.os.Bundle?) -> Unit = { _, _ -> },
     onlineCount: String = "",
     showOnlineCount: Boolean = true,
     showInteractionActions: Boolean = true,
@@ -986,10 +990,12 @@ private fun VideoHeaderContent(
             transitionEnabled = transitionEnabled,  // 🔗 传递共享元素开关
             bgmInfo = bgmInfo,
             bgmInfoList = bgmInfoList,
+            relatedVideos = relatedVideos,
             onlineCount = onlineCount,
             showOnlineCount = showOnlineCount,
             onBgmClick = onBgmClick,
             onDescriptionUrlClick = onDescriptionUrlClick,
+            onRelatedVideoClick = onRelatedVideoClick,
             animateLayout = animateVideoDetailLayout
         )
 

--- a/app/src/main/java/com/android/purebilibili/feature/video/screen/VideoDetailScreen.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/screen/VideoDetailScreen.kt
@@ -2413,7 +2413,6 @@ fun VideoDetailScreen(
                         },
                         onUpClick = navigateToUserSpaceFromVideo,
                         onBgmClick = onBgmClick,
-                        onUpClick = navigateToUserSpaceFromVideo,
                         onNavigateToAudioMode = {
                             isNavigatingToAudioMode = true // [Fix] Set flag to prevent notification cancellation
                             onNavigateToAudioMode()

--- a/app/src/main/java/com/android/purebilibili/feature/video/screen/VideoDetailScreen.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/screen/VideoDetailScreen.kt
@@ -2412,6 +2412,8 @@ fun VideoDetailScreen(
                             handleBack()
                         },
                         onUpClick = navigateToUserSpaceFromVideo,
+                        onBgmClick = onBgmClick,
+                        onUpClick = navigateToUserSpaceFromVideo,
                         onNavigateToAudioMode = {
                             isNavigatingToAudioMode = true // [Fix] Set flag to prevent notification cancellation
                             onNavigateToAudioMode()

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -1001,6 +1003,7 @@ private fun InlineBgmSection(
 ) {
     if (bgmList.isEmpty()) return
 
+    var showSheet by remember(bgmList.map(BgmInfo::musicId)) { mutableStateOf(false) }
     val leadSong = bgmList.first()
     val headerText = remember(bgmList, leadSong) {
         buildString {
@@ -1022,9 +1025,25 @@ private fun InlineBgmSection(
         subtitle = leadSong.actor.takeIf { it.isNotBlank() },
         showIndicator = bgmList.size > 1,
         onClick = {
-            onBgmClick(leadSong)
+            if (bgmList.size > 1) {
+                showSheet = true
+            } else {
+                onBgmClick(leadSong)
+            }
         }
     )
+
+    if (showSheet) {
+        BgmSelectionSheet(
+            title = headerText,
+            bgmList = bgmList,
+            onDismiss = { showSheet = false },
+            onBgmClick = { bgm ->
+                showSheet = false
+                onBgmClick(bgm)
+            }
+        )
+    }
 }
 
 /**
@@ -1092,6 +1111,146 @@ fun BgmInfoRow(
                         .size(18.dp)
                         .rotate(indicatorRotation)
                 )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BgmSelectionSheet(
+    title: String,
+    bgmList: List<BgmInfo>,
+    onDismiss: () -> Unit,
+    onBgmClick: (BgmInfo) -> Unit
+) {
+    val context = LocalContext.current
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    com.android.purebilibili.core.ui.IOSModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        dragHandle = null
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(0.58f)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(1f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        imageVector = CupertinoIcons.Default.Xmark,
+                        contentDescription = "关闭",
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+            }
+
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+
+            LazyColumn(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth(),
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                itemsIndexed(bgmList) { index, bgm ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(14.dp))
+                            .clickable { onBgmClick(bgm) }
+                            .padding(vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(54.dp)
+                                .clip(RoundedCornerShape(12.dp))
+                                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.48f))
+                                .border(
+                                    width = 1.dp,
+                                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.45f),
+                                    shape = RoundedCornerShape(12.dp)
+                                ),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            if (bgm.coverUrl.isNotBlank()) {
+                                AsyncImage(
+                                    model = ImageRequest.Builder(context)
+                                        .data(FormatUtils.fixImageUrl(bgm.coverUrl))
+                                        .crossfade(true)
+                                        .build(),
+                                    contentDescription = bgm.musicTitle,
+                                    modifier = Modifier.fillMaxSize(),
+                                    contentScale = ContentScale.Crop
+                                )
+                            } else {
+                                Icon(
+                                    imageVector = CupertinoIcons.Default.MusicNote,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.75f),
+                                    modifier = Modifier.size(20.dp)
+                                )
+                            }
+                        }
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = bgm.musicTitle.ifEmpty { "未知音乐" },
+                                style = MaterialTheme.typography.bodyMedium.copy(
+                                    fontWeight = FontWeight.SemiBold
+                                ),
+                                color = MaterialTheme.colorScheme.onSurface,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                text = buildString {
+                                    append("#")
+                                    append(index + 1)
+                                    if (bgm.actor.isNotBlank()) {
+                                        append(" · ")
+                                        append(bgm.actor)
+                                    }
+                                },
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Icon(
+                            imageVector = CupertinoIcons.Default.ChevronForward,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                            modifier = Modifier.size(16.dp)
+                        )
+                    }
+                    if (index != bgmList.lastIndex) {
+                        HorizontalDivider(
+                            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.35f)
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
@@ -73,6 +73,8 @@ import com.android.purebilibili.feature.video.ui.FollowTextTone
 import com.android.purebilibili.feature.video.ui.resolveVideoFollowVisualPolicy
 import com.android.purebilibili.data.repository.ViewGrpcRepository
 import com.android.purebilibili.feature.home.components.cards.ElegantVideoCard
+import com.android.purebilibili.feature.video.ui.components.ShimmerContainer
+import com.android.purebilibili.feature.video.ui.components.SkeletonBox
 import kotlinx.coroutines.delay
 
 internal const val VIDEO_DESCRIPTION_URL_TAG = "VIDEO_DESCRIPTION_URL"
@@ -156,6 +158,7 @@ internal fun resolveVideoInfoInitialExpandedState(
 private const val BGM_DISCOVERY_LOAD_DELAY_MS = 420L
 private const val BGM_RECOMMEND_PAGE_SIZE = 5
 private const val BGM_RECOMMEND_ROW_START_INDEX = 4
+private val BGM_DETAIL_CARD_HEIGHT = 168.dp
 
 /**
  * Video Title Section (Bilibili official style: compact layout)
@@ -1172,6 +1175,9 @@ private fun BgmSelectionSheet(
     }
     val selectedBgm = bgmList.getOrElse(selectedIndex) { bgmList.first() }
     val selectedData = itemStateByKey[selectedItemKey] ?: BgmSheetItemState()
+    val shouldShowDetailSkeleton = remember(selectedData.status, selectedData.detail) {
+        selectedData.status != BgmDiscoveryLoadStatus.Loaded && selectedData.detail == null
+    }
 
     LaunchedEffect(selectedItemKey, selectedBgm.musicId, aid, cid) {
         if (!shouldLoadBgmDiscoveryItem(selectedData, selectedBgm.musicId, aid, cid)) return@LaunchedEffect
@@ -1283,7 +1289,7 @@ private fun BgmSelectionSheet(
                 BgmDetailCard(
                     bgm = selectedBgm,
                     detail = selectedData.detail,
-                    isLoading = selectedData.status == BgmDiscoveryLoadStatus.Loading,
+                    isLoading = shouldShowDetailSkeleton,
                     statLine = selectedStatLine,
                     onOpenMusic = { onBgmClick(selectedBgm) }
                 )
@@ -1565,7 +1571,8 @@ private fun BgmDetailCard(
     onOpenMusic: () -> Unit
 ) {
     val scoreText = remember(detail) { resolveBgmScoreText(detail) }
-    val maskedStatLine = remember(statLine) { resolveMaskedBgmStatLine(statLine) }
+    val displayStatLine = remember(statLine) { statLine ?: resolveUnavailableBgmStatLine() }
+    val commentText = remember(detail) { resolveBgmCommentText(detail) }
     val description = remember(detail, bgm) {
         bgm.actor.takeIf { it.isNotBlank() }
             ?: detail?.originArtist?.takeIf { it.isNotBlank() }
@@ -1575,78 +1582,145 @@ private fun BgmDetailCard(
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp)
-            .clickable(onClick = onOpenMusic),
+            .padding(horizontal = 16.dp),
         shape = RoundedCornerShape(24.dp),
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.42f)
     ) {
+        if (isLoading) {
+            BgmDetailCardSkeleton()
+        } else {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(BGM_DETAIL_CARD_HEIGHT)
+                    .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                BgmDetailCover(
+                    coverUrl = detail?.mvCover.orEmpty().ifBlank { bgm.coverUrl },
+                    title = detail?.musicTitle.orEmpty().ifBlank { bgm.musicTitle }
+                )
+                Spacer(modifier = Modifier.width(14.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = detail?.musicTitle.orEmpty().ifBlank { bgm.musicTitle.ifBlank { "未知音乐" } },
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Spacer(modifier = Modifier.height(10.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = CupertinoIcons.Outlined.Star,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = scoreText,
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Text(
+                        text = displayStatLine,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Text(
+                        text = commentText,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.92f),
+                        maxLines = 3,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Spacer(modifier = Modifier.height(10.dp))
+                    Text(
+                        text = "打开音乐详情",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.clickable(onClick = onOpenMusic)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BgmDetailCardSkeleton() {
+    ShimmerContainer {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .heightIn(min = 168.dp)
+                .height(BGM_DETAIL_CARD_HEIGHT)
                 .padding(16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            BgmDetailCover(
-                coverUrl = detail?.mvCover.orEmpty().ifBlank { bgm.coverUrl },
-                title = detail?.musicTitle.orEmpty().ifBlank { bgm.musicTitle }
+            SkeletonBox(
+                modifier = Modifier.size(112.dp),
+                height = 112.dp,
+                cornerRadius = 22.dp
             )
             Spacer(modifier = Modifier.width(14.dp))
             Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = detail?.musicTitle.orEmpty().ifBlank { bgm.musicTitle.ifBlank { "未知音乐" } },
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis
-                )
-                Spacer(modifier = Modifier.height(10.dp))
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        imageVector = CupertinoIcons.Outlined.Star,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(16.dp)
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = if (isLoading) "加载音乐信息..." else scoreText,
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
-                }
-                Spacer(modifier = Modifier.height(6.dp))
-                Text(
-                    text = maskedStatLine,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-                Spacer(modifier = Modifier.height(6.dp))
-                Text(
-                    text = if (detail?.musicComment?.nums ?: 0 > 0) "*** 评论" else "*** 评论",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                SkeletonBox(
+                    modifier = Modifier.fillMaxWidth(0.72f),
+                    height = 20.dp,
+                    cornerRadius = 10.dp
                 )
                 Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = description,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.92f),
-                    maxLines = 3,
-                    overflow = TextOverflow.Ellipsis
+                SkeletonBox(
+                    modifier = Modifier.fillMaxWidth(0.46f),
+                    height = 16.dp,
+                    cornerRadius = 8.dp
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                SkeletonBox(
+                    modifier = Modifier.fillMaxWidth(0.88f),
+                    height = 14.dp,
+                    cornerRadius = 7.dp
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                SkeletonBox(
+                    modifier = Modifier.fillMaxWidth(0.34f),
+                    height = 14.dp,
+                    cornerRadius = 7.dp
                 )
                 Spacer(modifier = Modifier.height(10.dp))
-                Text(
-                    text = "打开音乐详情",
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                    fontWeight = FontWeight.SemiBold
+                SkeletonBox(
+                    modifier = Modifier.fillMaxWidth(0.94f),
+                    height = 14.dp,
+                    cornerRadius = 7.dp
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                SkeletonBox(
+                    modifier = Modifier.fillMaxWidth(0.66f),
+                    height = 14.dp,
+                    cornerRadius = 7.dp
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                SkeletonBox(
+                    modifier = Modifier.width(84.dp),
+                    height = 14.dp,
+                    cornerRadius = 7.dp
                 )
             }
         }
@@ -1693,24 +1767,27 @@ private fun BgmDetailCover(
 private fun resolveBgmScoreText(detail: BgmDetailData?): String {
     detail ?: return "音乐信息"
     return when {
-        detail.musicHot > 0L -> FormatUtils.formatStat(detail.musicHot)
-        detail.listenPv > 0L -> FormatUtils.formatStat(detail.listenPv)
-        else -> "音乐信息"
+        detail.musicHot > 0L -> "最新热度 ${FormatUtils.formatStat(detail.musicHot)}"
+        else -> "播放 ${FormatUtils.formatStat(detail.listenPv)}"
     }
 }
 
 private fun resolveBgmStatLine(detail: BgmDetailData?): String? {
     detail ?: return null
-    val parts = buildList {
-        if (detail.listenPv > 0L) add("${FormatUtils.formatStat(detail.listenPv)}播放")
-        if (detail.wishCount > 0) add("${FormatUtils.formatStat(detail.wishCount.toLong())}想听")
-        if (detail.musicShares > 0) add("${FormatUtils.formatStat(detail.musicShares.toLong())}分享")
-    }
-    return parts.takeIf { it.isNotEmpty() }?.joinToString(" · ")
+    return listOf(
+        "${FormatUtils.formatStat(detail.listenPv.coerceAtLeast(0L))}播放",
+        "${FormatUtils.formatStat(detail.wishCount.coerceAtLeast(0).toLong())}想听",
+        "${FormatUtils.formatStat(detail.musicShares.coerceAtLeast(0).toLong())}分享"
+    ).joinToString(" · ")
 }
 
-private fun resolveMaskedBgmStatLine(statLine: String?): String {
-    return "*** 播放 · *** 想听 · *** 分享"
+private fun resolveUnavailableBgmStatLine(): String {
+    return "--播放 · --想听 · --分享"
+}
+
+private fun resolveBgmCommentText(detail: BgmDetailData?): String {
+    detail ?: return "--评论"
+    return "${FormatUtils.formatStat((detail.musicComment?.nums ?: 0).coerceAtLeast(0).toLong())}评论"
 }
 
 private fun resolveBgmRecommendRowKey(

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
@@ -64,7 +64,6 @@ import com.android.purebilibili.data.model.response.BgmInfo
 import com.android.purebilibili.data.model.response.AiSummaryData
 import com.android.purebilibili.data.model.response.BgmRecommendVideo
 import com.android.purebilibili.data.model.response.Owner
-import com.android.purebilibili.data.model.response.RelatedVideo
 import com.android.purebilibili.data.model.response.Stat
 import com.android.purebilibili.data.model.response.VideoItem
 import com.android.purebilibili.feature.video.screen.buildVideoNavigationOptions
@@ -268,9 +267,7 @@ fun VideoTitleSection(
 fun VideoTitleWithDesc(
     info: ViewInfo,
     videoTags: List<VideoTag> = emptyList(),  //  视频标签
-    bgmInfo: BgmInfo? = null, // [新增] BGM 信息
-    bgmInfoList: List<BgmInfo> = emptyList(),
-    relatedVideos: List<RelatedVideo> = emptyList(),
+    bgmList: List<BgmInfo> = emptyList(),
     onlineCount: String = "",
     showOnlineCount: Boolean = true,
     transitionEnabled: Boolean = false,  // 🔗 共享元素过渡开关
@@ -505,15 +502,10 @@ fun VideoTitleWithDesc(
         }
 
         // [新增] BGM Info Row
-        val displayBgmList = remember(bgmInfo, bgmInfoList) {
-            if (bgmInfoList.isNotEmpty()) bgmInfoList
-            else if (bgmInfo != null) listOf(bgmInfo)
-            else emptyList()
-        }
-        if (displayBgmList.isNotEmpty()) {
+        if (bgmList.isNotEmpty()) {
             Spacer(Modifier.height(8.dp))
             InlineBgmSection(
-                bgmList = displayBgmList,
+                bgmList = bgmList,
                 onBgmClick = onBgmClick,
                 onRelatedVideoClick = onRelatedVideoClick
             )
@@ -1171,8 +1163,8 @@ private fun BgmSelectionSheet(
     }
     val selectedBgm = bgmList.getOrElse(selectedIndex) { bgmList.first() }
     val selectedData = itemStateByKey[selectedItemKey] ?: BgmSheetItemState()
-    val shouldShowDetailSkeleton = remember(selectedData.status, selectedData.detail) {
-        selectedData.status != BgmDiscoveryLoadStatus.Loaded && selectedData.detail == null
+    val shouldShowDetailSkeleton = remember(selectedData) {
+        shouldShowBgmDetailSkeleton(selectedData)
     }
 
     LaunchedEffect(selectedItemKey, selectedBgm.musicId, aid, cid) {
@@ -1226,8 +1218,7 @@ private fun BgmSelectionSheet(
         resolveBgmStatLine(selectedData.detail)
     }
     val shouldShowInitialRecommendationPlaceholders = remember(selectedData) {
-        selectedData.recommendedVideos.isEmpty() &&
-            selectedData.status != BgmDiscoveryLoadStatus.Error
+        shouldShowInitialBgmRecommendationPlaceholders(selectedData)
     }
     val recommendedVideoRows = remember(selectedData.recommendedVideos) {
         selectedData.recommendedVideos.chunked(2)
@@ -1807,6 +1798,15 @@ private fun resolveBgmRecommendRowItemIndex(rowIndex: Int): Int {
     return BGM_RECOMMEND_ROW_START_INDEX + rowIndex
 }
 
+internal fun resolveDisplayBgmList(
+    bgmInfo: BgmInfo?,
+    bgmInfoList: List<BgmInfo>
+): List<BgmInfo> {
+    return bgmInfoList.ifEmpty {
+        listOfNotNull(bgmInfo)
+    }
+}
+
 private fun resolveQueryLongParam(url: String, key: String): Long {
     return android.net.Uri.parse(url).getQueryParameter(key)?.toLongOrNull() ?: 0L
 }
@@ -1848,6 +1848,19 @@ internal fun shouldLoadBgmDiscoveryItem(
     if (musicId.isBlank() || aid <= 0L || cid <= 0L) return false
     return state.status == BgmDiscoveryLoadStatus.Idle ||
         state.status == BgmDiscoveryLoadStatus.Error
+}
+
+internal fun shouldShowBgmDetailSkeleton(
+    state: BgmSheetItemState
+): Boolean {
+    return state.status != BgmDiscoveryLoadStatus.Loaded && state.detail == null
+}
+
+internal fun shouldShowInitialBgmRecommendationPlaceholders(
+    state: BgmSheetItemState
+): Boolean {
+    return state.recommendedVideos.isEmpty() &&
+        state.status != BgmDiscoveryLoadStatus.Error
 }
 
 internal fun shouldLoadMoreBgmRecommendations(
@@ -1923,116 +1936,4 @@ private fun mergeBgmRecommendedVideos(
         seenKeys.add(key)
     }
     return existing + appended
-}
-
-
-@Composable
-fun BgmInfoListRow(
-    bgmList: List<BgmInfo>,
-    onBgmClick: (BgmInfo) -> Unit = {}
-) {
-    val context = LocalContext.current
-
-    Surface(
-        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.42f),
-        shape = RoundedCornerShape(16.dp),
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 8.dp)
-    ) {
-        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp)) {
-            Text(
-                text = "共 ${bgmList.size} 首音乐",
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.82f)
-            )
-            Spacer(modifier = Modifier.height(10.dp))
-            bgmList.forEachIndexed { index, bgm ->
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(14.dp))
-                        .clickable { onBgmClick(bgm) }
-                        .padding(vertical = 6.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .size(54.dp)
-                            .clip(RoundedCornerShape(12.dp))
-                            .background(MaterialTheme.colorScheme.surface)
-                            .border(
-                                width = 1.dp,
-                                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.45f),
-                                shape = RoundedCornerShape(12.dp)
-                            ),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        if (bgm.coverUrl.isNotBlank()) {
-                            AsyncImage(
-                                model = ImageRequest.Builder(context)
-                                    .data(FormatUtils.fixImageUrl(bgm.coverUrl))
-                                    .crossfade(true)
-                                    .build(),
-                                contentDescription = bgm.musicTitle,
-                                modifier = Modifier.fillMaxSize(),
-                                contentScale = ContentScale.Crop
-                            )
-                        } else {
-                            Icon(
-                                imageVector = CupertinoIcons.Default.MusicNote,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.75f),
-                                modifier = Modifier.size(20.dp)
-                            )
-                        }
-                    }
-                    Spacer(modifier = Modifier.width(12.dp))
-                    Column(modifier = Modifier.weight(1f)) {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Text(
-                                text = "#${index + 1}",
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.78f)
-                            )
-                            Spacer(modifier = Modifier.width(6.dp))
-                            Text(
-                                text = bgm.musicTitle.ifEmpty { "未知音乐" },
-                                style = MaterialTheme.typography.bodyMedium.copy(
-                                    fontWeight = FontWeight.SemiBold
-                                ),
-                                color = MaterialTheme.colorScheme.onSurface,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier.weight(1f, fill = false)
-                            )
-                        }
-                        if (bgm.actor.isNotBlank()) {
-                            Spacer(modifier = Modifier.height(4.dp))
-                            Text(
-                                text = bgm.actor,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                        }
-                    }
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Icon(
-                        imageVector = CupertinoIcons.Default.ChevronForward,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-                        modifier = Modifier.size(16.dp)
-                    )
-                }
-                if (index != bgmList.lastIndex) {
-                    HorizontalDivider(
-                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
-                        modifier = Modifier.padding(vertical = 2.dp)
-                    )
-                }
-            }
-        }
-    }
 }

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -55,11 +57,19 @@ import com.android.purebilibili.core.ui.components.UserUpBadge
 import com.android.purebilibili.core.ui.transition.shouldEnableVideoCoverSharedTransition
 import com.android.purebilibili.core.ui.transition.shouldEnableVideoMetadataSharedTransition
 import com.android.purebilibili.core.util.CardPositionManager
+import com.android.purebilibili.data.model.response.BgmCommentInfo
+import com.android.purebilibili.data.model.response.BgmDetailData
 import com.android.purebilibili.data.model.response.BgmInfo
 import com.android.purebilibili.data.model.response.AiSummaryData
+import com.android.purebilibili.data.model.response.BgmRecommendVideo
+import com.android.purebilibili.data.model.response.RelatedVideo
+import com.android.purebilibili.data.model.response.VideoItem
+import com.android.purebilibili.feature.home.components.cards.ElegantVideoCard
 import com.android.purebilibili.feature.video.ui.FollowButtonTone
 import com.android.purebilibili.feature.video.ui.FollowTextTone
 import com.android.purebilibili.feature.video.ui.resolveVideoFollowVisualPolicy
+import com.android.purebilibili.data.repository.AudioRepository
+import com.android.purebilibili.data.repository.ViewGrpcRepository
 
 internal const val VIDEO_DESCRIPTION_URL_TAG = "VIDEO_DESCRIPTION_URL"
 private val VIDEO_DESCRIPTION_URL_PATTERN =
@@ -249,12 +259,14 @@ fun VideoTitleWithDesc(
     videoTags: List<VideoTag> = emptyList(),  //  视频标签
     bgmInfo: BgmInfo? = null, // [新增] BGM 信息
     bgmInfoList: List<BgmInfo> = emptyList(),
+    relatedVideos: List<RelatedVideo> = emptyList(),
     onlineCount: String = "",
     showOnlineCount: Boolean = true,
     transitionEnabled: Boolean = false,  // 🔗 共享元素过渡开关
     animateLayout: Boolean = true,
     onDescriptionUrlClick: ((String) -> Unit)? = null,
-    onBgmClick: (BgmInfo) -> Unit = {}
+    onBgmClick: (BgmInfo) -> Unit = {},
+    onRelatedVideoClick: (String, android.os.Bundle?) -> Unit = { _, _ -> }
 ) {
     val context = LocalContext.current
     val defaultExpanded by com.android.purebilibili.core.store.SettingsManager
@@ -491,7 +503,8 @@ fun VideoTitleWithDesc(
             Spacer(Modifier.height(8.dp))
             InlineBgmSection(
                 bgmList = displayBgmList,
-                onBgmClick = onBgmClick
+                onBgmClick = onBgmClick,
+                onRelatedVideoClick = onRelatedVideoClick
             )
         }
         
@@ -999,7 +1012,8 @@ fun DescriptionSection(desc: String) {
 @Composable
 private fun InlineBgmSection(
     bgmList: List<BgmInfo>,
-    onBgmClick: (BgmInfo) -> Unit = {}
+    onBgmClick: (BgmInfo) -> Unit = {},
+    onRelatedVideoClick: (String, android.os.Bundle?) -> Unit = { _, _ -> }
 ) {
     if (bgmList.isEmpty()) return
 
@@ -1022,8 +1036,8 @@ private fun InlineBgmSection(
 
     BgmInfoRow(
         title = headerText,
-        subtitle = leadSong.actor.takeIf { it.isNotBlank() },
-        showIndicator = bgmList.size > 1,
+        subtitle = leadSong.actor.takeIf { it.isNotBlank() && bgmList.size == 1 },
+        showIndicator = false,
         onClick = {
             if (bgmList.size > 1) {
                 showSheet = true
@@ -1035,13 +1049,14 @@ private fun InlineBgmSection(
 
     if (showSheet) {
         BgmSelectionSheet(
-            title = headerText,
+            title = "发现音乐",
             bgmList = bgmList,
             onDismiss = { showSheet = false },
             onBgmClick = { bgm ->
                 showSheet = false
                 onBgmClick(bgm)
-            }
+            },
+            onRelatedVideoClick = onRelatedVideoClick
         )
     }
 }
@@ -1122,139 +1137,445 @@ private fun BgmSelectionSheet(
     title: String,
     bgmList: List<BgmInfo>,
     onDismiss: () -> Unit,
-    onBgmClick: (BgmInfo) -> Unit
+    onBgmClick: (BgmInfo) -> Unit,
+    onRelatedVideoClick: (String, android.os.Bundle?) -> Unit
 ) {
-    val context = LocalContext.current
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val aid = remember(bgmList) {
+        bgmList.firstOrNull()?.jumpUrl?.let { resolveQueryLongParam(it, "aid") } ?: 0L
+    }
+    val cid = remember(bgmList) {
+        bgmList.firstOrNull()?.jumpUrl?.let { resolveQueryLongParam(it, "cid") } ?: 0L
+    }
+    val preloadedData by produceState(
+        initialValue = bgmList.associate { it.musicId to BgmSheetItemState() },
+        key1 = bgmList,
+        key2 = aid,
+        key3 = cid
+    ) {
+        value = bgmList.associate { it.musicId to BgmSheetItemState() }
+        if (aid <= 0L || cid <= 0L) return@produceState
+        value = bgmList.associate { bgm ->
+            val detail = if (bgm.musicId.isNotBlank()) {
+                ViewGrpcRepository.getBgmDetail(
+                    musicId = bgm.musicId,
+                    aid = aid,
+                    cid = cid
+                ).getOrNull()
+            } else {
+                null
+            }
+            val recommendedVideos = if (bgm.musicId.isNotBlank()) {
+                ViewGrpcRepository.getBgmRecommendVideos(
+                    musicId = bgm.musicId,
+                    aid = aid,
+                    cid = cid
+                ).getOrDefault(emptyList())
+            } else {
+                emptyList()
+            }
+            bgm.musicId to BgmSheetItemState(
+                detail = detail,
+                recommendedVideos = recommendedVideos
+            )
+        }
+    }
+    var selectedMusicId by remember(bgmList.map(BgmInfo::musicId)) {
+        mutableStateOf(bgmList.firstOrNull()?.musicId.orEmpty())
+    }
+    val selectedBgm = remember(selectedMusicId, bgmList) {
+        bgmList.firstOrNull { it.musicId == selectedMusicId } ?: bgmList.first()
+    }
+    val selectedData = remember(preloadedData, selectedBgm.musicId) {
+        preloadedData[selectedBgm.musicId] ?: BgmSheetItemState()
+    }
+    val selectedVideoItems = remember(selectedData.recommendedVideos) {
+        selectedData.recommendedVideos.map(::bgmRecommendVideoToVideoItem)
+    }
 
     com.android.purebilibili.core.ui.IOSModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         dragHandle = null
     ) {
-        Column(
+        LazyColumn(
             modifier = Modifier
                 .fillMaxWidth()
-                .fillMaxHeight(0.58f)
+                .fillMaxHeight(0.68f),
+            contentPadding = PaddingValues(bottom = 20.dp)
         ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.weight(1f),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-                IconButton(onClick = onDismiss) {
-                    Icon(
-                        imageVector = CupertinoIcons.Default.Xmark,
-                        contentDescription = "关闭",
-                        modifier = Modifier.size(20.dp)
+            item {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 10.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.weight(1f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
+                    IconButton(onClick = onDismiss) {
+                        Icon(
+                            imageVector = CupertinoIcons.Default.Xmark,
+                            contentDescription = "关闭",
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
                 }
             }
 
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+            item {
+                BgmSelectionStrip(
+                    bgmList = bgmList,
+                    selectedMusicId = selectedBgm.musicId,
+                    onSelect = { selectedMusicId = it.musicId }
+                )
+            }
 
-            LazyColumn(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth(),
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
-                verticalArrangement = Arrangement.spacedBy(10.dp)
-            ) {
-                itemsIndexed(bgmList) { index, bgm ->
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(14.dp))
-                            .clickable { onBgmClick(bgm) }
-                            .padding(vertical = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .size(54.dp)
-                                .clip(RoundedCornerShape(12.dp))
-                                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.48f))
-                                .border(
-                                    width = 1.dp,
-                                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.45f),
-                                    shape = RoundedCornerShape(12.dp)
-                                ),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            if (bgm.coverUrl.isNotBlank()) {
-                                AsyncImage(
-                                    model = ImageRequest.Builder(context)
-                                        .data(FormatUtils.fixImageUrl(bgm.coverUrl))
-                                        .crossfade(true)
-                                        .build(),
-                                    contentDescription = bgm.musicTitle,
-                                    modifier = Modifier.fillMaxSize(),
-                                    contentScale = ContentScale.Crop
-                                )
+            item {
+                Spacer(modifier = Modifier.height(12.dp))
+                BgmDetailCard(
+                    bgm = selectedBgm,
+                    detail = selectedData.detail,
+                    onOpenMusic = { onBgmClick(selectedBgm) }
+                )
+            }
+
+            if (selectedVideoItems.isNotEmpty()) {
+                item {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = "使用该音乐的视频",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+                    Spacer(modifier = Modifier.height(10.dp))
+                }
+                item {
+                    BgmRelatedVideoGrid(
+                        videos = selectedVideoItems,
+                        onVideoClick = { video ->
+                            onDismiss()
+                            val navOptions = if (video.cid > 0L) {
+                                android.os.Bundle().apply {
+                                    putLong("target_cid", video.cid)
+                                }
                             } else {
-                                Icon(
-                                    imageVector = CupertinoIcons.Default.MusicNote,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.75f),
-                                    modifier = Modifier.size(20.dp)
-                                )
+                                null
                             }
+                            onRelatedVideoClick(video.bvid, navOptions)
                         }
-                        Spacer(modifier = Modifier.width(12.dp))
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = bgm.musicTitle.ifEmpty { "未知音乐" },
-                                style = MaterialTheme.typography.bodyMedium.copy(
-                                    fontWeight = FontWeight.SemiBold
-                                ),
-                                color = MaterialTheme.colorScheme.onSurface,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                            Spacer(modifier = Modifier.height(4.dp))
-                            Text(
-                                text = buildString {
-                                    append("#")
-                                    append(index + 1)
-                                    if (bgm.actor.isNotBlank()) {
-                                        append(" · ")
-                                        append(bgm.actor)
-                                    }
-                                },
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                        }
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Icon(
-                            imageVector = CupertinoIcons.Default.ChevronForward,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-                            modifier = Modifier.size(16.dp)
-                        )
-                    }
-                    if (index != bgmList.lastIndex) {
-                        HorizontalDivider(
-                            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.35f)
-                        )
-                    }
+                    )
                 }
             }
         }
     }
 }
+
+@Composable
+private fun BgmSelectionStrip(
+    bgmList: List<BgmInfo>,
+    selectedMusicId: String,
+    onSelect: (BgmInfo) -> Unit
+) {
+    val context = LocalContext.current
+    LazyRow(
+        contentPadding = PaddingValues(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        items(bgmList, key = { it.musicId }) { bgm ->
+            val selected = bgm.musicId == selectedMusicId
+            Column(
+                modifier = Modifier
+                    .width(76.dp)
+                    .clickable { onSelect(bgm) },
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(76.dp)
+                        .clip(RoundedCornerShape(20.dp))
+                        .background(
+                            if (selected) {
+                                MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+                            } else {
+                                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.55f)
+                            }
+                        )
+                        .border(
+                            width = if (selected) 1.5.dp else 1.dp,
+                            color = if (selected) {
+                                MaterialTheme.colorScheme.primary.copy(alpha = 0.55f)
+                            } else {
+                                MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.38f)
+                            },
+                            shape = RoundedCornerShape(20.dp)
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (bgm.coverUrl.isNotBlank()) {
+                        AsyncImage(
+                            model = ImageRequest.Builder(context)
+                                .data(FormatUtils.fixImageUrl(bgm.coverUrl))
+                                .crossfade(true)
+                                .build(),
+                            contentDescription = bgm.musicTitle,
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.Crop
+                        )
+                    } else {
+                        Icon(
+                            imageVector = CupertinoIcons.Default.MusicNote,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.78f),
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = bgm.musicTitle.ifBlank { "未知音乐" },
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (selected) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.onSurface
+                    },
+                    fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BgmDetailCard(
+    bgm: BgmInfo,
+    detail: BgmDetailData?,
+    onOpenMusic: () -> Unit
+) {
+    val scoreText = remember(detail) { resolveBgmScoreText(detail) }
+    val description = remember(detail, bgm) {
+        bgm.actor.takeIf { it.isNotBlank() }
+            ?: detail?.originArtist?.takeIf { it.isNotBlank() }
+            ?: "点击查看这首音乐的完整详情"
+    }
+
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        shape = RoundedCornerShape(24.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.42f)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            BgmDetailCover(
+                coverUrl = detail?.mvCover.orEmpty().ifBlank { bgm.coverUrl },
+                title = detail?.musicTitle.orEmpty().ifBlank { bgm.musicTitle }
+            )
+            Spacer(modifier = Modifier.width(14.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = detail?.musicTitle.orEmpty().ifBlank { bgm.musicTitle.ifBlank { "未知音乐" } },
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(modifier = Modifier.height(10.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = CupertinoIcons.Outlined.Star,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = scoreText,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+                detail?.musicComment?.takeIf { it.nums > 0 }?.let {
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Text(
+                        text = "${FormatUtils.formatStat(it.nums.toLong())}评论",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.92f),
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BgmDetailCover(
+    coverUrl: String,
+    title: String
+) {
+    val context = LocalContext.current
+    Box(
+        modifier = Modifier
+            .size(width = 112.dp, height = 112.dp)
+            .clip(RoundedCornerShape(22.dp))
+            .background(MaterialTheme.colorScheme.surface),
+        contentAlignment = Alignment.Center
+    ) {
+        if (coverUrl.isNotBlank()) {
+            AsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data(FormatUtils.fixImageUrl(coverUrl))
+                    .crossfade(true)
+                    .build(),
+                contentDescription = title,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+        } else {
+            Icon(
+                imageVector = CupertinoIcons.Default.MusicNote,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.8f),
+                modifier = Modifier.size(34.dp)
+            )
+        }
+    }
+}
+
+private fun resolveBgmScoreText(detail: BgmDetailData?): String {
+    detail ?: return "音乐信息"
+    return when {
+        detail.musicHot > 0L -> FormatUtils.formatStat(detail.musicHot)
+        detail.listenPv > 0L -> FormatUtils.formatStat(detail.listenPv)
+        else -> "音乐信息"
+    }
+}
+
+private fun resolveBgmStatLine(detail: BgmDetailData?): String? {
+    detail ?: return null
+    val parts = buildList {
+        if (detail.listenPv > 0L) add("${FormatUtils.formatStat(detail.listenPv)}播放")
+        if (detail.wishCount > 0) add("${FormatUtils.formatStat(detail.wishCount.toLong())}想听")
+        if (detail.musicShares > 0) add("${FormatUtils.formatStat(detail.musicShares.toLong())}分享")
+    }
+    return parts.takeIf { it.isNotEmpty() }?.joinToString(" · ")
+}
+
+private fun resolveQueryLongParam(url: String, key: String): Long {
+    return android.net.Uri.parse(url).getQueryParameter(key)?.toLongOrNull() ?: 0L
+}
+
+private data class BgmSheetItemState(
+    val detail: BgmDetailData? = null,
+    val recommendedVideos: List<BgmRecommendVideo> = emptyList()
+)
+
+@Composable
+private fun BgmRelatedVideoGrid(
+    videos: List<VideoItem>,
+    onVideoClick: (VideoItem) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 10.dp)
+    ) {
+        videos.chunked(2).forEachIndexed { rowIndex, rowVideos ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                rowVideos.forEachIndexed { columnIndex, video ->
+                    ElegantVideoCard(
+                        video = video,
+                        index = rowIndex * 2 + columnIndex,
+                        animationEnabled = false,
+                        transitionEnabled = false,
+                        scrollLiteModeEnabled = true,
+                        isDataSaverActive = false,
+                        preferLowQualityCover = false,
+                        glassEnabled = false,
+                        blurEnabled = false,
+                        compactStatsOnCover = true,
+                        showCoverGlassBadges = false,
+                        showInfoGlassBadges = false,
+                        showUpBadge = true,
+                        showDurationBadge = true,
+                        showPublishTime = false,
+                        modifier = Modifier.weight(1f),
+                        onClick = { _, _ -> onVideoClick(video) }
+                    )
+                }
+                if (rowVideos.size == 1) {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+            }
+        }
+    }
+}
+
+private fun relatedVideoToVideoItem(video: RelatedVideo): VideoItem {
+    return VideoItem(
+        id = if (video.aid > 0L) video.aid else video.cid,
+        bvid = video.bvid,
+        aid = video.aid,
+        cid = video.cid,
+        title = video.title,
+        pic = video.pic,
+        owner = video.owner,
+        stat = video.stat,
+        duration = video.duration
+    )
+}
+private fun bgmRecommendVideoToVideoItem(video: BgmRecommendVideo): VideoItem {
+    return VideoItem(
+        id = if (video.aid > 0L) video.aid else video.cid,
+        bvid = video.bvid,
+        aid = video.aid,
+        cid = video.cid,
+        title = video.title,
+        pic = video.cover,
+        owner = com.android.purebilibili.data.model.response.Owner(
+            mid = video.mid,
+            name = video.upNickName
+        ),
+        stat = com.android.purebilibili.data.model.response.Stat(
+            view = video.play,
+            danmaku = video.danmu
+        ),
+        duration = video.duration
+    )
+}
+
 
 @Composable
 fun BgmInfoListRow(

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
@@ -1,14 +1,9 @@
 // File: feature/video/ui/section/VideoInfoSection.kt
 package com.android.purebilibili.feature.video.ui.section
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.border
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -24,7 +19,6 @@ import io.github.alexzhirkevich.cupertino.icons.outlined.*
 import io.github.alexzhirkevich.cupertino.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -1007,9 +1001,6 @@ private fun InlineBgmSection(
 ) {
     if (bgmList.isEmpty()) return
 
-    var expanded by rememberSaveable(
-        inputs = arrayOf(bgmList.map(BgmInfo::musicId))
-    ) { mutableStateOf(false) }
     val leadSong = bgmList.first()
     val headerText = remember(bgmList, leadSong) {
         buildString {
@@ -1029,29 +1020,11 @@ private fun InlineBgmSection(
     BgmInfoRow(
         title = headerText,
         subtitle = leadSong.actor.takeIf { it.isNotBlank() },
-        expanded = expanded,
         showIndicator = bgmList.size > 1,
         onClick = {
-            if (bgmList.size > 1) {
-                expanded = !expanded
-            } else {
-                onBgmClick(leadSong)
-            }
+            onBgmClick(leadSong)
         }
     )
-
-    if (bgmList.size > 1) {
-        AnimatedVisibility(
-            visible = expanded,
-            enter = expandVertically() + fadeIn(),
-            exit = shrinkVertically() + fadeOut()
-        ) {
-            BgmInfoListRow(
-                bgmList = bgmList,
-                onBgmClick = onBgmClick
-            )
-        }
-    }
 }
 
 /**

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.border
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -29,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -1127,43 +1129,84 @@ fun BgmInfoListRow(
     bgmList: List<BgmInfo>,
     onBgmClick: (BgmInfo) -> Unit = {}
 ) {
+    val context = LocalContext.current
+
     Surface(
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.42f),
-        shape = RoundedCornerShape(12.dp),
+        shape = RoundedCornerShape(16.dp),
         modifier = Modifier
             .fillMaxWidth()
             .padding(top = 8.dp)
     ) {
-        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)) {
+        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp)) {
+            Text(
+                text = "共 ${bgmList.size} 首音乐",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.82f)
+            )
+            Spacer(modifier = Modifier.height(10.dp))
             bgmList.forEachIndexed { index, bgm ->
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .clip(RoundedCornerShape(14.dp))
                         .clickable { onBgmClick(bgm) }
-                        .padding(vertical = 8.dp),
+                        .padding(vertical = 6.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text(
-                        text = buildString {
-                            append(index + 1)
-                            append('.')
-                        },
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.78f),
-                        modifier = Modifier.width(28.dp)
-                    )
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = bgm.musicTitle.ifEmpty { "未知音乐" },
-                            style = MaterialTheme.typography.bodyMedium.copy(
-                                fontWeight = FontWeight.Medium
+                    Box(
+                        modifier = Modifier
+                            .size(54.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(MaterialTheme.colorScheme.surface)
+                            .border(
+                                width = 1.dp,
+                                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.45f),
+                                shape = RoundedCornerShape(12.dp)
                             ),
-                            color = MaterialTheme.colorScheme.onSurface,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
+                        contentAlignment = Alignment.Center
+                    ) {
+                        if (bgm.coverUrl.isNotBlank()) {
+                            AsyncImage(
+                                model = ImageRequest.Builder(context)
+                                    .data(FormatUtils.fixImageUrl(bgm.coverUrl))
+                                    .crossfade(true)
+                                    .build(),
+                                contentDescription = bgm.musicTitle,
+                                modifier = Modifier.fillMaxSize(),
+                                contentScale = ContentScale.Crop
+                            )
+                        } else {
+                            Icon(
+                                imageVector = CupertinoIcons.Default.MusicNote,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.75f),
+                                modifier = Modifier.size(20.dp)
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = "#${index + 1}",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.78f)
+                            )
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Text(
+                                text = bgm.musicTitle.ifEmpty { "未知音乐" },
+                                style = MaterialTheme.typography.bodyMedium.copy(
+                                    fontWeight = FontWeight.SemiBold
+                                ),
+                                color = MaterialTheme.colorScheme.onSurface,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.weight(1f, fill = false)
+                            )
+                        }
                         if (bgm.actor.isNotBlank()) {
-                            Spacer(modifier = Modifier.height(2.dp))
+                            Spacer(modifier = Modifier.height(4.dp))
                             Text(
                                 text = bgm.actor,
                                 style = MaterialTheme.typography.bodySmall,
@@ -1173,6 +1216,7 @@ fun BgmInfoListRow(
                             )
                         }
                     }
+                    Spacer(modifier = Modifier.width(8.dp))
                     Icon(
                         imageVector = CupertinoIcons.Default.ChevronForward,
                         contentDescription = null,
@@ -1181,7 +1225,10 @@ fun BgmInfoListRow(
                     )
                 }
                 if (index != bgmList.lastIndex) {
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.7f))
+                    HorizontalDivider(
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                        modifier = Modifier.padding(vertical = 2.dp)
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
@@ -11,9 +11,10 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -34,6 +35,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
@@ -57,19 +59,17 @@ import com.android.purebilibili.core.ui.components.UserUpBadge
 import com.android.purebilibili.core.ui.transition.shouldEnableVideoCoverSharedTransition
 import com.android.purebilibili.core.ui.transition.shouldEnableVideoMetadataSharedTransition
 import com.android.purebilibili.core.util.CardPositionManager
-import com.android.purebilibili.data.model.response.BgmCommentInfo
 import com.android.purebilibili.data.model.response.BgmDetailData
 import com.android.purebilibili.data.model.response.BgmInfo
 import com.android.purebilibili.data.model.response.AiSummaryData
 import com.android.purebilibili.data.model.response.BgmRecommendVideo
 import com.android.purebilibili.data.model.response.RelatedVideo
-import com.android.purebilibili.data.model.response.VideoItem
-import com.android.purebilibili.feature.home.components.cards.ElegantVideoCard
+import com.android.purebilibili.feature.video.screen.buildVideoNavigationOptions
 import com.android.purebilibili.feature.video.ui.FollowButtonTone
 import com.android.purebilibili.feature.video.ui.FollowTextTone
 import com.android.purebilibili.feature.video.ui.resolveVideoFollowVisualPolicy
-import com.android.purebilibili.data.repository.AudioRepository
 import com.android.purebilibili.data.repository.ViewGrpcRepository
+import kotlinx.coroutines.delay
 
 internal const val VIDEO_DESCRIPTION_URL_TAG = "VIDEO_DESCRIPTION_URL"
 private val VIDEO_DESCRIPTION_URL_PATTERN =
@@ -148,6 +148,11 @@ internal fun resolveVideoInfoInitialExpandedState(
     hasTags: Boolean,
     defaultExpanded: Boolean = true
 ): Boolean = defaultExpanded && (hasDescription || hasTags)
+
+private const val BGM_DISCOVERY_LOAD_DELAY_MS = 420L
+private const val BGM_RECOMMEND_PAGE_SIZE = 5
+private const val BGM_RECOMMEND_LIST_START_INDEX = 4
+private const val BGM_RECOMMEND_IMAGE_BUFFER_ITEMS = 1
 
 /**
  * Video Title Section (Bilibili official style: compact layout)
@@ -1141,56 +1146,88 @@ private fun BgmSelectionSheet(
     onRelatedVideoClick: (String, android.os.Bundle?) -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val itemKeys = remember(bgmList) {
+        bgmList.mapIndexed(::resolveBgmItemKey)
+    }
     val aid = remember(bgmList) {
         bgmList.firstOrNull()?.jumpUrl?.let { resolveQueryLongParam(it, "aid") } ?: 0L
     }
     val cid = remember(bgmList) {
         bgmList.firstOrNull()?.jumpUrl?.let { resolveQueryLongParam(it, "cid") } ?: 0L
     }
-    val preloadedData by produceState(
-        initialValue = bgmList.associate { it.musicId to BgmSheetItemState() },
-        key1 = bgmList,
-        key2 = aid,
-        key3 = cid
-    ) {
-        value = bgmList.associate { it.musicId to BgmSheetItemState() }
-        if (aid <= 0L || cid <= 0L) return@produceState
-        value = bgmList.associate { bgm ->
-            val detail = if (bgm.musicId.isNotBlank()) {
-                ViewGrpcRepository.getBgmDetail(
-                    musicId = bgm.musicId,
-                    aid = aid,
-                    cid = cid
-                ).getOrNull()
-            } else {
-                null
-            }
-            val recommendedVideos = if (bgm.musicId.isNotBlank()) {
-                ViewGrpcRepository.getBgmRecommendVideos(
-                    musicId = bgm.musicId,
-                    aid = aid,
-                    cid = cid
-                ).getOrDefault(emptyList())
-            } else {
-                emptyList()
-            }
-            bgm.musicId to BgmSheetItemState(
-                detail = detail,
-                recommendedVideos = recommendedVideos
-            )
+    val itemStateByKey = remember(itemKeys) {
+        mutableStateMapOf<String, BgmSheetItemState>().also { map ->
+            itemKeys.forEach { key -> map[key] = BgmSheetItemState() }
         }
     }
-    var selectedMusicId by remember(bgmList.map(BgmInfo::musicId)) {
-        mutableStateOf(bgmList.firstOrNull()?.musicId.orEmpty())
+    val listState = rememberLazyListState()
+    var selectedItemKey by remember(itemKeys) {
+        mutableStateOf(itemKeys.firstOrNull().orEmpty())
     }
-    val selectedBgm = remember(selectedMusicId, bgmList) {
-        bgmList.firstOrNull { it.musicId == selectedMusicId } ?: bgmList.first()
+    val selectedIndex = remember(selectedItemKey, itemKeys) {
+        itemKeys.indexOf(selectedItemKey).takeIf { it >= 0 } ?: 0
     }
-    val selectedData = remember(preloadedData, selectedBgm.musicId) {
-        preloadedData[selectedBgm.musicId] ?: BgmSheetItemState()
+    val selectedBgm = bgmList.getOrElse(selectedIndex) { bgmList.first() }
+    val selectedData = itemStateByKey[selectedItemKey] ?: BgmSheetItemState()
+
+    LaunchedEffect(selectedItemKey, selectedBgm.musicId, aid, cid) {
+        if (!shouldLoadBgmDiscoveryItem(selectedData, selectedBgm.musicId, aid, cid)) return@LaunchedEffect
+
+        delay(BGM_DISCOVERY_LOAD_DELAY_MS)
+        itemStateByKey[selectedItemKey] = selectedData.copy(
+            status = BgmDiscoveryLoadStatus.Loading,
+            errorMessage = null,
+            isAppendingRecommendations = false
+        )
+
+        val detail = ViewGrpcRepository.getBgmDetail(
+            musicId = selectedBgm.musicId,
+            aid = aid,
+            cid = cid
+        )
+        val recommendedVideos = ViewGrpcRepository.getBgmRecommendVideos(
+            musicId = selectedBgm.musicId,
+            aid = aid,
+            cid = cid,
+            page = 1,
+            pageSize = BGM_RECOMMEND_PAGE_SIZE
+        )
+        val loadedDetail = detail.getOrNull()
+        val loadedVideos = recommendedVideos.getOrDefault(emptyList())
+        val errorMessage = detail.exceptionOrNull()?.message
+            ?: recommendedVideos.exceptionOrNull()?.message
+
+        itemStateByKey[selectedItemKey] = BgmSheetItemState(
+            status = if (detail.isSuccess || recommendedVideos.isSuccess) {
+                BgmDiscoveryLoadStatus.Loaded
+            } else {
+                BgmDiscoveryLoadStatus.Error
+            },
+            detail = loadedDetail,
+            recommendedVideos = loadedVideos,
+            errorMessage = errorMessage,
+            nextRecommendPage = if (recommendedVideos.isSuccess) 2 else 1,
+            hasMoreRecommendations = if (recommendedVideos.isSuccess) {
+                loadedVideos.size >= BGM_RECOMMEND_PAGE_SIZE
+            } else {
+                true
+            },
+            isAppendingRecommendations = false
+        )
     }
-    val selectedVideoItems = remember(selectedData.recommendedVideos) {
-        selectedData.recommendedVideos.map(::bgmRecommendVideoToVideoItem)
+
+    val selectedMusicId = selectedBgm.musicId
+    val selectedStatLine = remember(selectedData.detail) {
+        resolveBgmStatLine(selectedData.detail)
+    }
+    val visibleSheetItemIndexes by remember(listState) {
+        derivedStateOf {
+            listState.layoutInfo.visibleItemsInfo.mapTo(mutableSetOf()) { it.index }
+        }
+    }
+    val shouldShowInitialRecommendationPlaceholders = remember(selectedData) {
+        selectedData.recommendedVideos.isEmpty() &&
+            selectedData.status != BgmDiscoveryLoadStatus.Error
     }
 
     com.android.purebilibili.core.ui.IOSModalBottomSheet(
@@ -1199,6 +1236,7 @@ private fun BgmSelectionSheet(
         dragHandle = null
     ) {
         LazyColumn(
+            state = listState,
             modifier = Modifier
                 .fillMaxWidth()
                 .fillMaxHeight(0.68f),
@@ -1233,8 +1271,9 @@ private fun BgmSelectionSheet(
             item {
                 BgmSelectionStrip(
                     bgmList = bgmList,
-                    selectedMusicId = selectedBgm.musicId,
-                    onSelect = { selectedMusicId = it.musicId }
+                    itemKeys = itemKeys,
+                    selectedItemKey = selectedItemKey,
+                    onSelect = { selectedItemKey = it }
                 )
             }
 
@@ -1243,39 +1282,264 @@ private fun BgmSelectionSheet(
                 BgmDetailCard(
                     bgm = selectedBgm,
                     detail = selectedData.detail,
+                    isLoading = selectedData.status == BgmDiscoveryLoadStatus.Loading,
+                    statLine = selectedStatLine,
                     onOpenMusic = { onBgmClick(selectedBgm) }
                 )
             }
 
-            if (selectedVideoItems.isNotEmpty()) {
-                item {
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Text(
-                        text = "使用该音乐的视频",
-                        style = MaterialTheme.typography.titleSmall,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.padding(horizontal = 16.dp)
-                    )
-                    Spacer(modifier = Modifier.height(10.dp))
+            item {
+                Spacer(modifier = Modifier.height(16.dp))
+                BgmDiscoveryRelatedHeader()
+            }
+
+            if (shouldShowInitialRecommendationPlaceholders) {
+                repeat(BGM_RECOMMEND_PAGE_SIZE) { placeholderIndex ->
+                    item(key = "bgm-recommend-placeholder-$placeholderIndex") {
+                        BgmRecommendVideoMiniCard(
+                            video = null,
+                            isPlaceholder = true,
+                            allowImageLoad = false,
+                            onClick = {}
+                        )
+                    }
                 }
-                item {
-                    BgmRelatedVideoGrid(
-                        videos = selectedVideoItems,
-                        onVideoClick = { video ->
+            } else if (selectedData.recommendedVideos.isNotEmpty()) {
+                itemsIndexed(
+                    items = selectedData.recommendedVideos,
+                    key = { index, video -> resolveBgmRecommendVideoKey(index, video) }
+                ) { index, video ->
+                    BgmRecommendVideoMiniCard(
+                        video = video,
+                        isPlaceholder = false,
+                        allowImageLoad = shouldRenderBgmRecommendImage(
+                            visibleItemIndexes = visibleSheetItemIndexes,
+                            itemIndex = resolveBgmRecommendListItemIndex(index)
+                        ),
+                        onClick = {
                             onDismiss()
-                            val navOptions = if (video.cid > 0L) {
-                                android.os.Bundle().apply {
-                                    putLong("target_cid", video.cid)
-                                }
-                            } else {
-                                null
-                            }
-                            onRelatedVideoClick(video.bvid, navOptions)
+                            onRelatedVideoClick(
+                                video.bvid,
+                                buildVideoNavigationOptions(targetCid = video.cid)
+                            )
                         }
                     )
                 }
+            } else if (selectedData.errorMessage?.isNotBlank() == true) {
+                item(key = "bgm-recommend-error") {
+                    Text(
+                        text = selectedData.errorMessage.takeIf { it.isNotBlank() } ?: "音乐推荐加载失败",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.78f),
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+                }
+            } else {
+                item(key = "bgm-recommend-empty") {
+                    Text(
+                        text = "暂无相关视频",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.78f),
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+                }
             }
+
+            if (selectedData.isAppendingRecommendations) {
+                item(key = "bgm-recommend-loading-more") {
+                    BgmDiscoveryLoadingRow()
+                }
+            }
+
+            if (selectedMusicId.isBlank() || aid <= 0L || cid <= 0L) {
+                item {
+                    Text(
+                        text = "暂时无法加载更多音乐信息",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.78f),
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
+                    )
+                }
+            }
+        }
+    }
+
+    LaunchedEffect(selectedItemKey) {
+        listState.scrollToItem(0)
+    }
+
+    LaunchedEffect(selectedItemKey, selectedMusicId, aid, cid) {
+        snapshotFlow {
+            val layoutInfo = listState.layoutInfo
+            (layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0) to layoutInfo.totalItemsCount
+        }.collect { (lastVisibleIndex, _) ->
+            val currentState = itemStateByKey[selectedItemKey] ?: return@collect
+            if (!shouldLoadMoreBgmRecommendations(currentState, selectedMusicId, aid, cid)) return@collect
+
+            val lastRecommendationIndex =
+                resolveBgmRecommendListItemIndex(currentState.recommendedVideos.lastIndex)
+            if (lastVisibleIndex < lastRecommendationIndex - 1) return@collect
+
+            loadMoreBgmRecommendations(
+                itemStateByKey = itemStateByKey,
+                itemKey = selectedItemKey,
+                bgm = selectedBgm,
+                aid = aid,
+                cid = cid
+            )
+        }
+    }
+}
+
+@Composable
+private fun BgmDiscoveryRelatedHeader() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+    ) {
+        Text(
+            text = "使用该音乐的视频",
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(modifier = Modifier.height(10.dp))
+    }
+}
+
+@Composable
+private fun BgmDiscoveryLoadingRow() {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(18.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.36f)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = CupertinoIcons.Default.MusicNote,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(modifier = Modifier.width(10.dp))
+            Text(
+                text = "正在加载音乐推荐...",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun BgmRecommendVideoMiniCard(
+    video: BgmRecommendVideo?,
+    isPlaceholder: Boolean,
+    allowImageLoad: Boolean,
+    onClick: () -> Unit
+) {
+    val context = LocalContext.current
+    val density = LocalDensity.current
+    val coverWidthPx = remember(density) { with(density) { 112.dp.roundToPx() } }
+    val coverHeightPx = remember(density) { with(density) { 70.dp.roundToPx() } }
+    val title = video?.title?.ifBlank { "相关视频" } ?: "相关视频"
+    val upName = video?.upNickName?.ifBlank { "未知 UP" } ?: "未知 UP"
+    val statText = if (isPlaceholder) {
+        "播放量 *** · 弹幕 *** · 时长 ***"
+    } else {
+        val playCount = video?.play ?: 0
+        val danmuCount = video?.danmu ?: 0
+        val durationSeconds = video?.duration ?: 0
+        buildString {
+            if (playCount > 0) append("播放量 ***")
+            if (danmuCount > 0) {
+                if (isNotEmpty()) append(" · ")
+                append("弹幕 ***")
+            }
+            if (durationSeconds > 0) {
+                if (isNotEmpty()) append(" · ")
+                append("时长 ***")
+            }
+        }.ifBlank { "点击查看" }
+    }
+
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .clickable(enabled = !isPlaceholder, onClick = onClick),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.36f)
+    ) {
+        Row(
+            modifier = Modifier.padding(10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(width = 112.dp, height = 70.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.10f)),
+                contentAlignment = Alignment.Center
+            ) {
+                if (allowImageLoad && video != null && video.cover.isNotBlank()) {
+                    AsyncImage(
+                        model = ImageRequest.Builder(context)
+                            .data(FormatUtils.fixImageUrl(video.cover))
+                            .size(coverWidthPx, coverHeightPx)
+                            .crossfade(false)
+                            .build(),
+                        contentDescription = video.title,
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Crop
+                    )
+                } else {
+                    Icon(
+                        imageVector = CupertinoIcons.Default.Play,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.75f),
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = upName,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = statText,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.78f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Icon(
+                imageVector = CupertinoIcons.Default.ChevronForward,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                modifier = Modifier.size(16.dp)
+            )
         }
     }
 }
@@ -1283,20 +1547,24 @@ private fun BgmSelectionSheet(
 @Composable
 private fun BgmSelectionStrip(
     bgmList: List<BgmInfo>,
-    selectedMusicId: String,
-    onSelect: (BgmInfo) -> Unit
+    itemKeys: List<String>,
+    selectedItemKey: String,
+    onSelect: (String) -> Unit
 ) {
     val context = LocalContext.current
+    val density = LocalDensity.current
+    val coverSizePx = remember(density) { with(density) { 76.dp.roundToPx() } }
     LazyRow(
         contentPadding = PaddingValues(horizontal = 16.dp),
         horizontalArrangement = Arrangement.spacedBy(10.dp)
     ) {
-        items(bgmList, key = { it.musicId }) { bgm ->
-            val selected = bgm.musicId == selectedMusicId
+        itemsIndexed(bgmList, key = { index, bgm -> itemKeys.getOrElse(index) { resolveBgmItemKey(index, bgm) } }) { index, bgm ->
+            val itemKey = itemKeys.getOrElse(index) { resolveBgmItemKey(index, bgm) }
+            val selected = itemKey == selectedItemKey
             Column(
                 modifier = Modifier
                     .width(76.dp)
-                    .clickable { onSelect(bgm) },
+                    .clickable { onSelect(itemKey) },
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Box(
@@ -1325,7 +1593,8 @@ private fun BgmSelectionStrip(
                         AsyncImage(
                             model = ImageRequest.Builder(context)
                                 .data(FormatUtils.fixImageUrl(bgm.coverUrl))
-                                .crossfade(true)
+                                .size(coverSizePx, coverSizePx)
+                                .crossfade(false)
                                 .build(),
                             contentDescription = bgm.musicTitle,
                             modifier = Modifier.fillMaxSize(),
@@ -1362,9 +1631,12 @@ private fun BgmSelectionStrip(
 private fun BgmDetailCard(
     bgm: BgmInfo,
     detail: BgmDetailData?,
+    isLoading: Boolean,
+    statLine: String?,
     onOpenMusic: () -> Unit
 ) {
     val scoreText = remember(detail) { resolveBgmScoreText(detail) }
+    val maskedStatLine = remember(statLine) { resolveMaskedBgmStatLine(statLine) }
     val description = remember(detail, bgm) {
         bgm.actor.takeIf { it.isNotBlank() }
             ?: detail?.originArtist?.takeIf { it.isNotBlank() }
@@ -1374,13 +1646,15 @@ private fun BgmDetailCard(
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp),
+            .padding(horizontal = 16.dp)
+            .clickable(onClick = onOpenMusic),
         shape = RoundedCornerShape(24.dp),
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.42f)
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .heightIn(min = 168.dp)
                 .padding(16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -1408,22 +1682,28 @@ private fun BgmDetailCard(
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                     Text(
-                        text = scoreText,
+                        text = if (isLoading) "加载音乐信息..." else scoreText,
                         style = MaterialTheme.typography.bodyMedium,
                         fontWeight = FontWeight.SemiBold,
                         color = MaterialTheme.colorScheme.onSurface
                     )
                 }
-                detail?.musicComment?.takeIf { it.nums > 0 }?.let {
-                    Spacer(modifier = Modifier.height(6.dp))
-                    Text(
-                        text = "${FormatUtils.formatStat(it.nums.toLong())}评论",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = maskedStatLine,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = if (detail?.musicComment?.nums ?: 0 > 0) "*** 评论" else "*** 评论",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
                     text = description,
@@ -1431,6 +1711,13 @@ private fun BgmDetailCard(
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.92f),
                     maxLines = 3,
                     overflow = TextOverflow.Ellipsis
+                )
+                Spacer(modifier = Modifier.height(10.dp))
+                Text(
+                    text = "打开音乐详情",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.SemiBold
                 )
             }
         }
@@ -1443,18 +1730,21 @@ private fun BgmDetailCover(
     title: String
 ) {
     val context = LocalContext.current
+    val density = LocalDensity.current
+    val coverSizePx = remember(density) { with(density) { 112.dp.roundToPx() } }
     Box(
         modifier = Modifier
             .size(width = 112.dp, height = 112.dp)
             .clip(RoundedCornerShape(22.dp))
-            .background(MaterialTheme.colorScheme.surface),
+            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.10f)),
         contentAlignment = Alignment.Center
     ) {
         if (coverUrl.isNotBlank()) {
             AsyncImage(
                 model = ImageRequest.Builder(context)
                     .data(FormatUtils.fixImageUrl(coverUrl))
-                    .crossfade(true)
+                    .size(coverSizePx, coverSizePx)
+                    .crossfade(false)
                     .build(),
                 contentDescription = title,
                 modifier = Modifier.fillMaxSize(),
@@ -1463,7 +1753,7 @@ private fun BgmDetailCover(
         } else {
             Icon(
                 imageVector = CupertinoIcons.Default.MusicNote,
-                contentDescription = null,
+                contentDescription = title,
                 tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.8f),
                 modifier = Modifier.size(34.dp)
             )
@@ -1490,90 +1780,144 @@ private fun resolveBgmStatLine(detail: BgmDetailData?): String? {
     return parts.takeIf { it.isNotEmpty() }?.joinToString(" · ")
 }
 
+private fun resolveMaskedBgmStatLine(statLine: String?): String {
+    return "*** 播放 · *** 想听 · *** 分享"
+}
+
+private fun resolveBgmRecommendVideoKey(index: Int, video: BgmRecommendVideo): String {
+    val stablePart = video.bvid.ifBlank { "${video.aid}:${video.cid}:${video.title}" }
+    return "bgm-recommend-$index:$stablePart"
+}
+
+private fun resolveBgmRecommendListItemIndex(index: Int): Int {
+    return BGM_RECOMMEND_LIST_START_INDEX + index
+}
+
+private fun shouldRenderBgmRecommendImage(
+    visibleItemIndexes: Set<Int>,
+    itemIndex: Int
+): Boolean {
+    return visibleItemIndexes.any { visibleIndex ->
+        kotlin.math.abs(visibleIndex - itemIndex) <= BGM_RECOMMEND_IMAGE_BUFFER_ITEMS
+    }
+}
+
 private fun resolveQueryLongParam(url: String, key: String): Long {
     return android.net.Uri.parse(url).getQueryParameter(key)?.toLongOrNull() ?: 0L
 }
 
-private data class BgmSheetItemState(
+internal enum class BgmDiscoveryLoadStatus {
+    Idle,
+    Loading,
+    Loaded,
+    Error
+}
+
+internal data class BgmSheetItemState(
+    val status: BgmDiscoveryLoadStatus = BgmDiscoveryLoadStatus.Idle,
     val detail: BgmDetailData? = null,
-    val recommendedVideos: List<BgmRecommendVideo> = emptyList()
+    val recommendedVideos: List<BgmRecommendVideo> = emptyList(),
+    val errorMessage: String? = null,
+    val nextRecommendPage: Int = 2,
+    val hasMoreRecommendations: Boolean = true,
+    val isAppendingRecommendations: Boolean = false
 )
 
-@Composable
-private fun BgmRelatedVideoGrid(
-    videos: List<VideoItem>,
-    onVideoClick: (VideoItem) -> Unit
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 10.dp)
-    ) {
-        videos.chunked(2).forEachIndexed { rowIndex, rowVideos ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
-                rowVideos.forEachIndexed { columnIndex, video ->
-                    ElegantVideoCard(
-                        video = video,
-                        index = rowIndex * 2 + columnIndex,
-                        animationEnabled = false,
-                        transitionEnabled = false,
-                        scrollLiteModeEnabled = true,
-                        isDataSaverActive = false,
-                        preferLowQualityCover = false,
-                        glassEnabled = false,
-                        blurEnabled = false,
-                        compactStatsOnCover = true,
-                        showCoverGlassBadges = false,
-                        showInfoGlassBadges = false,
-                        showUpBadge = true,
-                        showDurationBadge = true,
-                        showPublishTime = false,
-                        modifier = Modifier.weight(1f),
-                        onClick = { _, _ -> onVideoClick(video) }
-                    )
-                }
-                if (rowVideos.size == 1) {
-                    Spacer(modifier = Modifier.weight(1f))
-                }
+internal fun resolveBgmItemKey(index: Int, bgm: BgmInfo): String {
+    val stablePart = bgm.musicId
+        .trim()
+        .ifBlank {
+            bgm.jumpUrl.trim().ifBlank {
+                bgm.musicTitle.trim().ifBlank { "unknown" }
             }
         }
-    }
+    return "$index:$stablePart"
 }
 
-private fun relatedVideoToVideoItem(video: RelatedVideo): VideoItem {
-    return VideoItem(
-        id = if (video.aid > 0L) video.aid else video.cid,
-        bvid = video.bvid,
-        aid = video.aid,
-        cid = video.cid,
-        title = video.title,
-        pic = video.pic,
-        owner = video.owner,
-        stat = video.stat,
-        duration = video.duration
+internal fun shouldLoadBgmDiscoveryItem(
+    state: BgmSheetItemState,
+    musicId: String,
+    aid: Long,
+    cid: Long
+): Boolean {
+    if (musicId.isBlank() || aid <= 0L || cid <= 0L) return false
+    return state.status == BgmDiscoveryLoadStatus.Idle ||
+        state.status == BgmDiscoveryLoadStatus.Error
+}
+
+internal fun shouldLoadMoreBgmRecommendations(
+    state: BgmSheetItemState,
+    musicId: String,
+    aid: Long,
+    cid: Long
+): Boolean {
+    if (musicId.isBlank() || aid <= 0L || cid <= 0L) return false
+    if (state.status == BgmDiscoveryLoadStatus.Loading) return false
+    if (state.isAppendingRecommendations) return false
+    if (!state.hasMoreRecommendations) return false
+    return state.recommendedVideos.isNotEmpty()
+}
+
+private suspend fun loadMoreBgmRecommendations(
+    itemStateByKey: MutableMap<String, BgmSheetItemState>,
+    itemKey: String,
+    bgm: BgmInfo,
+    aid: Long,
+    cid: Long
+) {
+    val currentState = itemStateByKey[itemKey] ?: return
+    if (!shouldLoadMoreBgmRecommendations(currentState, bgm.musicId, aid, cid)) return
+
+    itemStateByKey[itemKey] = currentState.copy(
+        isAppendingRecommendations = true,
+        errorMessage = null
+    )
+
+    val result = ViewGrpcRepository.getBgmRecommendVideos(
+        musicId = bgm.musicId,
+        aid = aid,
+        cid = cid,
+        page = currentState.nextRecommendPage,
+        pageSize = BGM_RECOMMEND_PAGE_SIZE
+    )
+    val incomingVideos = result.getOrDefault(emptyList())
+    val mergedVideos = mergeBgmRecommendedVideos(
+        existing = currentState.recommendedVideos,
+        incoming = incomingVideos
+    )
+    val appendedCount = mergedVideos.size - currentState.recommendedVideos.size
+
+    val latestState = itemStateByKey[itemKey] ?: currentState
+    itemStateByKey[itemKey] = latestState.copy(
+        recommendedVideos = if (result.isSuccess) mergedVideos else latestState.recommendedVideos,
+        errorMessage = result.exceptionOrNull()?.message,
+        nextRecommendPage = if (result.isSuccess && appendedCount > 0) {
+            currentState.nextRecommendPage + 1
+        } else {
+            currentState.nextRecommendPage
+        },
+        hasMoreRecommendations = if (result.isSuccess) {
+            incomingVideos.size >= BGM_RECOMMEND_PAGE_SIZE && appendedCount > 0
+        } else {
+            latestState.hasMoreRecommendations
+        },
+        isAppendingRecommendations = false
     )
 }
-private fun bgmRecommendVideoToVideoItem(video: BgmRecommendVideo): VideoItem {
-    return VideoItem(
-        id = if (video.aid > 0L) video.aid else video.cid,
-        bvid = video.bvid,
-        aid = video.aid,
-        cid = video.cid,
-        title = video.title,
-        pic = video.cover,
-        owner = com.android.purebilibili.data.model.response.Owner(
-            mid = video.mid,
-            name = video.upNickName
-        ),
-        stat = com.android.purebilibili.data.model.response.Stat(
-            view = video.play,
-            danmaku = video.danmu
-        ),
-        duration = video.duration
-    )
+
+private fun mergeBgmRecommendedVideos(
+    existing: List<BgmRecommendVideo>,
+    incoming: List<BgmRecommendVideo>
+): List<BgmRecommendVideo> {
+    if (incoming.isEmpty()) return existing
+    val seenKeys = existing.mapTo(mutableSetOf()) { video ->
+        if (video.bvid.isNotBlank()) video.bvid else "${video.aid}:${video.cid}"
+    }
+    val appended = incoming.filter { video ->
+        val key = if (video.bvid.isNotBlank()) video.bvid else "${video.aid}:${video.cid}"
+        seenKeys.add(key)
+    }
+    return existing + appended
 }
 
 

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
@@ -506,7 +506,7 @@ fun VideoTitleWithDesc(
 
         // [新增] BGM Info Row
         val displayBgmList = remember(bgmInfo, bgmInfoList) {
-            if (bgmInfoList.size > 1) bgmInfoList
+            if (bgmInfoList.isNotEmpty()) bgmInfoList
             else if (bgmInfo != null) listOf(bgmInfo)
             else emptyList()
         }
@@ -1050,11 +1050,7 @@ private fun InlineBgmSection(
         subtitle = leadSong.actor.takeIf { it.isNotBlank() && bgmList.size == 1 },
         showIndicator = false,
         onClick = {
-            if (bgmList.size > 1) {
-                showSheet = true
-            } else {
-                onBgmClick(leadSong)
-            }
+            showSheet = true
         }
     )
 
@@ -1275,13 +1271,15 @@ private fun BgmSelectionSheet(
                 }
             }
 
-            item {
-                BgmSelectionStrip(
-                    bgmList = bgmList,
-                    itemKeys = itemKeys,
-                    selectedItemKey = selectedItemKey,
-                    onSelect = { selectedItemKey = it }
-                )
+            if (bgmList.size > 1) {
+                item {
+                    BgmSelectionStrip(
+                        bgmList = bgmList,
+                        itemKeys = itemKeys,
+                        selectedItemKey = selectedItemKey,
+                        onSelect = { selectedItemKey = it }
+                    )
+                }
             }
 
             item {
@@ -1594,14 +1592,19 @@ private fun BgmDetailCard(
                     .fillMaxWidth()
                     .height(BGM_DETAIL_CARD_HEIGHT)
                     .padding(16.dp),
-                verticalAlignment = Alignment.CenterVertically
+                verticalAlignment = Alignment.Top
             ) {
                 BgmDetailCover(
                     coverUrl = detail?.mvCover.orEmpty().ifBlank { bgm.coverUrl },
                     title = detail?.musicTitle.orEmpty().ifBlank { bgm.musicTitle }
                 )
                 Spacer(modifier = Modifier.width(14.dp))
-                Column(modifier = Modifier.weight(1f)) {
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight(),
+                    verticalArrangement = Arrangement.Top
+                ) {
                     Text(
                         text = detail?.musicTitle.orEmpty().ifBlank { bgm.musicTitle.ifBlank { "未知音乐" } },
                         style = MaterialTheme.typography.titleMedium,
@@ -1650,7 +1653,7 @@ private fun BgmDetailCard(
                         maxLines = 3,
                         overflow = TextOverflow.Ellipsis
                     )
-                    Spacer(modifier = Modifier.height(10.dp))
+                    Spacer(modifier = Modifier.weight(1f, fill = true))
                     Text(
                         text = "打开音乐详情",
                         style = MaterialTheme.typography.labelMedium,

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
@@ -485,17 +485,10 @@ fun VideoTitleWithDesc(
         }
         if (displayBgmList.isNotEmpty()) {
             Spacer(Modifier.height(8.dp))
-            if (displayBgmList.size == 1) {
-                BgmInfoRow(
-                    bgmInfo = displayBgmList.first(),
-                    onBgmClick = onBgmClick
-                )
-            } else {
-                BgmInfoListRow(
-                    bgmList = displayBgmList,
-                    onBgmClick = onBgmClick
-                )
-            }
+            InlineBgmSection(
+                bgmList = displayBgmList,
+                onBgmClick = onBgmClick
+            )
         }
         
         //  Description - 默认隐藏，展开后显示
@@ -996,6 +989,26 @@ fun DescriptionSection(desc: String) {
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun InlineBgmSection(
+    bgmList: List<BgmInfo>,
+    onBgmClick: (BgmInfo) -> Unit = {}
+) {
+    if (bgmList.isEmpty()) return
+
+    if (bgmList.size == 1) {
+        BgmInfoRow(
+            bgmInfo = bgmList.first(),
+            onBgmClick = onBgmClick
+        )
+    } else {
+        BgmInfoListRow(
+            bgmList = bgmList,
+            onBgmClick = onBgmClick
+        )
     }
 }
 

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
@@ -1,9 +1,14 @@
 // File: feature/video/ui/section/VideoInfoSection.kt
 package com.android.purebilibili.feature.video.ui.section
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -18,6 +23,7 @@ import io.github.alexzhirkevich.cupertino.icons.outlined.*
 import io.github.alexzhirkevich.cupertino.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -999,16 +1005,50 @@ private fun InlineBgmSection(
 ) {
     if (bgmList.isEmpty()) return
 
-    if (bgmList.size == 1) {
-        BgmInfoRow(
-            bgmInfo = bgmList.first(),
-            onBgmClick = onBgmClick
-        )
-    } else {
-        BgmInfoListRow(
-            bgmList = bgmList,
-            onBgmClick = onBgmClick
-        )
+    var expanded by rememberSaveable(
+        inputs = arrayOf(bgmList.map(BgmInfo::musicId))
+    ) { mutableStateOf(false) }
+    val leadSong = bgmList.first()
+    val headerText = remember(bgmList, leadSong) {
+        buildString {
+            append("发现音乐")
+            val title = leadSong.musicTitle.ifBlank { "未知音乐" }
+            append("《")
+            append(title)
+            append("》")
+            if (bgmList.size > 1) {
+                append("等")
+                append(bgmList.size)
+                append("首音乐")
+            }
+        }
+    }
+
+    BgmInfoRow(
+        title = headerText,
+        subtitle = leadSong.actor.takeIf { it.isNotBlank() },
+        expanded = expanded,
+        showIndicator = bgmList.size > 1,
+        onClick = {
+            if (bgmList.size > 1) {
+                expanded = !expanded
+            } else {
+                onBgmClick(leadSong)
+            }
+        }
+    )
+
+    if (bgmList.size > 1) {
+        AnimatedVisibility(
+            visible = expanded,
+            enter = expandVertically() + fadeIn(),
+            exit = shrinkVertically() + fadeOut()
+        ) {
+            BgmInfoListRow(
+                bgmList = bgmList,
+                onBgmClick = onBgmClick
+            )
+        }
     }
 }
 
@@ -1017,44 +1057,67 @@ private fun InlineBgmSection(
  */
 @Composable
 fun BgmInfoRow(
-    bgmInfo: BgmInfo,
-    onBgmClick: (BgmInfo) -> Unit = {}
+    title: String,
+    subtitle: String? = null,
+    expanded: Boolean = false,
+    showIndicator: Boolean = false,
+    onClick: () -> Unit = {}
 ) {
+    val indicatorRotation by animateFloatAsState(
+        targetValue = if (expanded) 180f else 0f,
+        animationSpec = tween(durationMillis = 220),
+        label = "BgmExpandIndicator"
+    )
+
     Surface(
-        // Optimization: Use primary color with very low alpha for a subtle, branded look
         color = MaterialTheme.colorScheme.primary.copy(alpha = 0.08f),
         shape = RoundedCornerShape(8.dp),
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { onBgmClick(bgmInfo) }
+            .clickable(onClick = onClick)
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
                 imageVector = CupertinoIcons.Default.MusicNote,
                 contentDescription = "BGM",
                 tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.8f),
-                modifier = Modifier.size(14.dp)
+                modifier = Modifier.size(16.dp)
             )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = buildString {
-                    append(bgmInfo.musicTitle.ifEmpty { "发现音乐" })
-                    if (bgmInfo.actor.isNotBlank()) {
-                        append(" - ")
-                        append(bgmInfo.actor)
-                    }
-                },
-                style = MaterialTheme.typography.labelMedium.copy(
-                    fontWeight = FontWeight.Medium
-                ),
-                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.9f),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f)
-            )
+            Spacer(modifier = Modifier.width(10.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.labelMedium.copy(
+                        fontWeight = FontWeight.Medium
+                    ),
+                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.92f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                subtitle?.takeIf { it.isNotBlank() }?.let {
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.78f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+            if (showIndicator) {
+                Icon(
+                    imageVector = CupertinoIcons.Default.ChevronDown,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.72f),
+                    modifier = Modifier
+                        .size(18.dp)
+                        .rotate(indicatorRotation)
+                )
+            }
         }
     }
 }
@@ -1064,66 +1127,61 @@ fun BgmInfoListRow(
     bgmList: List<BgmInfo>,
     onBgmClick: (BgmInfo) -> Unit = {}
 ) {
-    var expanded by remember { mutableStateOf(false) }
-    val displayList = if (expanded) bgmList else bgmList.take(2)
-
     Surface(
-        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.08f),
-        shape = RoundedCornerShape(8.dp),
-        modifier = Modifier.fillMaxWidth()
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.42f),
+        shape = RoundedCornerShape(12.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp)
     ) {
-        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Icon(
-                    imageVector = CupertinoIcons.Default.MusicNote,
-                    contentDescription = "BGM",
-                    tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.8f),
-                    modifier = Modifier.size(14.dp)
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = "发现 ${bgmList.size} 首音乐",
-                    style = MaterialTheme.typography.labelMedium.copy(
-                        fontWeight = FontWeight.Medium
-                    ),
-                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.9f),
-                    modifier = Modifier.weight(1f)
-                )
-                if (bgmList.size > 2) {
-                    Text(
-                        text = if (expanded) "收起" else "展开",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f),
-                        modifier = Modifier.clickable { expanded = !expanded }
-                    )
-                }
-            }
-            displayList.forEach { bgm ->
-                Spacer(modifier = Modifier.height(4.dp))
+        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)) {
+            bgmList.forEachIndexed { index, bgm ->
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
                         .clickable { onBgmClick(bgm) }
-                        .padding(start = 22.dp, top = 2.dp, bottom = 2.dp),
+                        .padding(vertical = 8.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
                         text = buildString {
-                            append(bgm.musicTitle.ifEmpty { "未知音乐" })
-                            if (bgm.actor.isNotBlank()) {
-                                append(" - ")
-                                append(bgm.actor)
-                            }
+                            append(index + 1)
+                            append('.')
                         },
                         style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f)
+                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.78f),
+                        modifier = Modifier.width(28.dp)
                     )
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = bgm.musicTitle.ifEmpty { "未知音乐" },
+                            style = MaterialTheme.typography.bodyMedium.copy(
+                                fontWeight = FontWeight.Medium
+                            ),
+                            color = MaterialTheme.colorScheme.onSurface,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        if (bgm.actor.isNotBlank()) {
+                            Spacer(modifier = Modifier.height(2.dp))
+                            Text(
+                                text = bgm.actor,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    }
+                    Icon(
+                        imageVector = CupertinoIcons.Default.ChevronForward,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                        modifier = Modifier.size(16.dp)
+                    )
+                }
+                if (index != bgmList.lastIndex) {
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.7f))
                 }
             }
         }

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoInfoSection.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -51,6 +50,7 @@ import com.android.purebilibili.data.model.response.VideoStaff
 import com.android.purebilibili.data.model.response.ViewInfo
 import com.android.purebilibili.data.model.response.VideoTag
 import com.android.purebilibili.core.ui.common.copyOnLongPress
+import com.android.purebilibili.core.ui.VideoCardSkeleton
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.ui.draw.rotate
 import com.android.purebilibili.core.ui.common.copyOnClick
@@ -63,12 +63,16 @@ import com.android.purebilibili.data.model.response.BgmDetailData
 import com.android.purebilibili.data.model.response.BgmInfo
 import com.android.purebilibili.data.model.response.AiSummaryData
 import com.android.purebilibili.data.model.response.BgmRecommendVideo
+import com.android.purebilibili.data.model.response.Owner
 import com.android.purebilibili.data.model.response.RelatedVideo
+import com.android.purebilibili.data.model.response.Stat
+import com.android.purebilibili.data.model.response.VideoItem
 import com.android.purebilibili.feature.video.screen.buildVideoNavigationOptions
 import com.android.purebilibili.feature.video.ui.FollowButtonTone
 import com.android.purebilibili.feature.video.ui.FollowTextTone
 import com.android.purebilibili.feature.video.ui.resolveVideoFollowVisualPolicy
 import com.android.purebilibili.data.repository.ViewGrpcRepository
+import com.android.purebilibili.feature.home.components.cards.ElegantVideoCard
 import kotlinx.coroutines.delay
 
 internal const val VIDEO_DESCRIPTION_URL_TAG = "VIDEO_DESCRIPTION_URL"
@@ -151,8 +155,7 @@ internal fun resolveVideoInfoInitialExpandedState(
 
 private const val BGM_DISCOVERY_LOAD_DELAY_MS = 420L
 private const val BGM_RECOMMEND_PAGE_SIZE = 5
-private const val BGM_RECOMMEND_LIST_START_INDEX = 4
-private const val BGM_RECOMMEND_IMAGE_BUFFER_ITEMS = 1
+private const val BGM_RECOMMEND_ROW_START_INDEX = 4
 
 /**
  * Video Title Section (Bilibili official style: compact layout)
@@ -1220,14 +1223,12 @@ private fun BgmSelectionSheet(
     val selectedStatLine = remember(selectedData.detail) {
         resolveBgmStatLine(selectedData.detail)
     }
-    val visibleSheetItemIndexes by remember(listState) {
-        derivedStateOf {
-            listState.layoutInfo.visibleItemsInfo.mapTo(mutableSetOf()) { it.index }
-        }
-    }
     val shouldShowInitialRecommendationPlaceholders = remember(selectedData) {
         selectedData.recommendedVideos.isEmpty() &&
             selectedData.status != BgmDiscoveryLoadStatus.Error
+    }
+    val recommendedVideoRows = remember(selectedData.recommendedVideos) {
+        selectedData.recommendedVideos.chunked(2)
     }
 
     com.android.purebilibili.core.ui.IOSModalBottomSheet(
@@ -1294,29 +1295,20 @@ private fun BgmSelectionSheet(
             }
 
             if (shouldShowInitialRecommendationPlaceholders) {
-                repeat(BGM_RECOMMEND_PAGE_SIZE) { placeholderIndex ->
-                    item(key = "bgm-recommend-placeholder-$placeholderIndex") {
-                        BgmRecommendVideoMiniCard(
-                            video = null,
-                            isPlaceholder = true,
-                            allowImageLoad = false,
-                            onClick = {}
-                        )
+                repeat((BGM_RECOMMEND_PAGE_SIZE + 1) / 2) { placeholderRowIndex ->
+                    item(key = "bgm-recommend-placeholder-row-$placeholderRowIndex") {
+                        BgmRecommendVideoSkeletonRow(indexBase = placeholderRowIndex * 2)
                     }
                 }
             } else if (selectedData.recommendedVideos.isNotEmpty()) {
                 itemsIndexed(
-                    items = selectedData.recommendedVideos,
-                    key = { index, video -> resolveBgmRecommendVideoKey(index, video) }
-                ) { index, video ->
-                    BgmRecommendVideoMiniCard(
-                        video = video,
-                        isPlaceholder = false,
-                        allowImageLoad = shouldRenderBgmRecommendImage(
-                            visibleItemIndexes = visibleSheetItemIndexes,
-                            itemIndex = resolveBgmRecommendListItemIndex(index)
-                        ),
-                        onClick = {
+                    items = recommendedVideoRows,
+                    key = { rowIndex, videos -> resolveBgmRecommendRowKey(rowIndex, videos) }
+                ) { rowIndex, rowVideos ->
+                    BgmRecommendVideoCardRow(
+                        rowVideos = rowVideos,
+                        rowIndex = rowIndex,
+                        onVideoClick = { video ->
                             onDismiss()
                             onRelatedVideoClick(
                                 video.bvid,
@@ -1347,7 +1339,7 @@ private fun BgmSelectionSheet(
 
             if (selectedData.isAppendingRecommendations) {
                 item(key = "bgm-recommend-loading-more") {
-                    BgmDiscoveryLoadingRow()
+                    BgmRecommendVideoSkeletonRow(indexBase = recommendedVideoRows.size * 2)
                 }
             }
 
@@ -1377,7 +1369,7 @@ private fun BgmSelectionSheet(
             if (!shouldLoadMoreBgmRecommendations(currentState, selectedMusicId, aid, cid)) return@collect
 
             val lastRecommendationIndex =
-                resolveBgmRecommendListItemIndex(currentState.recommendedVideos.lastIndex)
+                resolveBgmRecommendRowItemIndex((currentState.recommendedVideos.size - 1) / 2)
             if (lastVisibleIndex < lastRecommendationIndex - 1) return@collect
 
             loadMoreBgmRecommendations(
@@ -1409,139 +1401,76 @@ private fun BgmDiscoveryRelatedHeader() {
 }
 
 @Composable
-private fun BgmDiscoveryLoadingRow() {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(18.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.36f)
+private fun BgmRecommendVideoCardRow(
+    rowVideos: List<BgmRecommendVideo>,
+    rowIndex: Int,
+    onVideoClick: (BgmRecommendVideo) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Icon(
-                imageVector = CupertinoIcons.Default.MusicNote,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(18.dp)
+        rowVideos.forEachIndexed { columnIndex, video ->
+            ElegantVideoCard(
+                video = bgmRecommendVideoToVideoItem(video),
+                index = rowIndex * 2 + columnIndex,
+                animationEnabled = false,
+                showPublishTime = true,
+                isDataSaverActive = true,
+                preferLowQualityCover = true,
+                modifier = Modifier.weight(1f),
+                onClick = { _, _ ->
+                    onVideoClick(video)
+                }
             )
-            Spacer(modifier = Modifier.width(10.dp))
-            Text(
-                text = "正在加载音乐推荐...",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+        }
+        if (rowVideos.size == 1) {
+            Spacer(modifier = Modifier.weight(1f))
         }
     }
 }
 
 @Composable
-private fun BgmRecommendVideoMiniCard(
-    video: BgmRecommendVideo?,
-    isPlaceholder: Boolean,
-    allowImageLoad: Boolean,
-    onClick: () -> Unit
+private fun BgmRecommendVideoSkeletonRow(
+    indexBase: Int
 ) {
-    val context = LocalContext.current
-    val density = LocalDensity.current
-    val coverWidthPx = remember(density) { with(density) { 112.dp.roundToPx() } }
-    val coverHeightPx = remember(density) { with(density) { 70.dp.roundToPx() } }
-    val title = video?.title?.ifBlank { "相关视频" } ?: "相关视频"
-    val upName = video?.upNickName?.ifBlank { "未知 UP" } ?: "未知 UP"
-    val statText = if (isPlaceholder) {
-        "播放量 *** · 弹幕 *** · 时长 ***"
-    } else {
-        val playCount = video?.play ?: 0
-        val danmuCount = video?.danmu ?: 0
-        val durationSeconds = video?.duration ?: 0
-        buildString {
-            if (playCount > 0) append("播放量 ***")
-            if (danmuCount > 0) {
-                if (isNotEmpty()) append(" · ")
-                append("弹幕 ***")
-            }
-            if (durationSeconds > 0) {
-                if (isNotEmpty()) append(" · ")
-                append("时长 ***")
-            }
-        }.ifBlank { "点击查看" }
-    }
-
-    Surface(
+    Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(16.dp))
-            .clickable(enabled = !isPlaceholder, onClick = onClick),
-        shape = RoundedCornerShape(16.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.36f)
+            .padding(horizontal = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        Row(
-            modifier = Modifier.padding(10.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Box(
-                modifier = Modifier
-                    .size(width = 112.dp, height = 70.dp)
-                    .clip(RoundedCornerShape(12.dp))
-                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.10f)),
-                contentAlignment = Alignment.Center
-            ) {
-                if (allowImageLoad && video != null && video.cover.isNotBlank()) {
-                    AsyncImage(
-                        model = ImageRequest.Builder(context)
-                            .data(FormatUtils.fixImageUrl(video.cover))
-                            .size(coverWidthPx, coverHeightPx)
-                            .crossfade(false)
-                            .build(),
-                        contentDescription = video.title,
-                        modifier = Modifier.fillMaxSize(),
-                        contentScale = ContentScale.Crop
-                    )
-                } else {
-                    Icon(
-                        imageVector = CupertinoIcons.Default.Play,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.75f),
-                        modifier = Modifier.size(24.dp)
-                    )
-                }
-            }
-            Spacer(modifier = Modifier.width(12.dp))
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis
-                )
-                Spacer(modifier = Modifier.height(6.dp))
-                Text(
-                    text = upName,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = statText,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.78f),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
-            Spacer(modifier = Modifier.width(8.dp))
-            Icon(
-                imageVector = CupertinoIcons.Default.ChevronForward,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
-                modifier = Modifier.size(16.dp)
-            )
-        }
+        VideoCardSkeleton(
+            modifier = Modifier.weight(1f),
+            index = indexBase
+        )
+        VideoCardSkeleton(
+            modifier = Modifier.weight(1f),
+            index = indexBase + 1
+        )
     }
+}
+
+private fun bgmRecommendVideoToVideoItem(video: BgmRecommendVideo): VideoItem {
+    return VideoItem(
+        id = if (video.aid > 0L) video.aid else video.cid,
+        bvid = video.bvid,
+        aid = video.aid,
+        cid = video.cid,
+        title = video.title,
+        pic = video.cover,
+        owner = Owner(
+            mid = video.mid,
+            name = video.upNickName
+        ),
+        stat = Stat(
+            view = video.play,
+            danmaku = 0
+        ),
+        duration = video.duration
+    )
 }
 
 @Composable
@@ -1784,22 +1713,18 @@ private fun resolveMaskedBgmStatLine(statLine: String?): String {
     return "*** 播放 · *** 想听 · *** 分享"
 }
 
-private fun resolveBgmRecommendVideoKey(index: Int, video: BgmRecommendVideo): String {
-    val stablePart = video.bvid.ifBlank { "${video.aid}:${video.cid}:${video.title}" }
-    return "bgm-recommend-$index:$stablePart"
-}
-
-private fun resolveBgmRecommendListItemIndex(index: Int): Int {
-    return BGM_RECOMMEND_LIST_START_INDEX + index
-}
-
-private fun shouldRenderBgmRecommendImage(
-    visibleItemIndexes: Set<Int>,
-    itemIndex: Int
-): Boolean {
-    return visibleItemIndexes.any { visibleIndex ->
-        kotlin.math.abs(visibleIndex - itemIndex) <= BGM_RECOMMEND_IMAGE_BUFFER_ITEMS
+private fun resolveBgmRecommendRowKey(
+    rowIndex: Int,
+    videos: List<BgmRecommendVideo>
+): String {
+    val stablePart = videos.joinToString(separator = "|") { video ->
+        video.bvid.ifBlank { "${video.aid}:${video.cid}:${video.title}" }
     }
+    return "bgm-recommend-row-$rowIndex:$stablePart"
+}
+
+private fun resolveBgmRecommendRowItemIndex(rowIndex: Int): Int {
+    return BGM_RECOMMEND_ROW_START_INDEX + rowIndex
 }
 
 private fun resolveQueryLongParam(url: String, key: String): Long {

--- a/app/src/test/java/com/android/purebilibili/feature/video/ui/section/BgmDiscoverySheetPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/ui/section/BgmDiscoverySheetPolicyTest.kt
@@ -34,6 +34,39 @@ class BgmDiscoverySheetPolicyTest {
     }
 
     @Test
+    fun displayBgmList_prefersProvidedList() {
+        val fallback = BgmInfo(musicId = "fallback", musicTitle = "Fallback")
+        val primary = BgmInfo(musicId = "primary", musicTitle = "Primary")
+
+        assertEquals(
+            listOf(primary),
+            resolveDisplayBgmList(
+                bgmInfo = fallback,
+                bgmInfoList = listOf(primary)
+            )
+        )
+    }
+
+    @Test
+    fun displayBgmList_fallsBackToSingleInfo() {
+        val fallback = BgmInfo(musicId = "fallback", musicTitle = "Fallback")
+
+        assertEquals(
+            listOf(fallback),
+            resolveDisplayBgmList(
+                bgmInfo = fallback,
+                bgmInfoList = emptyList()
+            )
+        )
+        assertTrue(
+            resolveDisplayBgmList(
+                bgmInfo = null,
+                bgmInfoList = emptyList()
+            ).isEmpty()
+        )
+    }
+
+    @Test
     fun discoveryItem_doesNotLoadWithoutRequiredIdentity() {
         val idle = BgmSheetItemState()
 
@@ -74,6 +107,41 @@ class BgmDiscoverySheetPolicyTest {
                 musicId = "MA123",
                 aid = 1L,
                 cid = 2L
+            )
+        )
+    }
+
+    @Test
+    fun detailSkeleton_showsUntilLoadedDetailArrives() {
+        assertTrue(shouldShowBgmDetailSkeleton(BgmSheetItemState()))
+        assertTrue(
+            shouldShowBgmDetailSkeleton(
+                BgmSheetItemState(status = BgmDiscoveryLoadStatus.Loading)
+            )
+        )
+        assertFalse(
+            shouldShowBgmDetailSkeleton(
+                BgmSheetItemState(
+                    status = BgmDiscoveryLoadStatus.Loaded,
+                    detail = BgmDetailData(musicTitle = "Song")
+                )
+            )
+        )
+    }
+
+    @Test
+    fun initialRecommendationPlaceholders_hideAfterErrorOrData() {
+        assertTrue(shouldShowInitialBgmRecommendationPlaceholders(BgmSheetItemState()))
+        assertFalse(
+            shouldShowInitialBgmRecommendationPlaceholders(
+                BgmSheetItemState(status = BgmDiscoveryLoadStatus.Error)
+            )
+        )
+        assertFalse(
+            shouldShowInitialBgmRecommendationPlaceholders(
+                BgmSheetItemState(
+                    recommendedVideos = listOf(BgmRecommendVideo(bvid = "BV1"))
+                )
             )
         )
     }

--- a/app/src/test/java/com/android/purebilibili/feature/video/ui/section/BgmDiscoverySheetPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/ui/section/BgmDiscoverySheetPolicyTest.kt
@@ -1,0 +1,80 @@
+package com.android.purebilibili.feature.video.ui.section
+
+import com.android.purebilibili.data.model.response.BgmInfo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class BgmDiscoverySheetPolicyTest {
+
+    @Test
+    fun itemKey_includesIndexToAvoidDuplicateMusicIdsColliding() {
+        val bgm = BgmInfo(
+            musicId = "MA123",
+            musicTitle = "Song"
+        )
+
+        assertNotEquals(
+            resolveBgmItemKey(0, bgm),
+            resolveBgmItemKey(1, bgm)
+        )
+    }
+
+    @Test
+    fun itemKey_fallsBackWhenMusicIdIsBlank() {
+        assertEquals(
+            "0:Fallback Song",
+            resolveBgmItemKey(
+                index = 0,
+                bgm = BgmInfo(musicTitle = "Fallback Song")
+            )
+        )
+    }
+
+    @Test
+    fun discoveryItem_doesNotLoadWithoutRequiredIdentity() {
+        val idle = BgmSheetItemState()
+
+        assertFalse(shouldLoadBgmDiscoveryItem(idle, musicId = "", aid = 1L, cid = 1L))
+        assertFalse(shouldLoadBgmDiscoveryItem(idle, musicId = "MA123", aid = 0L, cid = 1L))
+        assertFalse(shouldLoadBgmDiscoveryItem(idle, musicId = "MA123", aid = 1L, cid = 0L))
+    }
+
+    @Test
+    fun discoveryItem_loadsOnlyIdleOrErrorStates() {
+        assertTrue(
+            shouldLoadBgmDiscoveryItem(
+                state = BgmSheetItemState(status = BgmDiscoveryLoadStatus.Idle),
+                musicId = "MA123",
+                aid = 1L,
+                cid = 2L
+            )
+        )
+        assertTrue(
+            shouldLoadBgmDiscoveryItem(
+                state = BgmSheetItemState(status = BgmDiscoveryLoadStatus.Error),
+                musicId = "MA123",
+                aid = 1L,
+                cid = 2L
+            )
+        )
+        assertFalse(
+            shouldLoadBgmDiscoveryItem(
+                state = BgmSheetItemState(status = BgmDiscoveryLoadStatus.Loading),
+                musicId = "MA123",
+                aid = 1L,
+                cid = 2L
+            )
+        )
+        assertFalse(
+            shouldLoadBgmDiscoveryItem(
+                state = BgmSheetItemState(status = BgmDiscoveryLoadStatus.Loaded),
+                musicId = "MA123",
+                aid = 1L,
+                cid = 2L
+            )
+        )
+    }
+}


### PR DESCRIPTION
## 问题描述

本 PR 解决了视频详情页中“发现音乐”入口跳转网页后，与应用内界面体验割裂的问题。

---

### 问题：点击“发现音乐”后跳转网页，交互链路与应用界面割裂

此前在视频详情页点击 BGM 相关入口后，应用主要通过跳转 WebView 展示 B 站官方音乐发现页。

这种方式虽然可以查看音乐内容，但存在明显问题：

- 页面内容依赖网页承载，与应用内视频详情页的视觉和交互风格不一致
- 用户从视频页进入音乐发现后，会从原本连续的应用内浏览流程切换到网页式界面
- 多首 BGM 的浏览、切换和相关推荐查看都依赖网页页面完成，体验割裂感较强
- 在视频详情页中，“发现音乐”只是跳转入口，而不是应用内原生能力的一部分

这会导致用户点击“发现音乐”后，虽然进入了功能页面，但整体感受更像“跳出当前页面去看一个网页”，而不是继续留在应用内完成音乐发现。

**修复前：** 点击“发现音乐”后跳转网页，音乐发现体验与应用内界面割裂。  
**修复后：** 将“发现音乐”主要收拢到视频详情页内，以应用内原生 UI 承载音乐发现流程，减少网页跳转带来的割裂感。


https://github.com/user-attachments/assets/9bd9c98a-1a13-4ee4-af4f-bdc1d2887255



#### 解决方案

在视频详情页内实现一套原生的内联 BGM 发现 UI，用来替代原本以网页跳转为主的发现方式：

- 在视频信息区域新增内联式“发现音乐”入口
- 支持在当前视频详情页内直接展开和浏览 BGM 信息
- 对多首 BGM 的视频，支持在应用内查看歌曲列表，而不是依赖网页页内展示
- 使用底部弹层承载音乐发现内容，保持用户仍处于当前视频详情页上下文中
- 在弹层内展示歌曲封面、标题、基础信息和相关推荐视频
- 补齐手机、平板、影院布局下的 BGM 点击链路和参数透传
- 优化发现弹层中的图片加载与列表渲染，降低界面切换和加载时的割裂感

这样处理后，用户点击“发现音乐”时，不再是简单跳去网页，而是在当前视频详情页内继续完成音乐浏览和发现流程，让该能力真正融入应用本身。

---

### 补充说明：本次改动重点是将“音乐发现”从网页跳转收回到应用内

这次改动的核心不是单纯补一个入口，而是把原本依赖网页承载的发现体验，尽可能转成视频页内的原生交互流程。

对应地，本 PR 也一并处理了配套问题：

- 多首 BGM 的统一展示与收敛
- 平板布局下 BGM 点击事件透传不完整的问题
- 相关推荐视频点击后的跳转链路
- 发现弹层中的加载、占位与渲染性能细节

这些调整的目标一致，都是为了降低“从视频页跳到网页”的割裂感，让“发现音乐”更像应用内原生功能，而不是外部页面跳转。

---

**TODO:**
- 后续可继续补充更多音乐详情信息与交互能力
- 当前已完成应用内发现 UI 的主链路替代，但仍建议结合真机继续检查手机/平板布局表现
- 代码改动涉及视频详情页、平板布局、BGM 弹层与数据透传，仍需 **代码审查** 后合并
