### PR TITLE
Fix DASH cast audio on legacy Chromecast

### DIFF
--- a/app/src/main/java/com/android/purebilibili/data/repository/VideoCastPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/data/repository/VideoCastPolicy.kt
@@ -1,6 +1,11 @@
 package com.android.purebilibili.data.repository
 
 import com.android.purebilibili.core.network.AppSignUtils
+import com.android.purebilibili.data.model.response.Dash
+import com.android.purebilibili.data.model.response.DashAudio
+import com.android.purebilibili.data.model.response.DashVideo
+import com.android.purebilibili.data.model.response.Dolby
+import com.android.purebilibili.data.model.response.Flac
 import com.android.purebilibili.data.model.response.PlayUrlData
 
 internal const val TV_CAST_DEFAULT_QUALITY = 80
@@ -45,12 +50,60 @@ internal fun extractTvCastPlayableUrl(data: PlayUrlData?): String? {
             return backup
         }
     }
-
-    val dashVideo = data.dash?.video
-        ?.firstOrNull { it.getValidUrl().isNotBlank() }
-        ?.getValidUrl()
-    if (!dashVideo.isNullOrBlank()) {
-        return dashVideo
-    }
     return null
+}
+
+internal fun selectCastDashVideo(videos: List<DashVideo>, targetQuality: Int): DashVideo? {
+    val validVideos = videos.filter { it.getValidUrl().isNotBlank() }
+    if (validVideos.isEmpty()) return null
+
+    fun codecFamily(codecs: String): Int = when {
+        codecs.startsWith("avc1", ignoreCase = true) -> 0
+        codecs.startsWith("hev1", ignoreCase = true) || codecs.startsWith("hvc1", ignoreCase = true) -> 1
+        codecs.startsWith("av01", ignoreCase = true) -> 2
+        else -> 3
+    }
+
+    fun bestInQuality(candidates: List<DashVideo>): DashVideo? {
+        return candidates.minByOrNull { it.bandwidth.coerceAtLeast(1) }
+    }
+
+    fun pickBestInFamily(candidates: List<DashVideo>): DashVideo? {
+        val byQuality: Map<Int, List<DashVideo>> = candidates.groupBy { it.id }
+
+        byQuality[targetQuality]?.let { return bestInQuality(it) }
+
+        val lowerIds = byQuality.keys.filter { it <= targetQuality }
+        if (lowerIds.isNotEmpty()) {
+            return bestInQuality(byQuality[lowerIds.max()]!!)
+        }
+
+        val higherIds = byQuality.keys.filter { it > targetQuality }
+        if (higherIds.isNotEmpty()) {
+            return bestInQuality(byQuality[higherIds.min()]!!)
+        }
+
+        return null
+    }
+
+    val families: Map<Int, List<DashVideo>> = validVideos.groupBy { codecFamily(it.codecs) }
+    for (family in listOf(0, 1, 2, 3)) {
+        families[family]?.let { familyVideos ->
+            pickBestInFamily(familyVideos)?.let { return it }
+        }
+    }
+
+    return null
+}
+
+internal fun selectCastDashAudio(audios: List<DashAudio>, dolby: Dolby?, flac: Flac?): DashAudio? {
+    val aacTracks = audios.filter { it.codecs.startsWith("mp4a", ignoreCase = true) && it.getValidUrl().isNotBlank() }
+    if (aacTracks.isEmpty()) return null
+    return aacTracks.maxByOrNull { it.bandwidth }
+}
+
+internal fun isCastDashManifestAvailable(dash: Dash): Boolean {
+    val hasPlayableVideo = dash.video.any { it.getValidUrl().isNotBlank() }
+    if (!hasPlayableVideo) return false
+    return selectCastDashAudio(dash.audio.orEmpty(), dash.dolby, dash.flac) != null
 }

--- a/app/src/main/java/com/android/purebilibili/data/repository/VideoRepository.kt
+++ b/app/src/main/java/com/android/purebilibili/data/repository/VideoRepository.kt
@@ -1092,11 +1092,11 @@ object VideoRepository {
         )?.data
     }
 
-    suspend fun getTvCastPlayUrl(
+    suspend fun getTvCastPlayData(
         aid: Long,
         cid: Long,
         qn: Int
-    ): String? = withContext(Dispatchers.IO) {
+    ): PlayUrlData? = withContext(Dispatchers.IO) {
         if (aid <= 0L || cid <= 0L) return@withContext null
 
         try {
@@ -1115,12 +1115,18 @@ object VideoRepository {
                 )
                 return@withContext null
             }
-            extractTvCastPlayableUrl(response.data)
+            response.data
         } catch (e: Exception) {
             com.android.purebilibili.core.util.Logger.w("VideoRepo", " tvPlayUrl exception: ${e.message}")
             null
         }
     }
