### PR TITLE
fix: 修复空间页头像无法预览的问题

### DIFF
--- a/app/src/main/java/com/android/purebilibili/feature/space/SpaceScreen.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/space/SpaceScreen.kt
@@ -159,6 +159,7 @@ fun SpaceScreen(
     var showMenu by remember { mutableStateOf(false) }
     var showBlockConfirmDialog by remember { mutableStateOf(false) }
     var showTopPhotoPreview by remember(mid) { mutableStateOf(false) }
+    var showAvatarPreview by remember(mid) { mutableStateOf(false) }
     var repostDynamicId by remember { mutableStateOf<String?>(null) }
     val hazeState = rememberRecoverableHazeState()
     val gridState = rememberLazyGridState()
@@ -347,6 +348,7 @@ fun SpaceScreen(
                             onSearchQueryChange = viewModel::updateSearchQuery,
                             onFollowClick = viewModel::toggleFollow,
                             onTopPhotoClick = { showTopPhotoPreview = true },
+                            onAvatarClick = { showAvatarPreview = true },
                             dynamicCardItems = dynamicCardItems,
                             likedDynamics = likedDynamics,
                             onSpaceDynamicCommentClick = dynamicInteractionViewModel::openCommentSheet,
@@ -378,11 +380,19 @@ fun SpaceScreen(
     val previewUrl = normalizeSpaceTopPhotoUrl(
         currentSuccessState?.userInfo?.topPhoto.orEmpty()
     )
+    val avatarPreviewUrl = currentSuccessState?.userInfo?.face.orEmpty()
     if (showTopPhotoPreview && shouldEnableSpaceTopPhotoPreview(previewUrl)) {
         ImagePreviewDialog(
             images = listOf(previewUrl),
             initialIndex = 0,
             onDismiss = { showTopPhotoPreview = false }
+        )
+    }
+    if (showAvatarPreview && avatarPreviewUrl.isNotBlank()) {
+        ImagePreviewDialog(
+            images = listOf(avatarPreviewUrl),
+            initialIndex = 0,
+            onDismiss = { showAvatarPreview = false }
         )
     }
 
@@ -571,6 +581,7 @@ private fun SpaceContent(
     onSearchQueryChange: (String) -> Unit,
     onFollowClick: () -> Unit,
     onTopPhotoClick: () -> Unit,
+    onAvatarClick: () -> Unit,
     dynamicCardItems: List<com.android.purebilibili.data.model.response.DynamicItem>,
     likedDynamics: Set<String>,
     onSpaceDynamicCommentClick: (com.android.purebilibili.data.model.response.DynamicItem) -> Unit,
@@ -713,6 +724,7 @@ private fun SpaceContent(
                     upStat = state.headerState.upStat ?: state.upStat,
                     onFollowClick = onFollowClick,
                     onTopPhotoClick = onTopPhotoClick,
+                    onAvatarClick = onAvatarClick,
                     onLiveClick = { url, title -> onWebClick(url, title) },
                     sharedTransitionScope = sharedTransitionScope,
                     animatedVisibilityScope = animatedVisibilityScope
@@ -1573,12 +1585,14 @@ private fun SpaceHeader(
     upStat: UpStatData?,
     onFollowClick: () -> Unit,
     onTopPhotoClick: () -> Unit,
+    onAvatarClick: () -> Unit,
     onLiveClick: (String, String) -> Unit,
     sharedTransitionScope: SharedTransitionScope?,
     animatedVisibilityScope: AnimatedVisibilityScope?
 ) {
     val context = LocalContext.current
     val topPhotoUrl = normalizeSpaceTopPhotoUrl(userInfo.topPhoto)
+    val avatarPreviewEnabled = userInfo.face.isNotBlank()
     val followLabel = if (userInfo.isFollowed) "已关注" else "关注"
     val officialText = userInfo.official.title.ifBlank { userInfo.official.desc }
     val metrics = remember(relationStat, upStat) {
@@ -1668,7 +1682,9 @@ private fun SpaceHeader(
                     }
 
                     Box(
-                        modifier = Modifier.size(avatarSize)
+                        modifier = Modifier
+                            .size(avatarSize)
+                            .clickable(enabled = avatarPreviewEnabled, onClick = onAvatarClick)
                     ) {
                         AsyncImage(
                             model = ImageRequest.Builder(context)


### PR DESCRIPTION
## 问题描述

本 PR 修复了用户空间页（Space）头像无法点击预览的问题。

---

### 问题：进入用户空间页后，点击头像无法查看大图

在视频详情页、评论区或其他用户入口点击用户头像后，应用会进入用户空间页（Space）。该页面顶部背景图支持点击预览，但头像本身仅做了展示，未接入点击预览逻辑，因此用户无法查看头像大图。

该问题可以稳定复现。

**修复前：** Space 页面头像仅显示，不支持点击预览。  
**修复后：** Space 页面头像支持点击，可弹出图片预览查看头像大图。

#### 解决方案

复用 Space 页面现有的顶部背景图预览模式，在 `SpaceScreen.kt` 中为头像补齐完整的预览链路：

- 新增 `showAvatarPreview` 状态，并补上头像点击后的预览开关
- 将 `onAvatarClick` 从 `SpaceScreen` 透传到 `SpaceHeader`，把头像点击事件接通
- 复用现有 `ImagePreviewDialog`，直接使用 `userInfo.face` 作为头像大图预览源

这样可以在不改动数据层和通用预览组件的前提下，以最小改动修复头像无法查看的问题。

https://github.com/user-attachments/assets/6bc24053-c0e8-46c2-9ce0-628c90f89099

---

**TODO:**
- 后续如有需要，可考虑统一 Space 页面顶部背景图与头像的图片预览状态管理方式。
- 页面顶部的背景图也做了预览，但也没有进行展示呈现出黑色的状态，也可以接入点击预览逻辑。
- 代码改动较少，但仍需**代码审查**后合并。