+
+    suspend fun getTvCastPlayUrl(
+        aid: Long,
+        cid: Long,
+        qn: Int
+    ): String? = extractTvCastPlayableUrl(getTvCastPlayData(aid, cid, qn))
 
 
     private data class PlayUrlFetchResult(

--- a/app/src/main/java/com/android/purebilibili/feature/cast/LocalProxyServer.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/cast/LocalProxyServer.kt
@@ -13,10 +13,12 @@ import java.io.InputStream
 import java.net.Inet4Address
 import java.net.InetAddress
 import java.net.URLEncoder
+import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * 运行在手机上的轻量级 HTTP 代理服务器。
- * 作用：拦截 DLNA 设备的播放请求，转发给 Bilibili 服务器并修改请求头，从而绕过防盗链 (403 Forbidden)。
+ * 作用：拦截 DLNA/Chromecast 设备的播放请求，转发给 Bilibili 服务器并修改请求头，从而绕过防盗链 (403 Forbidden)。
  *
  * 原理：
  * 1. 电视/DLNA 设备请求: http://<手机IP>:<端口>/proxy?url=<编码后的B站视频URL>
@@ -28,36 +30,56 @@ class LocalProxyServer(port: Int = 8901) : NanoHTTPD(port) {
 
     private val client = OkHttpClient.Builder()
         .followRedirects(true)
-        .followSslRedirects(true) // 虽然电视可能只发起 HTTP 请求，但我们需要从 B 站获取 HTTPS 数据
+        .followSslRedirects(true)
         .build()
 
     override fun serve(session: IHTTPSession): NanoHTTPD.Response {
-        val uri = session.uri
-        // 仅处理 /proxy 路径的请求
-        if (uri != "/proxy") {
-            return newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "Not Found")
+        val uri = session.uri ?: "/"
+
+        if (session.method == Method.OPTIONS) {
+            val corsHeaders = corsHeaders()
+            return newFixedLengthResponse(Response.Status.OK, MIME_PLAINTEXT, "").also { resp ->
+                corsHeaders.forEach { (key, value) -> resp.addHeader(key, value) }
+            }
         }
 
+        if (uri.startsWith("/dash/") && uri.endsWith(".mpd")) {
+            val key = uri.removePrefix("/dash/").removeSuffix(".mpd")
+            val manifest = manifestStore[key]
+            if (manifest != null) {
+                val resp = newFixedLengthResponse(Response.Status.OK, DASH_CONTENT_TYPE, manifest)
+                corsHeaders().forEach { (key, value) -> resp.addHeader(key, value) }
+                return resp
+            }
+            return newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "Manifest not found")
+        }
+
+        if (uri == "/proxy") {
+            return serveProxy(session)
+        }
+
+        return newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "Not Found")
+    }
+
+    private fun serveProxy(session: IHTTPSession): NanoHTTPD.Response {
         val params = session.parms
         val targetUrl = params["url"]
-        
-        // 基础校验：必须包含目标 URL
+
         if (targetUrl.isNullOrEmpty()) {
-             return newFixedLengthResponse(Response.Status.BAD_REQUEST, MIME_PLAINTEXT, "Missing 'url' parameter")
+            return newFixedLengthResponse(Response.Status.BAD_REQUEST, MIME_PLAINTEXT, "Missing 'url' parameter")
         }
         if (!isSupportedTargetUrl(targetUrl)) {
             return newFixedLengthResponse(Response.Status.BAD_REQUEST, MIME_PLAINTEXT, "Unsupported target URL")
         }
         val parsedTargetUrl = targetUrl.toHttpUrlOrNull()
             ?: return newFixedLengthResponse(Response.Status.BAD_REQUEST, MIME_PLAINTEXT, "Invalid target URL")
-        
+
         Logger.d("LocalProxyServer", "📺 [Proxy] 正在代理请求: $targetUrl")
 
         try {
-            // 构建发往 Bilibili 的请求
-            // 关键点：设置 Referer 和 User-Agent 以绕过 B 站的防盗链检查
             val referer = params["referer"] ?: "https://www.bilibili.com"
-            val userAgent = params["ua"] ?: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+            val userAgent =
+                params["ua"] ?: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
 
             val request = Request.Builder()
                 .url(parsedTargetUrl)
@@ -69,7 +91,7 @@ class LocalProxyServer(port: Int = 8901) : NanoHTTPD(port) {
             val upstreamRequest = request.build()
 
             val upstreamResponse = client.newCall(upstreamRequest).execute()
-            
+
             if (!upstreamResponse.isSuccessful) {
                 val body = upstreamResponse.body?.string().orEmpty()
                 upstreamResponse.close()
@@ -80,7 +102,6 @@ class LocalProxyServer(port: Int = 8901) : NanoHTTPD(port) {
                 )
             }
 
-            // 获取 B 站返回的视频流和元数据
             val body = upstreamResponse.body
             if (body == null) {
                 upstreamResponse.close()
@@ -90,17 +111,17 @@ class LocalProxyServer(port: Int = 8901) : NanoHTTPD(port) {
             val contentType = upstreamResponse.header("Content-Type") ?: "video/mp4"
             val contentLength = body.contentLength()
 
-            // 构造返回给电视的响应
-            // 使用 ChunkedResponse 以支持流式传输，避免将整个视频加载到内存中
-            val nanoResponse = newChunkedResponse(mapToNanoStatus(upstreamResponse.code), contentType, inputStream)
-            
-            // 转发关键响应头 (如 Content-Length)，这对播放器的进度条显示和拖动至关重要
+            val nanoResponse =
+                newChunkedResponse(mapToNanoStatus(upstreamResponse.code), contentType, inputStream)
+
             if (contentLength != -1L) {
-                 nanoResponse.addHeader("Content-Length", contentLength.toString())
+                nanoResponse.addHeader("Content-Length", contentLength.toString())
             }
             upstreamResponse.header("Content-Range")?.let { nanoResponse.addHeader("Content-Range", it) }
             upstreamResponse.header("Accept-Ranges")?.let { nanoResponse.addHeader("Accept-Ranges", it) }
-            
+
+            corsHeaders().forEach { (key, value) -> nanoResponse.addHeader(key, value) }
+
             return nanoResponse
 
         } catch (e: Exception) {
@@ -111,8 +132,11 @@ class LocalProxyServer(port: Int = 8901) : NanoHTTPD(port) {
 
     companion object {
         const val PORT = 8901
+        const val DASH_CONTENT_TYPE = "application/dash+xml"
+
         @Volatile private var sharedServer: LocalProxyServer? = null
         private val bootstrapLock = Any()
+        private val manifestStore = ConcurrentHashMap<String, String>()
 
         @JvmStatic
         fun ensureStarted(): Boolean {
@@ -124,7 +148,25 @@ class LocalProxyServer(port: Int = 8901) : NanoHTTPD(port) {
                 return true
             }
         }
-        
+
+        fun dashManifestPath(key: String): String = "/dash/$key.mpd"
+
+        fun corsHeaders(): Map<String, String> = mapOf(
+            "Access-Control-Allow-Origin" to "*",
+            "Access-Control-Allow-Methods" to "GET, HEAD, OPTIONS",
+            "Access-Control-Allow-Headers" to "Range, Content-Type, Origin, Accept",
+            "Access-Control-Max-Age" to "3600"
+        )
+
+        fun registerDashManifest(context: Context, manifest: String): String {
+            ensureStarted()
+            val digest = MessageDigest.getInstance("SHA-256").digest(manifest.toByteArray(Charsets.UTF_8))
+            val key = digest.joinToString("") { "%02x".format(it) }.take(12)
+            manifestStore[key] = manifest
+            val ipAddress = resolveLocalIpv4Address(context)
+            return "http://$ipAddress:$PORT${dashManifestPath(key)}"
+        }
+
         /**
          * 生成代理 URL供 DLNA 设备使用
          * @param context 用于获取 Wi-Fi IP 地址
@@ -133,10 +175,10 @@ class LocalProxyServer(port: Int = 8901) : NanoHTTPD(port) {
          */
         fun getProxyUrl(context: Context, targetUrl: String): String {
             val ipAddress = resolveLocalIpv4Address(context)
-            
+
             // 对目标 URL 进行编码，作为参数传递
             val encodedUrl = URLEncoder.encode(targetUrl, "UTF-8")
-            
+
             return "http://$ipAddress:$PORT/proxy?url=$encodedUrl"
         }
 
@@ -162,7 +204,8 @@ class LocalProxyServer(port: Int = 8901) : NanoHTTPD(port) {
                 .orEmpty()
             pickBestIpv4Address(linkAddresses)?.let { return it }
 
-            val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+            val wifiManager =
+                context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
             val fallbackIp = Formatter.formatIpAddress(wifiManager.connectionInfo.ipAddress)
             if (!fallbackIp.isNullOrBlank() && fallbackIp != "0.0.0.0") {
                 return fallbackIp

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/VideoPlayerOverlay.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/VideoPlayerOverlay.kt
@@ -51,13 +51,16 @@ import com.android.purebilibili.feature.video.ui.components.PagesSelector
 import com.android.purebilibili.data.model.response.SponsorProgressMarker
 import com.android.purebilibili.data.model.response.ViewPoint
 import com.android.purebilibili.data.repository.VideoRepository
+import com.android.purebilibili.data.repository.isCastDashManifestAvailable
+import com.android.purebilibili.data.repository.selectCastDashAudio
+import com.android.purebilibili.data.repository.selectCastDashVideo
+import com.android.purebilibili.feature.video.playback.dash.buildLocalDashManifest
 import com.android.purebilibili.feature.common.resolveIndexedVideoLazyKey
 import com.android.purebilibili.feature.video.progress.PbpRidgeSample
 import io.github.alexzhirkevich.cupertino.CupertinoActivityIndicator
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.Dispatchers
 
@@ -156,6 +159,8 @@ internal fun shouldConsumeBackgroundGesturesForEndDrawer(
 
 internal fun shouldDismissCastDialogOnUrlFailure(castUrl: String?): Boolean = castUrl.isNullOrBlank()
 
+internal data class CastMediaResolution(val url: String, val contentType: String)
+
 internal fun resolveEffectivePlayerProgress(
     localProgress: PlayerProgress,
     pluginState: CastPluginPlaybackState?
@@ -178,10 +183,10 @@ internal fun resolveEffectivePlayingState(
 
 internal fun shouldActivatePluginPlaybackAfterCast(pluginState: CastPluginPlaybackState): Boolean = pluginState.isActive
 
-internal data class CastMediaSourceSignature(val aid: Long, val cid: Long, val quality: Int, val videoUrl: String)
+internal data class CastMediaSourceSignature(val aid: Long, val cid: Long, val quality: Int, val videoUrl: String, val audioUrl: String = "")
 
-internal fun buildCastMediaSourceSignature(currentAid: Long, cid: Long, currentQuality: Int, currentVideoUrl: String): CastMediaSourceSignature {
-    return CastMediaSourceSignature(aid = currentAid, cid = cid, quality = currentQuality, videoUrl = currentVideoUrl)
+internal fun buildCastMediaSourceSignature(currentAid: Long, cid: Long, currentQuality: Int, currentVideoUrl: String, currentAudioUrl: String = ""): CastMediaSourceSignature {
+    return CastMediaSourceSignature(aid = currentAid, cid = cid, quality = currentQuality, videoUrl = currentVideoUrl, audioUrl = currentAudioUrl)
 }
 
 internal fun shouldReloadActiveCastAfterMediaSourceChange(
@@ -195,21 +200,66 @@ internal fun shouldReloadActiveCastAfterMediaSourceChange(
     return currentSignature != lastCastSignature
 }
 
+internal fun resolveCastDashDurationMs(timelengthMs: Long, dashDurationSec: Int): Long = when {
+    timelengthMs > 0L -> timelengthMs
+    dashDurationSec > 0 -> dashDurationSec * 1000L
+    else -> 0L
+}
+
 internal suspend fun resolveCastPlayUrl(
     context: Context,
     currentAid: Long,
     cid: Long,
     currentQuality: Int,
     currentVideoUrl: String
-): String? = withContext(Dispatchers.IO) {
-    val tvCastUrl = runCatching {
-        VideoRepository.getTvCastPlayUrl(aid = currentAid, cid = cid, qn = currentQuality)
+): CastMediaResolution? = withContext(Dispatchers.IO) {
+    val tvData = runCatching {
+        VideoRepository.getTvCastPlayData(aid = currentAid, cid = cid, qn = currentQuality)
     }.getOrNull()
-    if (!tvCastUrl.isNullOrBlank()) return@withContext tvCastUrl
+
+    if (tvData != null) {
+        val durlUrl = tvData.durl.orEmpty().firstOrNull { it.url.isNotBlank() }?.url
+            ?: tvData.durl.orEmpty().firstNotNullOfOrNull { segment ->
+                segment.backupUrl?.firstOrNull { it.isNotBlank() }
+            }
+        if (!durlUrl.isNullOrBlank()) {
+            return@withContext CastMediaResolution(url = durlUrl, contentType = "video/mp4")
+        }
+
+        val dash = tvData.dash
+        if (dash != null && isCastDashManifestAvailable(dash)) {
+            val selectedVideo = selectCastDashVideo(dash.video, currentQuality.takeIf { it > 0 } ?: 80)
+            val selectedAudio = selectCastDashAudio(dash.audio.orEmpty(), dash.dolby, dash.flac)
+            if (selectedVideo != null && selectedAudio != null) {
+                val proxyVideo = selectedVideo.copy(
+                    baseUrl = LocalProxyServer.getProxyUrl(context, selectedVideo.getValidUrl()),
+                    backupUrl = null
+                )
+                val proxyAudio = selectedAudio.copy(
+                    baseUrl = LocalProxyServer.getProxyUrl(context, selectedAudio.getValidUrl()),
+                    backupUrl = null
+                )
+                val durationMs = resolveCastDashDurationMs(tvData.timelength, dash.duration)
+                val minBufferMs = (dash.minBufferTime * 1000f).toLong().coerceAtLeast(0L)
+                val manifest = buildLocalDashManifest(
+                    durationMs = durationMs,
+                    minBufferTimeMs = minBufferMs,
+                    videoTracks = listOf(proxyVideo),
+                    audioTracks = listOf(proxyAudio)
+                )
+                val manifestUrl = LocalProxyServer.registerDashManifest(context, manifest)
+                return@withContext CastMediaResolution(url = manifestUrl, contentType = LocalProxyServer.DASH_CONTENT_TYPE)
+            }
+        }
+    }
+
     runCatching {
         if (currentVideoUrl.isBlank()) return@runCatching null
         LocalProxyServer.ensureStarted()
-        LocalProxyServer.getProxyUrl(context, currentVideoUrl)
+        CastMediaResolution(
+            url = LocalProxyServer.getProxyUrl(context, currentVideoUrl),
+            contentType = "video/mp4"
+        )
     }.getOrNull()
 }
 
@@ -1856,25 +1906,26 @@ fun VideoPlayerOverlay(
         )
         
         // --- 12. 📺 投屏对话框 ---
-        val currentCastSignature = remember(currentAid, cid, currentQuality, currentVideoUrl) {
-            buildCastMediaSourceSignature(currentAid, cid, currentQuality, currentVideoUrl)
+        val currentCastSignature = remember(currentAid, cid, currentQuality, currentVideoUrl, currentAudioUrl) {
+            buildCastMediaSourceSignature(currentAid, cid, currentQuality, currentVideoUrl, currentAudioUrl)
         }
         if (showCastDialog) {
             DeviceListDialog(
                 onDismissRequest = { showCastDialog = false },
                 onPluginCastDeviceSelected = { plugin, route ->
                     scope.launch {
-                        val castUrl = resolveCastPlayUrl(context, currentAid, cid, currentQuality, currentVideoUrl)
-                        if (shouldDismissCastDialogOnUrlFailure(castUrl)) {
+                        val resolution = resolveCastPlayUrl(context, currentAid, cid, currentQuality, currentVideoUrl)
+                        if (resolution == null) {
                             showCastDialog = false
                             android.widget.Toast.makeText(context, "投屏地址解析失败", android.widget.Toast.LENGTH_SHORT).show()
                             return@launch
                         }
-                        val pluginCastUrl = castUrl!!
+                        val pluginCastUrl = resolution.url
                         val mediaRequest = CastPluginMediaRequest(
                             url = pluginCastUrl,
                             title = videoTitle,
-                            creator = videoOwnerName
+                            creator = videoOwnerName,
+                            contentType = resolution.contentType
                         )
                         val result = plugin.cast(context, route, mediaRequest)
                         showCastDialog = false
@@ -1918,21 +1969,22 @@ fun VideoPlayerOverlay(
                 return@LaunchedEffect
             }
 
-            val castUrl = resolveCastPlayUrl(context, currentAid, cid, currentQuality, currentVideoUrl)
-            if (castUrl.isNullOrBlank()) {
+            val resolution = resolveCastPlayUrl(context, currentAid, cid, currentQuality, currentVideoUrl)
+            if (resolution == null) {
                 android.widget.Toast.makeText(context, "投屏地址解析失败", android.widget.Toast.LENGTH_SHORT).show()
                 return@LaunchedEffect
             }
 
-            if (castUrl == lastCastMediaUrl) {
+            if (resolution.url == lastCastMediaUrl) {
                 lastCastMediaSignature = currentCastSignature
                 return@LaunchedEffect
             }
 
             val request = CastPluginMediaRequest(
-                url = castUrl,
+                url = resolution.url,
                 title = videoTitle,
                 creator = videoOwnerName,
+                contentType = resolution.contentType,
                 startPositionMs = pluginPlaybackState.currentPositionMs.coerceAtLeast(0L),
                 autoplay = pluginPlaybackState.isPlaying
             )
@@ -1940,7 +1992,7 @@ fun VideoPlayerOverlay(
             val result = plugin.cast(context, route, request)
             if (result.isSuccess) {
                 lastCastMediaSignature = currentCastSignature
-                lastCastMediaUrl = castUrl
+                lastCastMediaUrl = resolution.url
             } else {
                 android.widget.Toast.makeText(
                     context,

--- a/app/src/test/java/com/android/purebilibili/data/repository/VideoCastPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/data/repository/VideoCastPolicyTest.kt
@@ -1,14 +1,18 @@
 package com.android.purebilibili.data.repository
 
 import com.android.purebilibili.data.model.response.Dash
+import com.android.purebilibili.data.model.response.DashAudio
 import com.android.purebilibili.data.model.response.DashVideo
+import com.android.purebilibili.data.model.response.Dolby
 import com.android.purebilibili.data.model.response.Durl
+import com.android.purebilibili.data.model.response.Flac
 import com.android.purebilibili.data.model.response.PlayUrlData
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class VideoCastPolicyTest {
 
@@ -47,21 +51,29 @@ class VideoCastPolicyTest {
     }
 
     @Test
-    fun `extractTvCastPlayableUrl prefers durl url then backup then dash`() {
+    fun `extractTvCastPlayableUrl prefers durl url then backup url`() {
         val durlPrimary = PlayUrlData(
             durl = listOf(Durl(url = "https://cdn.example.com/main.mp4"))
         )
         val durlBackup = PlayUrlData(
             durl = listOf(Durl(url = "", backupUrl = listOf("https://cdn.example.com/backup.mp4")))
         )
-        val dashFallback = PlayUrlData(
-            durl = emptyList(),
-            dash = Dash(video = listOf(DashVideo(baseUrl = "https://cdn.example.com/video.m4s")))
-        )
 
         assertEquals("https://cdn.example.com/main.mp4", extractTvCastPlayableUrl(durlPrimary))
         assertEquals("https://cdn.example.com/backup.mp4", extractTvCastPlayableUrl(durlBackup))
-        assertEquals("https://cdn.example.com/video.m4s", extractTvCastPlayableUrl(dashFallback))
+    }
+
+    @Test
+    fun `extractTvCastPlayableUrl returns null for DASH-only payload instead of leaking video-only URL`() {
+        val dashOnly = PlayUrlData(
+            durl = emptyList(),
+            dash = Dash(
+                video = listOf(DashVideo(baseUrl = "https://cdn.example.com/video.m4s")),
+                audio = listOf(DashAudio(baseUrl = "https://cdn.example.com/audio.m4s"))
+            )
+        )
+
+        assertNull(extractTvCastPlayableUrl(dashOnly))
     }
 
     @Test
@@ -69,5 +81,240 @@ class VideoCastPolicyTest {
         val emptyPayload = PlayUrlData(durl = emptyList(), dash = Dash(video = emptyList()))
 
         assertNull(extractTvCastPlayableUrl(emptyPayload))
+    }
+
+    // --- Cast DASH video selection (legacy Chromecast compatibility) ---
+
+    @Test
+    fun `selectCastDashVideo prefers AVC over HEVC at target quality for Chromecast 2 compatibility`() {
+        val videos = listOf(
+            DashVideo(id = 80, baseUrl = "https://cdn.example.com/video-avc.m4s", codecs = "avc1.640028", width = 1920, height = 1080),
+            DashVideo(id = 80, baseUrl = "https://cdn.example.com/video-hevc.m4s", codecs = "hev1.2.4.L153", width = 1920, height = 1080)
+        )
+
+        val selected = assertNotNull(selectCastDashVideo(videos, targetQuality = 80))
+
+        assertEquals("avc1.640028", selected.codecs)
+        assertEquals("https://cdn.example.com/video-avc.m4s", selected.baseUrl)
+    }
+
+    @Test
+    fun `selectCastDashVideo falls back to HEVC when no AVC available at target quality`() {
+        val videos = listOf(
+            DashVideo(id = 112, baseUrl = "https://cdn.example.com/video-hevc.m4s", codecs = "hev1.2.4.L153", width = 1920, height = 1080),
+            DashVideo(id = 112, baseUrl = "https://cdn.example.com/video-av1.m4s", codecs = "av01.0.13M.10", width = 1920, height = 1080)
+        )
+
+        val selected = assertNotNull(selectCastDashVideo(videos, targetQuality = 112))
+
+        assertEquals("hev1.2.4.L153", selected.codecs)
+    }
+
+    @Test
+    fun `selectCastDashVideo falls back to highest lower quality when target is missing`() {
+        val videos = listOf(
+            DashVideo(id = 80, baseUrl = "https://cdn.example.com/video-80.m4s", codecs = "avc1.640028", width = 1920, height = 1080),
+            DashVideo(id = 64, baseUrl = "https://cdn.example.com/video-64.m4s", codecs = "avc1.64001E", width = 1280, height = 720),
+            DashVideo(id = 32, baseUrl = "https://cdn.example.com/video-32.m4s", codecs = "avc1.64000D", width = 640, height = 360)
+        )
+
+        val selected = assertNotNull(selectCastDashVideo(videos, targetQuality = 116))
+
+        assertEquals(80, selected.id)
+    }
+
+    @Test
+    fun `selectCastDashVideo falls back to lowest higher quality when all qualities exceed target`() {
+        val videos = listOf(
+            DashVideo(id = 80, baseUrl = "https://cdn.example.com/video-80.m4s", codecs = "avc1.640028", width = 1920, height = 1080),
+            DashVideo(id = 64, baseUrl = "https://cdn.example.com/video-64.m4s", codecs = "avc1.64001E", width = 1280, height = 720)
+        )
+
+        val selected = assertNotNull(selectCastDashVideo(videos, targetQuality = 32))
+
+        assertEquals(64, selected.id)
+    }
+
+    @Test
+    fun `selectCastDashVideo returns null when no valid video tracks exist`() {
+        val videos = listOf(
+            DashVideo(id = 80, baseUrl = "", codecs = "avc1.640028", width = 1920, height = 1080),
+            DashVideo(id = 64, baseUrl = "   ", codecs = "avc1.64001E", width = 1280, height = 720)
+        )
+
+        assertNull(selectCastDashVideo(videos, targetQuality = 80))
+    }
+
+    @Test
+    fun `selectCastDashVideo prefers lower-quality AVC over exact-quality HEVC for Chromecast compatibility`() {
+        val videos = listOf(
+            DashVideo(id = 80, baseUrl = "https://cdn.example.com/video-hevc.m4s", codecs = "hev1.2.4.L153", width = 1920, height = 1080),
+            DashVideo(id = 64, baseUrl = "https://cdn.example.com/video-avc.m4s", codecs = "avc1.64001E", width = 1280, height = 720)
+        )
+
+        val selected = assertNotNull(selectCastDashVideo(videos, targetQuality = 80))
+
+        assertEquals("avc1.64001E", selected.codecs)
+        assertEquals(64, selected.id)
+        assertEquals("https://cdn.example.com/video-avc.m4s", selected.baseUrl)
+    }
+
+    @Test
+    fun `selectCastDashVideo prefers lower-quality AVC over exact-quality AV1 for Chromecast compatibility`() {
+        val videos = listOf(
+            DashVideo(id = 80, baseUrl = "https://cdn.example.com/video-av1.m4s", codecs = "av01.0.13M.10", width = 1920, height = 1080),
+            DashVideo(id = 64, baseUrl = "https://cdn.example.com/video-avc.m4s", codecs = "avc1.64001E", width = 1280, height = 720)
+        )
+
+        val selected = assertNotNull(selectCastDashVideo(videos, targetQuality = 80))
+
+        assertEquals("avc1.64001E", selected.codecs)
+        assertEquals(64, selected.id)
+    }
+
+    @Test
+    fun `selectCastDashVideo prefers lower-quality HEVC over exact-quality AV1 when no AVC available`() {
+        val videos = listOf(
+            DashVideo(id = 80, baseUrl = "https://cdn.example.com/video-av1.m4s", codecs = "av01.0.13M.10", width = 1920, height = 1080),
+            DashVideo(id = 64, baseUrl = "https://cdn.example.com/video-hevc.m4s", codecs = "hev1.2.4.L153", width = 1280, height = 720)
+        )
+
+        val selected = assertNotNull(selectCastDashVideo(videos, targetQuality = 80))
+
+        assertEquals("hev1.2.4.L153", selected.codecs)
+        assertEquals(64, selected.id)
+    }
+
+    @Test
+    fun `selectCastDashVideo prefers lower bandwidth within same codec family and quality`() {
+        val videos = listOf(
+            DashVideo(id = 80, baseUrl = "https://cdn.example.com/video-high.m4s", codecs = "avc1.640028", width = 1920, height = 1080, bandwidth = 5000000),
+            DashVideo(id = 80, baseUrl = "https://cdn.example.com/video-low.m4s", codecs = "avc1.640028", width = 1920, height = 1080, bandwidth = 2000000)
+        )
+
+        val selected = assertNotNull(selectCastDashVideo(videos, targetQuality = 80))
+
+        assertEquals(2000000, selected.bandwidth)
+        assertEquals("https://cdn.example.com/video-low.m4s", selected.baseUrl)
+    }
+
+    // --- Cast DASH audio selection (AAC/mp4a only, ignore dolby/flac) ---
+
+    @Test
+    fun `selectCastDashAudio prefers AAC mp4a from normal dash audio tracks`() {
+        val audios = listOf(
+            DashAudio(id = 30280, baseUrl = "https://cdn.example.com/audio-aac.m4s", codecs = "mp4a.40.2", bandwidth = 192000),
+            DashAudio(id = 30300, baseUrl = "https://cdn.example.com/audio-ec3.m4s", codecs = "ec-3", bandwidth = 256000)
+        )
+
+        val selected = assertNotNull(selectCastDashAudio(audios, dolby = null, flac = null))
+
+        assertEquals("mp4a.40.2", selected.codecs)
+    }
+
+    @Test
+    fun `selectCastDashAudio ignores dolby and flac special tracks when normal audio is empty`() {
+        val dolbyAudio = DashAudio(id = 30250, baseUrl = "https://cdn.example.com/dolby.m4s", codecs = "ec-3")
+        val flacAudio = DashAudio(id = 30251, baseUrl = "https://cdn.example.com/flac.m4s", codecs = "flac")
+
+        val selected = selectCastDashAudio(
+            audios = emptyList(),
+            dolby = Dolby(type = 1, audio = listOf(dolbyAudio)),
+            flac = Flac(display = true, audio = flacAudio)
+        )
+
+        assertNull(selected)
+    }
+
+    @Test
+    fun `selectCastDashVideo recognizes hvc1 as HEVC codec`() {
+        val videos = listOf(
+            DashVideo(id = 80, baseUrl = "https://cdn.example.com/video-hvc1.m4s", codecs = "hvc1.2.4.L153", width = 1920, height = 1080),
+            DashVideo(id = 80, baseUrl = "https://cdn.example.com/video-av1.m4s", codecs = "av01.0.13M.10", width = 1920, height = 1080)
+        )
+
+        val selected = assertNotNull(selectCastDashVideo(videos, targetQuality = 80))
+
+        assertEquals("hvc1.2.4.L153", selected.codecs)
+        assertEquals("https://cdn.example.com/video-hvc1.m4s", selected.baseUrl)
+    }
+
+    @Test
+    fun `selectCastDashAudio excludes tracks with blank url`() {
+        val audios = listOf(
+            DashAudio(id = 30280, baseUrl = "", codecs = "mp4a.40.2", bandwidth = 192000),
+            DashAudio(id = 30300, baseUrl = "https://cdn.example.com/audio-aac.m4s", codecs = "mp4a.40.2", bandwidth = 128000)
+        )
+
+        val selected = assertNotNull(selectCastDashAudio(audios, dolby = null, flac = null))
+
+        assertEquals(30300, selected.id)
+        assertEquals("https://cdn.example.com/audio-aac.m4s", selected.baseUrl)
+    }
+
+    @Test
+    fun `selectCastDashAudio returns null when all AAC tracks have blank url`() {
+        val audios = listOf(
+            DashAudio(id = 30280, baseUrl = "", codecs = "mp4a.40.2", bandwidth = 192000),
+            DashAudio(id = 30300, baseUrl = "   ", codecs = "mp4a.40.2", bandwidth = 128000)
+        )
+
+        val selected = selectCastDashAudio(audios, dolby = null, flac = null)
+
+        assertNull(selected)
+    }
+
+    @Test
+    fun `selectCastDashAudio returns null when only non-AAC codecs in normal audio`() {
+        val audios = listOf(
+            DashAudio(id = 30250, baseUrl = "https://cdn.example.com/audio.m4s", codecs = "ec-3")
+        )
+
+        val selected = selectCastDashAudio(audios, dolby = null, flac = null)
+
+        assertNull(selected)
+    }
+
+    // --- Cast DASH manifest availability ---
+
+    @Test
+    fun `isCastDashManifestAvailable returns true when both playable video and AAC audio exist`() {
+        val dash = Dash(
+            video = listOf(DashVideo(id = 80, baseUrl = "https://cdn.example.com/video.m4s", codecs = "avc1.640028")),
+            audio = listOf(DashAudio(baseUrl = "https://cdn.example.com/audio.m4s", codecs = "mp4a.40.2"))
+        )
+
+        assertTrue(isCastDashManifestAvailable(dash))
+    }
+
+    @Test
+    fun `isCastDashManifestAvailable returns false when video is missing`() {
+        val dash = Dash(
+            video = emptyList(),
+            audio = listOf(DashAudio(baseUrl = "https://cdn.example.com/audio.m4s", codecs = "mp4a.40.2"))
+        )
+
+        assertFalse(isCastDashManifestAvailable(dash))
+    }
+
+    @Test
+    fun `isCastDashManifestAvailable returns false when audio is missing`() {
+        val dash = Dash(
+            video = listOf(DashVideo(id = 80, baseUrl = "https://cdn.example.com/video.m4s", codecs = "avc1.640028")),
+            audio = emptyList()
+        )
+
+        assertFalse(isCastDashManifestAvailable(dash))
+    }
+
+    @Test
+    fun `isCastDashManifestAvailable returns false when only dolby audio without AAC`() {
+        val dash = Dash(
+            video = listOf(DashVideo(id = 80, baseUrl = "https://cdn.example.com/video.m4s", codecs = "avc1.640028")),
+            audio = emptyList(),
+            dolby = Dolby(type = 1, audio = listOf(DashAudio(baseUrl = "https://cdn.example.com/dolby.m4s", codecs = "ec-3")))
+        )
+
+        assertFalse(isCastDashManifestAvailable(dash))
     }
 }

--- a/app/src/test/java/com/android/purebilibili/feature/cast/GoogleCastMediaLoaderTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/cast/GoogleCastMediaLoaderTest.kt
@@ -89,6 +89,17 @@ class GoogleCastMediaLoaderTest {
     }
 
     @Test
+    fun `buildMediaLoadRequest preserves application dash xml content type for DASH manifests`() {
+        val request = GoogleCastMediaLoader.buildMediaLoadRequest(
+            url = "https://example.com/manifest.mpd",
+            title = "DASH Stream",
+            contentType = "application/dash+xml"
+        )
+
+        assertEquals("application/dash+xml", requireMediaInfo(request).contentType)
+    }
+
+    @Test
     fun `buildMediaLoadRequest creates metadata of movie type`() {
         val request = GoogleCastMediaLoader.buildMediaLoadRequest(
             url = "https://example.com/video.mp4",

--- a/app/src/test/java/com/android/purebilibili/feature/cast/LocalProxyServerPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/cast/LocalProxyServerPolicyTest.kt
@@ -29,4 +29,26 @@ class LocalProxyServerPolicyTest {
         assertFalse(LocalProxyServer.isSupportedTargetUrl("file:///sdcard/video.mp4"))
         assertFalse(LocalProxyServer.isSupportedTargetUrl("javascript:alert(1)"))
     }
+
+    // --- DASH manifest routing ---
+
+    @Test
+    fun `dash manifest URL uses dash key mpd path`() {
+        assertEquals("/dash/video123.mpd", LocalProxyServer.dashManifestPath("video123"))
+        assertEquals("/dash/abc-def.mpd", LocalProxyServer.dashManifestPath("abc-def"))
+    }
+
+    @Test
+    fun `dash content type constant is application dash xml`() {
+        assertEquals("application/dash+xml", LocalProxyServer.DASH_CONTENT_TYPE)
+    }
+
+    // --- CORS ---
+
+    @Test
+    fun `cors headers include Access-Control-Allow-Origin star`() {
+        val headers = LocalProxyServer.corsHeaders()
+
+        assertEquals("*", headers["Access-Control-Allow-Origin"])
+    }
 }

--- a/app/src/test/java/com/android/purebilibili/feature/video/ui/overlay/VideoPlayerOverlayCastPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/ui/overlay/VideoPlayerOverlayCastPolicyTest.kt
@@ -218,6 +218,28 @@ class VideoPlayerOverlayCastPolicyTest {
         )
     }
 
+    // --- resolveCastDashDurationMs ---
+
+    @Test
+    fun `resolveCastDashDurationMs prefers timelength in ms over dash duration`() {
+        assertEquals(120000L, resolveCastDashDurationMs(timelengthMs = 120000L, dashDurationSec = 120))
+    }
+
+    @Test
+    fun `resolveCastDashDurationMs falls back to dash duration converted to ms`() {
+        assertEquals(120000L, resolveCastDashDurationMs(timelengthMs = 0L, dashDurationSec = 120))
+    }
+
+    @Test
+    fun `resolveCastDashDurationMs returns zero when both are unavailable`() {
+        assertEquals(0L, resolveCastDashDurationMs(timelengthMs = 0L, dashDurationSec = 0))
+    }
+
+    @Test
+    fun `resolveCastDashDurationMs returns zero when timelength is negative and dash is zero`() {
+        assertEquals(0L, resolveCastDashDurationMs(timelengthMs = -1L, dashDurationSec = 0))
+    }
+
     @Test
     fun `shouldReloadActiveCast returns false when signature unchanged`() {
         val sig = buildCastMediaSourceSignature(

--- a/docs/GOOGLE_CAST_PLUGIN.md
+++ b/docs/GOOGLE_CAST_PLUGIN.md
@@ -189,7 +189,35 @@ Verification:
 .\gradlew.bat "-Pkotlin.compiler.execution.strategy=in-process" :app:assembleDebug --no-daemon
 ```
 
-Both commands completed with `BUILD SUCCESSFUL`.
+All commands completed with `BUILD SUCCESSFUL`.
+
+### Slice 8: Bugfix — DASH-Only Cast Audio On Legacy Chromecast
+
+Goal: fix videos that show picture but have no sound on Chromecast 2 when the BiliBili TV cast API returns DASH-only data.
+
+Root cause:
+
+- `extractTvCastPlayableUrl` previously fell back to `dash.video.first().getValidUrl()` when no `durl` URL existed.
+- DASH video URLs are video-only `.m4s` resources, so loading that URL directly into Google Cast can produce video without audio.
+- Chromecast 2 also needs conservative codec selection, so Cast DASH fallback should prefer AVC/H.264 video and AAC audio.
+
+Result on 2026-05-27:
+
+- `extractTvCastPlayableUrl` now returns only complete `durl` primary/backup URLs and no longer leaks video-only DASH URLs.
+- DASH-only TV cast payloads are converted into a local MPD manifest containing one proxied video representation and one proxied AAC audio representation.
+- `LocalProxyServer` now serves registered `/dash/*.mpd` manifests as `application/dash+xml` and adds CORS headers for manifest/proxy requests.
+- DASH video selection prefers AVC/H.264 across qualities before HEVC/HVC1, AV1, or unknown codecs; within a codec family it still prefers exact quality, then closest lower, then closest higher quality.
+- Active Cast source signatures now include `currentAudioUrl` so audio-only source changes can trigger a Cast reload.
+
+Verification:
+
+```powershell
+.\gradlew.bat "-Pkotlin.compiler.execution.strategy=in-process" :app:testDebugUnitTest --tests "com.android.purebilibili.data.repository.VideoCastPolicyTest" --tests "com.android.purebilibili.feature.cast.LocalProxyServerPolicyTest" --tests "com.android.purebilibili.feature.plugin.googlecast.GoogleCastMediaLoaderTest" --tests "com.android.purebilibili.feature.video.ui.overlay.VideoPlayerOverlayCastPolicyTest" --no-daemon
+.\gradlew.bat "-Pkotlin.compiler.execution.strategy=in-process" :app:testDebugUnitTest --tests "*Cast*" --no-daemon
+.\gradlew.bat "-Pkotlin.compiler.execution.strategy=in-process" :app:compileDebugKotlin --no-daemon
+.\gradlew.bat "-Pkotlin.compiler.execution.strategy=in-process" :app:assembleDebug --no-daemon
+git diff --check
+```
 
 ## Progress Log
 
@@ -203,3 +231,4 @@ Both commands completed with `BUILD SUCCESSFUL`.
 - 2026-05-26: Completed Slice 6 bugfix — DLNA DOCTYPE parsing, first-tap RemoteMediaClient wait, and cast playback control.
 - 2026-05-26: Updated Google Cast plugin author metadata from 'BiliPai项目组' to 'Leko (lekoOwO)' before opening upstream PR.
 - 2026-05-26: Completed Slice 7 active Google Cast quality/source reload while keeping DLNA one-shot/manual.
+- 2026-05-27: Completed Slice 8 Chromecast 2 DASH-only audio fix by replacing video-only DASH URL fallback with a local DASH manifest and AVC/AAC selection policy.


### PR DESCRIPTION
## Summary
- Fix Google Cast fallback for DASH-only TV cast payloads by generating a local DASH manifest that includes both video and AAC audio.
- Stop passing video-only DASH `.m4s` URLs directly to Chromecast when no `durl` URL is available.
- Prefer AVC/H.264 video tracks for legacy Chromecast compatibility, with AAC audio and proxied media URLs served through the existing local proxy.
- Include audio source changes in the active Cast media signature so audio-only source changes can trigger a reload.

## Root Cause
Some TV cast responses contain DASH streams only. The previous fallback loaded the first DASH video URL directly, but that resource is video-only. On Chromecast 2 this can render picture without sound, while newer Google TV devices may hide the issue with broader media handling.

## Verification
- `.\gradlew.bat "-Pkotlin.compiler.execution.strategy=in-process" :app:testDebugUnitTest --tests "*Cast*" --no-daemon`
- `.\gradlew.bat "-Pkotlin.compiler.execution.strategy=in-process" :app:compileDebugKotlin --no-daemon`
- `.\gradlew.bat "-Pkotlin.compiler.execution.strategy=in-process" :app:assembleDebug --no-daemon`
- `git diff --check upstream/main..HEAD`
