### PR TITLE
修复消息评论跳转

### DIFF
--- a/app/src/main/java/com/android/purebilibili/core/store/SettingsManager.kt
+++ b/app/src/main/java/com/android/purebilibili/core/store/SettingsManager.kt
@@ -355,6 +355,7 @@ data class HomeSettings(
     val isBottomBarFloating: Boolean = true,
     val bottomBarLabelMode: Int = 0,       // (0=图标+文字, 1=仅图标, 2=仅文字)
     val topTabLabelMode: Int = 2,          // (0=图标+文字, 1=仅图标, 2=仅文字)
+    val homeTopRightAction: HomeTopRightAction = HomeTopRightAction.SETTINGS,
     val isHeaderBlurEnabled: Boolean = true,
     val headerBlurMode: HomeHeaderBlurMode = HomeHeaderBlurMode.FOLLOW_PRESET,
     val isBottomBarBlurEnabled: Boolean = true,
@@ -425,6 +426,16 @@ enum class HomeWallpaperEffectScope(val value: Int, val label: String) {
     companion object {
         fun fromValue(value: Int): HomeWallpaperEffectScope =
             entries.find { it.value == value } ?: HOME_ONLY
+    }
+}
+
+enum class HomeTopRightAction(val value: Int, val label: String) {
+    SETTINGS(0, "设置"),
+    INBOX(1, "消息");
+
+    companion object {
+        fun fromValue(value: Int): HomeTopRightAction =
+            entries.find { it.value == value } ?: SETTINGS
     }
 }
 
@@ -802,6 +813,7 @@ object SettingsManager {
     private val KEY_BOTTOM_BAR_LABEL_MODE = intPreferencesKey("bottom_bar_label_mode")
     //  [新增] 顶部标签显示模式 (0=图标+文字, 1=仅图标, 2=仅文字)
     private val KEY_TOP_TAB_LABEL_MODE = intPreferencesKey("top_tab_label_mode")
+    private val KEY_HOME_TOP_RIGHT_ACTION = intPreferencesKey("home_top_right_action")
     //  [新增] 顶部标签自定义 - 顺序和可见性
     private val KEY_TOP_TAB_ORDER = stringPreferencesKey("top_tab_order")
     private val KEY_TOP_TAB_VISIBLE_TABS = stringPreferencesKey("top_tab_visible_tabs")
@@ -955,6 +967,9 @@ object SettingsManager {
             isBottomBarFloating = preferences[KEY_BOTTOM_BAR_FLOATING] ?: true,
             bottomBarLabelMode = preferences[KEY_BOTTOM_BAR_LABEL_MODE] ?: BottomBarLabelMode.ICON_AND_TEXT,
             topTabLabelMode = preferences[KEY_TOP_TAB_LABEL_MODE] ?: TopTabLabelMode.TEXT_ONLY,
+            homeTopRightAction = HomeTopRightAction.fromValue(
+                preferences[KEY_HOME_TOP_RIGHT_ACTION] ?: HomeTopRightAction.SETTINGS.value
+            ),
             isHeaderBlurEnabled = headerBlurMode != HomeHeaderBlurMode.ALWAYS_OFF,
             headerBlurMode = headerBlurMode,
             isHeaderCollapseEnabled = preferences[KEY_HEADER_COLLAPSE_ENABLED] ?: true,
@@ -2070,6 +2085,19 @@ object SettingsManager {
 
     suspend fun setTopTabLabelMode(context: Context, value: Int) {
         context.settingsDataStore.edit { preferences -> preferences[KEY_TOP_TAB_LABEL_MODE] = value }
+    }
+
+    fun getHomeTopRightAction(context: Context): Flow<HomeTopRightAction> = context.settingsDataStore.data
+        .map { preferences ->
+            HomeTopRightAction.fromValue(
+                preferences[KEY_HOME_TOP_RIGHT_ACTION] ?: HomeTopRightAction.SETTINGS.value
+            )
+        }
+
+    suspend fun setHomeTopRightAction(context: Context, action: HomeTopRightAction) {
+        context.settingsDataStore.edit { preferences ->
+            preferences[KEY_HOME_TOP_RIGHT_ACTION] = action.value
+        }
     }
 
     //  [新增] --- 顶部标签顺序配置 ---
@@ -5157,6 +5185,7 @@ object SettingsManager {
             BooleanShareablePreferenceDefinition(KEY_BOTTOM_BAR_FLOATING, SettingsShareSection.APPEARANCE),
             IntShareablePreferenceDefinition(KEY_BOTTOM_BAR_LABEL_MODE, SettingsShareSection.APPEARANCE),
             IntShareablePreferenceDefinition(KEY_TOP_TAB_LABEL_MODE, SettingsShareSection.APPEARANCE),
+            IntShareablePreferenceDefinition(KEY_HOME_TOP_RIGHT_ACTION, SettingsShareSection.APPEARANCE),
             StringShareablePreferenceDefinition(KEY_TOP_TAB_ORDER, SettingsShareSection.APPEARANCE),
             StringShareablePreferenceDefinition(KEY_TOP_TAB_VISIBLE_TABS, SettingsShareSection.APPEARANCE),
             StringShareablePreferenceDefinition(KEY_DYNAMIC_TAB_VISIBLE_TABS, SettingsShareSection.APPEARANCE),

--- a/app/src/main/java/com/android/purebilibili/data/model/response/MessageResponse.kt
+++ b/app/src/main/java/com/android/purebilibili/data/model/response/MessageResponse.kt
@@ -322,6 +322,18 @@ data class MessageFeedReplyItem(
 
 @Serializable
 data class MessageFeedReplyContent(
+    @SerialName("subject_id")
+    @Serializable(with = FlexibleLongSerializer::class)
+    val subjectId: Long = 0,
+    @SerialName("root_id")
+    @Serializable(with = FlexibleLongSerializer::class)
+    val rootId: Long = 0,
+    @SerialName("source_id")
+    @Serializable(with = FlexibleLongSerializer::class)
+    val sourceId: Long = 0,
+    @SerialName("target_id")
+    @Serializable(with = FlexibleLongSerializer::class)
+    val targetId: Long = 0,
     val business: String = "",
     @SerialName("business_id")
     val businessId: Int = 0,
@@ -432,6 +444,18 @@ data class MessageFeedLikeItem(
 
 @Serializable
 data class MessageFeedLikeContent(
+    @SerialName("subject_id")
+    @Serializable(with = FlexibleLongSerializer::class)
+    val subjectId: Long = 0,
+    @SerialName("root_id")
+    @Serializable(with = FlexibleLongSerializer::class)
+    val rootId: Long = 0,
+    @SerialName("source_id")
+    @Serializable(with = FlexibleLongSerializer::class)
+    val sourceId: Long = 0,
+    @SerialName("target_id")
+    @Serializable(with = FlexibleLongSerializer::class)
+    val targetId: Long = 0,
     val business: String = "",
     @SerialName("business_id")
     val businessId: Int = 0,

--- a/app/src/main/java/com/android/purebilibili/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/home/HomeScreen.kt
@@ -1566,6 +1566,7 @@ fun HomeScreen(
                 }
             },
             onSettingsClick = onSettingsClick,
+            onInboxClick = onInboxClick,
             onSearchClick = onSearchClick,
             topCategories = localizedTopCategoryLabels,
             topCategoryKeys = topCategories.map { it.name },

--- a/app/src/main/java/com/android/purebilibili/feature/home/components/iOSHomeHeader.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/home/components/iOSHomeHeader.kt
@@ -71,9 +71,11 @@ import com.android.purebilibili.core.ui.AppShapes
 import com.android.purebilibili.core.ui.AppSurfaceTokens
 import com.android.purebilibili.core.ui.ContainerLevel
 import com.android.purebilibili.core.ui.motion.AppMotionTokens
+import com.android.purebilibili.core.ui.rememberAppInboxIcon
 import com.android.purebilibili.core.ui.rememberAppSettingsIcon
 import com.android.purebilibili.core.store.HomeHeaderBlurMode
 import com.android.purebilibili.core.store.HomeSettings
+import com.android.purebilibili.core.store.HomeTopRightAction
 import com.android.purebilibili.core.store.resolveEffectiveLiquidGlassEnabled
 import com.android.purebilibili.feature.home.resolveHomeTopCategories
 import com.android.purebilibili.feature.home.resolveHomeTopCollapsedHandleHeight
@@ -1450,6 +1452,7 @@ fun iOSHomeHeader(
     user: UserState,
     onAvatarClick: () -> Unit,
     onSettingsClick: () -> Unit,
+    onInboxClick: () -> Unit = {},
     onSearchClick: () -> Unit,
     topCategories: List<String> = resolveHomeTopCategories().map { it.label },
     topCategoryKeys: List<String> = resolveHomeTopCategories().map { it.name },
@@ -1497,7 +1500,16 @@ fun iOSHomeHeader(
     val edgeButtonShape = resolveHomeTopEdgeButtonShape(uiPreset, androidNativeVariant)
     val searchContainerShape = resolveHomeTopSearchContainerShape(uiPreset, androidNativeVariant)
     val searchIcon = if (uiPreset == UiPreset.MD3) Icons.Outlined.Search else CupertinoIcons.Default.MagnifyingGlass
+    val topRightAction = homeSettings?.homeTopRightAction ?: HomeTopRightAction.SETTINGS
     val settingsIcon = rememberAppSettingsIcon()
+    val inboxIcon = rememberAppInboxIcon()
+    val topRightActionIcon = if (topRightAction == HomeTopRightAction.INBOX) inboxIcon else settingsIcon
+    val topRightActionContentDescription = topRightAction.label
+    val onTopRightActionClick = if (topRightAction == HomeTopRightAction.INBOX) {
+        onInboxClick
+    } else {
+        onSettingsClick
+    }
     val topChromeLiquidGlassEnabled = resolveHomeTopChromeLiquidGlassEnabled(
         homeSettings = homeSettings,
         uiPreset = uiPreset
@@ -2110,7 +2122,7 @@ fun iOSHomeHeader(
                     }
             )
 
-            // 2. Search Bar + Avatar + Settings
+                    // 2. Search Bar + Avatar + right action
             // 高度和透明度由外部直接控制，实现物理跟手
             Box(
                 modifier = Modifier
@@ -2599,20 +2611,20 @@ fun iOSHomeHeader(
                                     .then(
                                         if (uiPreset == UiPreset.MD3) {
                                             Modifier.clickable {
-                                                performHomeTopBarTap(haptic = haptic, onClick = onSettingsClick)
+                                                performHomeTopBarTap(haptic = haptic, onClick = onTopRightActionClick)
                                             }
                                         } else {
                                             Modifier.iOSTapEffect {
                                                 haptic(HapticType.LIGHT)
-                                                onSettingsClick()
+                                                onTopRightActionClick()
                                             }
                                         }
                                     ),
                                 contentAlignment = Alignment.Center
                             ) {
                                 Icon(
-                                    settingsIcon,
-                                    contentDescription = "设置",
+                                    topRightActionIcon,
+                                    contentDescription = topRightActionContentDescription,
                                     tint = if (isLightMode) {
                                         topForegroundColor
                                     } else {

--- a/app/src/main/java/com/android/purebilibili/feature/message/feed/AtMeScreen.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/message/feed/AtMeScreen.kt
@@ -187,7 +187,17 @@ fun AtMeScreen(
                             AtMeCard(
                                 item = item,
                                 onClick = {
-                                    firstNonBlank(item.item?.nativeUri, item.item?.uri)?.let(onOpenLink)
+                                    item.item?.let { content ->
+                                        buildMessageFeedCommentNavigationLink(
+                                            nativeUri = content.nativeUri,
+                                            uri = content.uri,
+                                            businessId = content.businessId.toInt(),
+                                            subjectId = content.subjectId,
+                                            rootId = content.rootId,
+                                            sourceId = content.sourceId,
+                                            targetId = content.targetId
+                                        )?.let(onOpenLink)
+                                    }
                                 },
                                 onUserClick = {
                                     item.user?.mid?.takeIf { it > 0 }?.let(onOpenSpace)

--- a/app/src/main/java/com/android/purebilibili/feature/message/feed/LikeMeScreen.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/message/feed/LikeMeScreen.kt
@@ -229,7 +229,17 @@ fun LikeMeScreen(
                                     item = item,
                                     modifier = Modifier.padding(horizontal = 16.dp),
                                     onClick = {
-                                        firstNonBlank(item.item?.nativeUri, item.item?.uri)?.let(onOpenLink)
+                                        item.item?.let { content ->
+                                            buildMessageFeedCommentNavigationLink(
+                                                nativeUri = content.nativeUri,
+                                                uri = content.uri,
+                                                businessId = content.businessId,
+                                                subjectId = content.subjectId,
+                                                rootId = content.rootId,
+                                                sourceId = content.sourceId,
+                                                targetId = content.targetId
+                                            )?.let(onOpenLink)
+                                        }
                                     },
                                     onUserClick = {
                                         item.users?.firstOrNull()?.mid?.takeIf { it > 0 }?.let(onOpenSpace)
@@ -247,7 +257,17 @@ fun LikeMeScreen(
                                     item = item,
                                     modifier = Modifier.padding(horizontal = 16.dp),
                                     onClick = {
-                                        firstNonBlank(item.item?.nativeUri, item.item?.uri)?.let(onOpenLink)
+                                        item.item?.let { content ->
+                                            buildMessageFeedCommentNavigationLink(
+                                                nativeUri = content.nativeUri,
+                                                uri = content.uri,
+                                                businessId = content.businessId,
+                                                subjectId = content.subjectId,
+                                                rootId = content.rootId,
+                                                sourceId = content.sourceId,
+                                                targetId = content.targetId
+                                            )?.let(onOpenLink)
+                                        }
                                     },
                                     onUserClick = {
                                         item.users?.firstOrNull()?.mid?.takeIf { it > 0 }?.let(onOpenSpace)

--- a/app/src/main/java/com/android/purebilibili/feature/message/feed/MessageFeedCommon.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/message/feed/MessageFeedCommon.kt
@@ -51,6 +51,28 @@ internal fun firstNonBlank(vararg values: String?): String? {
     return values.firstOrNull { !it.isNullOrBlank() }?.trim()
 }
 
+internal fun buildMessageFeedCommentNavigationLink(
+    nativeUri: String?,
+    uri: String?,
+    businessId: Int,
+    subjectId: Long,
+    rootId: Long,
+    sourceId: Long,
+    targetId: Long
+): String? {
+    firstNonBlank(nativeUri, uri)?.let { return it }
+    if (businessId <= 0 || subjectId <= 0L) return null
+
+    val rootReplyId = listOf(rootId, sourceId, targetId)
+        .firstOrNull { it > 0L }
+        ?: return null
+    val targetReplyId = listOf(sourceId, targetId)
+        .firstOrNull { it > 0L && it != rootReplyId }
+        ?: 0L
+    val targetQuery = if (targetReplyId > 0L) "?comment_id=$targetReplyId" else ""
+    return "bilibili://comment/detail/$businessId/$subjectId/$rootReplyId$targetQuery"
+}
+
 @Composable
 internal fun MessageFeedAvatar(
     avatarUrl: String,

--- a/app/src/main/java/com/android/purebilibili/feature/message/feed/ReplyMeScreen.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/message/feed/ReplyMeScreen.kt
@@ -193,7 +193,17 @@ fun ReplyMeScreen(
                             ReplyMeCard(
                                 item = item,
                                 onClick = {
-                                    firstNonBlank(item.item?.nativeUri, item.item?.uri)?.let(onOpenLink)
+                                    item.item?.let { content ->
+                                        buildMessageFeedCommentNavigationLink(
+                                            nativeUri = content.nativeUri,
+                                            uri = content.uri,
+                                            businessId = content.businessId,
+                                            subjectId = content.subjectId,
+                                            rootId = content.rootId,
+                                            sourceId = content.sourceId,
+                                            targetId = content.targetId
+                                        )?.let(onOpenLink)
+                                    }
                                 },
                                 onUserClick = {
                                     item.user?.mid?.takeIf { it > 0 }?.let(onOpenSpace)

--- a/app/src/main/java/com/android/purebilibili/feature/settings/SettingsSearchPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/settings/SettingsSearchPolicy.kt
@@ -641,9 +641,29 @@ private val SETTINGS_SEARCH_INDEX: List<SettingsSearchEntry> = listOf(
     SettingsSearchEntry(
         target = SettingsSearchTarget.BOTTOM_BAR,
         title = "顶部标签管理",
-        subtitle = "显示/隐藏、排序、自动收缩",
+        subtitle = "显示/隐藏、排序、自动收缩、右上角入口",
         section = "导航设置",
-        aliases = listOf("顶部标签", "顶部标签样式", "顶部模糊", "顶部标签管理", "标签排序", "标签显示", "顶部栏自动收缩", "自动收缩", "自动隐藏", "回到顶部显示", "推荐分类", "直播标签"),
+        aliases = listOf(
+            "顶部标签",
+            "顶部标签样式",
+            "顶部模糊",
+            "顶部标签管理",
+            "标签排序",
+            "标签显示",
+            "顶部栏自动收缩",
+            "自动收缩",
+            "自动隐藏",
+            "回到顶部显示",
+            "推荐分类",
+            "直播标签",
+            "首页右上角",
+            "首页右上角入口",
+            "首页右上角消息",
+            "消息入口",
+            "设置图标",
+            "右上角设置",
+            "右上角消息"
+        ),
         focusId = SettingsSearchFocusIds.BOTTOM_BAR_TOP_TABS
     ),
     SettingsSearchEntry(

--- a/app/src/main/java/com/android/purebilibili/feature/settings/screen/BottomBarSettingsScreen.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/settings/screen/BottomBarSettingsScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.android.purebilibili.R
 import com.android.purebilibili.core.store.HomeHeaderBlurMode
+import com.android.purebilibili.core.store.HomeTopRightAction
 import com.android.purebilibili.core.store.SettingsManager
 import com.android.purebilibili.core.theme.BottomBarColors  //  统一底栏颜色配置
 import com.android.purebilibili.core.theme.BottomBarColorPalette  //  调色板
@@ -260,6 +261,8 @@ fun BottomBarSettingsContent(
         .collectAsState(initial = SettingsManager.TopTabLabelMode.TEXT_ONLY)
     val headerBlurMode by SettingsManager.getHomeHeaderBlurMode(context)
         .collectAsState(initial = HomeHeaderBlurMode.FOLLOW_PRESET)
+    val homeTopRightAction by SettingsManager.getHomeTopRightAction(context)
+        .collectAsState(initial = HomeTopRightAction.SETTINGS)
     val tabletUseSidebar by SettingsManager.getTabletUseSidebar(context).collectAsState(initial = false)
     
     // 可编辑的本地状态
@@ -606,6 +609,77 @@ fun BottomBarSettingsContent(
                                             .clip(RoundedCornerShape(12.dp))
                                             .clickable {
                                                 scope.launch { SettingsManager.setTopTabLabelMode(context, mode) }
+                                            }
+                                            .background(
+                                                if (isSelected) MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+                                                else Color.Transparent
+                                            )
+                                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                                    ) {
+                                        Icon(
+                                            icon,
+                                            contentDescription = null,
+                                            tint = if (isSelected) MaterialTheme.colorScheme.primary
+                                            else MaterialTheme.colorScheme.onSurfaceVariant,
+                                            modifier = Modifier.size(24.dp)
+                                        )
+                                        Spacer(modifier = Modifier.height(4.dp))
+                                        Text(
+                                            text = label,
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = if (isSelected) MaterialTheme.colorScheme.primary
+                                            else MaterialTheme.colorScheme.onSurfaceVariant,
+                                            fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal
+                                        )
+                                    }
+                                }
+                            }
+
+                            HorizontalDivider()
+
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Icon(
+                                    imageVector = if (homeTopRightAction == HomeTopRightAction.INBOX) {
+                                        CupertinoIcons.Outlined.Envelope
+                                    } else {
+                                        CupertinoIcons.Default.Gearshape
+                                    },
+                                    contentDescription = null,
+                                    tint = com.android.purebilibili.core.theme.iOSOrange,
+                                    modifier = Modifier.size(24.dp)
+                                )
+                                Spacer(modifier = Modifier.width(16.dp))
+                                Column {
+                                    Text(
+                                        text = "首页右上角入口",
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        color = MaterialTheme.colorScheme.onSurface
+                                    )
+                                    Text(
+                                        text = homeTopRightAction.label,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
+
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceEvenly
+                            ) {
+                                listOf(
+                                    Triple(HomeTopRightAction.SETTINGS, "设置", CupertinoIcons.Default.Gearshape),
+                                    Triple(HomeTopRightAction.INBOX, "消息", CupertinoIcons.Outlined.Envelope)
+                                ).forEach { (action, label, icon) ->
+                                    val isSelected = homeTopRightAction == action
+                                    Column(
+                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                        modifier = Modifier
+                                            .clip(RoundedCornerShape(12.dp))
+                                            .clickable {
+                                                scope.launch {
+                                                    SettingsManager.setHomeTopRightAction(context, action)
+                                                }
                                             }
                                             .background(
                                                 if (isSelected) MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)

--- a/app/src/main/java/com/android/purebilibili/feature/video/screen/VideoDetailScreen.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/screen/VideoDetailScreen.kt
@@ -1262,11 +1262,13 @@ fun VideoDetailScreen(
             commentViewModel.openSubReply(rootReply, openCommentTargetRpidFromRoute)
             hasHandledCommentRootFromRoute = true
         } else if (!commentState.isRepliesLoading) {
-            commentViewModel.openSubReplyFromRoute(
+            val openStarted = commentViewModel.openSubReplyFromRoute(
                 rootReplyId = openCommentRootRpidFromRoute,
                 targetReplyId = openCommentTargetRpidFromRoute
             )
-            hasHandledCommentRootFromRoute = true
+            if (openStarted) {
+                hasHandledCommentRootFromRoute = true
+            }
         }
     }
     val commentDefaultSortMode by com.android.purebilibili.core.store.SettingsManager
@@ -4330,6 +4332,11 @@ fun VideoDetailScreen(
             successState = successState,
             commentState = commentState,
             commentViewModel = commentViewModel,
+            forceInitialize = shouldForceInitializeDetachedCommentThreadHostForRoute(
+                routeCommentRootRpid = openCommentRootRpidFromRoute,
+                aid = successState?.info?.aid ?: 0L,
+                hasHandledRouteComment = hasHandledCommentRootFromRoute
+            ),
             viewModel = viewModel,
             onUpClick = navigateToUserSpaceFromVideo,
             onNavigateToRelatedVideo = { targetVideoId ->
@@ -5300,6 +5307,14 @@ internal fun resolveVideoDetailCommentThreadHostMainSheetVisible(
     return useEmbeddedPresentation && subReplyVisible
 }
 
+internal fun shouldForceInitializeDetachedCommentThreadHostForRoute(
+    routeCommentRootRpid: Long,
+    aid: Long,
+    hasHandledRouteComment: Boolean
+): Boolean {
+    return routeCommentRootRpid > 0L && aid > 0L && !hasHandledRouteComment
+}
+
 internal fun shouldApplyPhoneAutoRotatePolicy(
     isCompactDevice: Boolean
 ): Boolean {
@@ -5656,6 +5671,7 @@ private fun DetachedVideoCommentThreadHost(
     successState: PlayerUiState.Success?,
     commentState: CommentUiState,
     commentViewModel: VideoCommentViewModel,
+    forceInitialize: Boolean,
     viewModel: PlayerViewModel,
     onUpClick: (Long) -> Unit,
     onNavigateToRelatedVideo: (String) -> Unit,
@@ -5695,6 +5711,7 @@ private fun DetachedVideoCommentThreadHost(
         topReservedPx = topReservedPx,
         onTimestampClick = onTimestampClick,
         maxTimestampMs = successState?.videoDurationMs?.takeIf { it > 0L },
+        forceInitialize = forceInitialize,
         handleFraudEvents = false
     )
 }

--- a/app/src/main/java/com/android/purebilibili/feature/video/screen/VideoDetailScreen.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/screen/VideoDetailScreen.kt
@@ -1040,6 +1040,7 @@ fun VideoDetailScreen(
     autoEnterPortraitFromRoute: Boolean = false,
     resumePositionMsFromRoute: Long = 0L,
     openCommentRootRpidFromRoute: Long = 0L,
+    openCommentTargetRpidFromRoute: Long = 0L,
     sourceRouteForSharedElement: String? = null,
     isReturningFromDetail: Boolean = false,
     isQuickReturningFromDetail: Boolean = false,
@@ -1103,7 +1104,11 @@ fun VideoDetailScreen(
     var isNavigatingToMiniMode by remember { mutableStateOf(false) }
     var hasAutoEnteredAudioMode by rememberSaveable { mutableStateOf(false) }
     var hasAutoEnteredPortraitFromRoute by rememberSaveable(bvid) { mutableStateOf(false) }
-    var hasHandledCommentRootFromRoute by rememberSaveable(bvid, openCommentRootRpidFromRoute) { mutableStateOf(false) }
+    var hasHandledCommentRootFromRoute by rememberSaveable(
+        bvid,
+        openCommentRootRpidFromRoute,
+        openCommentTargetRpidFromRoute
+    ) { mutableStateOf(false) }
     // 🔄 [Seamless Playback] Internal BVID state to support seamless switching in portrait mode
     var currentBvid by rememberSaveable(bvid) { mutableStateOf(bvid) }
 
@@ -1243,6 +1248,7 @@ fun VideoDetailScreen(
 
     LaunchedEffect(
         openCommentRootRpidFromRoute,
+        openCommentTargetRpidFromRoute,
         commentState.replies,
         commentState.isRepliesLoading,
         subReplyState.visible
@@ -1253,9 +1259,13 @@ fun VideoDetailScreen(
 
         val rootReply = commentState.replies.firstOrNull { it.rpid == openCommentRootRpidFromRoute }
         if (rootReply != null) {
-            commentViewModel.openSubReply(rootReply)
+            commentViewModel.openSubReply(rootReply, openCommentTargetRpidFromRoute)
             hasHandledCommentRootFromRoute = true
-        } else if (!commentState.isRepliesLoading && commentState.isRepliesEnd) {
+        } else if (!commentState.isRepliesLoading) {
+            commentViewModel.openSubReplyFromRoute(
+                rootReplyId = openCommentRootRpidFromRoute,
+                targetReplyId = openCommentTargetRpidFromRoute
+            )
             hasHandledCommentRootFromRoute = true
         }
     }

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/components/SubReplyDetailComponents.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/components/SubReplyDetailComponents.kt
@@ -258,6 +258,17 @@ internal fun resolveSubReplyDetailListScrollResetKey(
     )
 }
 
+internal fun resolveSubReplyTargetListIndex(
+    rootReplyId: Long,
+    visibleReplies: List<ReplyItem>,
+    targetReplyId: Long
+): Int? {
+    if (targetReplyId <= 0L) return null
+    if (targetReplyId == rootReplyId) return 0
+    val replyIndex = visibleReplies.indexOfFirst { it.rpid == targetReplyId }
+    return replyIndex.takeIf { it >= 0 }?.plus(1)
+}
+
 internal fun resolveSubReplyAuxiliaryLabel(item: ReplyItem): String? {
     val visual = resolveFanGroupVisualFromMemberAndSailing(
         member = item.member,
@@ -335,7 +346,8 @@ internal fun VideoInlineSubReplyDetailContent(
         onUrlClick = onUrlClick,
         showIdentityDecorations = showIdentityDecorations,
         onAvatarClick = onAvatarClick,
-        maxTimestampMs = maxTimestampMs
+        maxTimestampMs = maxTimestampMs,
+        targetReplyId = state.targetReplyId
     )
 }
 
@@ -369,7 +381,8 @@ internal fun SubReplyDetailContent(
     showIdentityDecorations: Boolean = true,
     onAvatarClick: ((String) -> Unit)? = null,
     maxTimestampMs: Long? = null,
-    remoteReplyCount: Int = 0
+    remoteReplyCount: Int = 0,
+    targetReplyId: Long = 0
 ) {
     val layoutPolicy = remember {
         resolveSubReplyDetailLayoutPolicy(showRootCommentEntry = false)
@@ -424,6 +437,17 @@ internal fun SubReplyDetailContent(
     }
     LaunchedEffect(listScrollResetKey) {
         listState.scrollToItem(0)
+    }
+    LaunchedEffect(targetReplyId, visibleReplies, isLoading, isEnd) {
+        val targetIndex = resolveSubReplyTargetListIndex(
+            rootReplyId = rootReply.rpid,
+            visibleReplies = visibleReplies,
+            targetReplyId = targetReplyId
+        )
+        when {
+            targetIndex != null -> listState.animateScrollToItem(targetIndex)
+            targetReplyId > 0L && !isLoading && !isEnd && !effectiveConversationMode -> onLoadMore()
+        }
     }
 
     Column(

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/components/SubReplySheet.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/components/SubReplySheet.kt
@@ -66,7 +66,8 @@ fun SubReplySheet(
                 likedComments = likedComments,
                 onUrlClick = onUrlClick,
                 showIdentityDecorations = showIdentityDecorations,
-                onAvatarClick = onAvatarClick
+                onAvatarClick = onAvatarClick,
+                targetReplyId = state.targetReplyId
             )
         }
     }

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/components/VideoCommentSheetHost.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/components/VideoCommentSheetHost.kt
@@ -170,6 +170,13 @@ internal fun shouldApplyVideoCommentThreadStatusBarPadding(
     return !mainSheetVisible && topReservedPx <= 0
 }
 
+internal fun shouldInitializeVideoCommentSheetHost(
+    mainSheetVisible: Boolean,
+    forceInitialize: Boolean
+): Boolean {
+    return mainSheetVisible || forceInitialize
+}
+
 internal fun shouldDismissVideoCommentSheetHostOnBackdropTap(
     mainSheetVisible: Boolean
 ): Boolean {
@@ -239,6 +246,7 @@ fun VideoCommentSheetHost(
     onTimestampClick: ((Long) -> Unit)? = null,
     maxTimestampMs: Long? = null,
     onImagePreview: ((List<String>, Int, Rect?, ImagePreviewTextContent?) -> Unit)? = null,
+    forceInitialize: Boolean = false,
     handleFraudEvents: Boolean = true
 ) {
     val context = LocalContext.current
@@ -377,8 +385,8 @@ fun VideoCommentSheetHost(
         }
     }
 
-    LaunchedEffect(aid, mainSheetVisible, preferredSortMode, upMid, expectedReplyCount) {
-        if (mainSheetVisible) {
+    LaunchedEffect(aid, mainSheetVisible, forceInitialize, preferredSortMode, upMid, expectedReplyCount) {
+        if (shouldInitializeVideoCommentSheetHost(mainSheetVisible, forceInitialize)) {
             commentViewModel.init(
                 aid = aid,
                 upMid = upMid,

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/components/VideoCommentSheetHost.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/components/VideoCommentSheetHost.kt
@@ -637,7 +637,8 @@ fun VideoCommentSheetHost(
                                         onAvatarClick = { mid ->
                                             mid.toLongOrNull()?.let(onUserClick)
                                         },
-                                        maxTimestampMs = maxTimestampMs
+                                        maxTimestampMs = maxTimestampMs,
+                                        targetReplyId = subReplyState.targetReplyId
                                     )
                                 }
                             }

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/PortraitFullscreenOverlay.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/PortraitFullscreenOverlay.kt
@@ -89,6 +89,7 @@ fun PortraitFullscreenOverlay(
     isCoined: Boolean,
     isFavorited: Boolean,
     onLikeClick: () -> Unit,
+    onLikeLongClick: () -> Unit = {},
     onCoinClick: () -> Unit,
     onFavoriteClick: () -> Unit,
     onCommentClick: () -> Unit = {},
@@ -211,6 +212,7 @@ fun PortraitFullscreenOverlay(
                     commentCount = statReply.takeIf { it > 0 } ?: statDanmaku, // 优先用评论数，没有则用弹幕数代替展示
                     shareCount = statShare,
                     onLikeClick = onLikeClick,
+                    onLikeLongClick = onLikeLongClick,
                     onFavoriteClick = onFavoriteClick,
                     onCommentClick = onCommentClick,
                     onShareClick = onShareClick,

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/PortraitInteractionBar.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/PortraitInteractionBar.kt
@@ -1,6 +1,7 @@
 package com.android.purebilibili.feature.video.ui.overlay
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -51,6 +52,7 @@ fun PortraitInteractionBar(
     commentCount: Int,
     shareCount: Int,
     onLikeClick: () -> Unit,
+    onLikeLongClick: () -> Unit = {},
     onFavoriteClick: () -> Unit,
     onCommentClick: () -> Unit,
     onShareClick: () -> Unit,
@@ -80,7 +82,8 @@ fun PortraitInteractionBar(
             isActive = isLiked,
             activeColor = BiliPink,
             layoutPolicy = layoutPolicy,
-            onClick = onLikeClick
+            onClick = onLikeClick,
+            onLongClick = onLikeLongClick
         )
         
         // 评论
@@ -123,14 +126,25 @@ private fun InteractionButton(
     isActive: Boolean,
     activeColor: Color = BiliPink,
     layoutPolicy: PortraitInteractionBarLayoutPolicy,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    onLongClick: (() -> Unit)? = null
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.clickable(
-            indication = null,
-            interactionSource = remember { MutableInteractionSource() }
-        ) { onClick() }
+        modifier = if (onLongClick != null) {
+            Modifier.combinedClickable(
+                indication = null,
+                interactionSource = interactionSource,
+                onClick = onClick,
+                onLongClick = onLongClick
+            )
+        } else {
+            Modifier.clickable(
+                indication = null,
+                interactionSource = interactionSource
+            ) { onClick() }
+        }
     ) {
         Box(
             modifier = Modifier

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/pager/PortraitVideoPager.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/pager/PortraitVideoPager.kt
@@ -2029,6 +2029,24 @@ private fun VideoPageItem(
                     }
                 }
             },
+            onLikeLongClick = {
+                if (canHandlePortraitInteraction) {
+                    val currentInteractionState = resolvedInteractionState
+                    viewModel.doTripleActionForVideo(
+                        aid = aid,
+                        bvid = bvid,
+                        currentLiked = currentInteractionState.isLiked,
+                        currentCoinCount = currentSuccess?.coinCount ?: 0,
+                        currentFavorited = currentInteractionState.isFavorited
+                    ) { result ->
+                        portraitInteractionOverride = resolvePortraitTripleActionOverride(
+                            currentState = currentInteractionState,
+                            likeSuccess = result.likeSuccess,
+                            favoriteSuccess = result.favoriteSuccess
+                        )
+                    }
+                }
+            },
             onCoinClick = { },
             onFavoriteClick = {
                 if (canHandlePortraitInteraction) {
@@ -2310,6 +2328,23 @@ internal fun resolvePortraitVideoInteractionUiState(
             favoriteCount = localOverride?.favoriteCount ?: fallbackStat.favorite
         )
     }
+}
+
+internal fun resolvePortraitTripleActionOverride(
+    currentState: PortraitVideoInteractionUiState,
+    likeSuccess: Boolean,
+    favoriteSuccess: Boolean
+): PortraitVideoInteractionOverride {
+    val nextLiked = currentState.isLiked || likeSuccess
+    val nextFavorited = currentState.isFavorited || favoriteSuccess
+    val likeDelta = if (!currentState.isLiked && nextLiked) 1 else 0
+    val favoriteDelta = if (!currentState.isFavorited && nextFavorited) 1 else 0
+    return PortraitVideoInteractionOverride(
+        isLiked = nextLiked,
+        isFavorited = nextFavorited,
+        likeCount = (currentState.likeCount + likeDelta).coerceAtLeast(0),
+        favoriteCount = (currentState.favoriteCount + favoriteDelta).coerceAtLeast(0)
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/PlayerViewModel.kt
@@ -5446,24 +5446,46 @@ class PlayerViewModel : ViewModel() {
     
     fun doTripleAction() {
         val current = _uiState.value as? PlayerUiState.Success ?: return
+        doTripleActionForVideo(
+            aid = current.info.aid,
+            bvid = current.info.bvid,
+            currentLiked = current.isLiked,
+            currentCoinCount = current.coinCount,
+            currentFavorited = current.isFavorited
+        )
+    }
+
+    fun doTripleActionForVideo(
+        aid: Long,
+        bvid: String,
+        currentLiked: Boolean,
+        currentCoinCount: Int,
+        currentFavorited: Boolean,
+        onResult: ((TripleActionResult) -> Unit)? = null
+    ) {
+        if (aid <= 0L || bvid.isBlank()) return
         viewModelScope.launch {
             toast("正在三连")
-            interactionUseCase.doTripleAction(current.info.aid)
+            interactionUseCase.doTripleAction(aid)
                 .onSuccess { result ->
                     val visualState = resolveTripleActionVisualState(
-                        currentLiked = current.isLiked,
-                        currentCoinCount = current.coinCount,
-                        currentFavorited = current.isFavorited,
+                        currentLiked = currentLiked,
+                        currentCoinCount = currentCoinCount,
+                        currentFavorited = currentFavorited,
                         likeSuccess = result.likeSuccess,
                         coinSuccess = result.coinSuccess,
                         coinFailureMessage = result.coinMessage,
                         favoriteSuccess = result.favoriteSuccess
                     )
-                    _uiState.value = current.copy(
-                        isLiked = visualState.isLiked,
-                        coinCount = visualState.coinCount,
-                        isFavorited = visualState.isFavorited
-                    )
+                    val current = _uiState.value as? PlayerUiState.Success
+                    if (current != null && current.info.aid == aid && current.info.bvid == bvid) {
+                        _uiState.value = current.copy(
+                            isLiked = visualState.isLiked,
+                            coinCount = visualState.coinCount,
+                            isFavorited = visualState.isFavorited
+                        )
+                    }
+                    onResult?.invoke(result)
                     if (result.allSuccess) _tripleCelebrationVisible.value = true
                     toast(
                         resolveTripleActionFeedbackMessage(
@@ -5478,7 +5500,7 @@ class PlayerViewModel : ViewModel() {
                     viewModelScope.launch {
                         val context = appContext ?: return@launch
                         val isJumpEnabled = com.android.purebilibili.core.store.SettingsManager.getTripleJumpEnabled(context).first()
-                        if (result.allSuccess && isJumpEnabled) {
+                        if (result.allSuccess && isJumpEnabled && current?.info?.bvid == bvid) {
                              // Wait a bit for the celebration to show
                             delay(2000)
                             loadVideo("BV1JsK5eyEuB", autoPlay = true)

--- a/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/VideoCommentViewModel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/VideoCommentViewModel.kt
@@ -140,6 +140,13 @@ internal fun resolveRoutedCommentRootReply(
         ?: remoteData?.root?.takeIf { it.rpid == rootReplyId }
 }
 
+internal fun shouldStartRoutedSubReplyOpen(
+    rootReplyId: Long,
+    currentAid: Long
+): Boolean {
+    return rootReplyId > 0L && currentAid > 0L
+}
+
 class VideoCommentViewModel : ViewModel() {
     private val _commentState = MutableStateFlow(CommentUiState())
     val commentState = _commentState.asStateFlow()
@@ -358,8 +365,8 @@ class VideoCommentViewModel : ViewModel() {
         loadSubReplies(rootReply.oid, rootReply.rpid, 1)
     }
 
-    fun openSubReplyFromRoute(rootReplyId: Long, targetReplyId: Long = 0L) {
-        if (rootReplyId <= 0L || currentAid <= 0L) return
+    fun openSubReplyFromRoute(rootReplyId: Long, targetReplyId: Long = 0L): Boolean {
+        if (!shouldStartRoutedSubReplyOpen(rootReplyId, currentAid)) return false
 
         resolveRoutedCommentRootReply(
             loadedReplies = allReplies.ifEmpty { _commentState.value.replies },
@@ -367,9 +374,10 @@ class VideoCommentViewModel : ViewModel() {
             rootReplyId = rootReplyId
         )?.let { rootReply ->
             openSubReply(rootReply, targetReplyId)
-            return
+            return true
         }
 
+        val routeAid = currentAid
         _subReplyState.value = _subReplyState.value.copy(
             visible = false,
             isLoading = true,
@@ -379,7 +387,7 @@ class VideoCommentViewModel : ViewModel() {
 
         viewModelScope.launch {
             CommentRepository.getSubCommentsForSubject(
-                oid = currentAid,
+                oid = routeAid,
                 type = 1,
                 rootId = rootReplyId,
                 page = 1,
@@ -436,6 +444,7 @@ class VideoCommentViewModel : ViewModel() {
                 )
             }
         }
+        return true
     }
 
     fun closeSubReply() {

--- a/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/VideoCommentViewModel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/VideoCommentViewModel.kt
@@ -84,6 +84,7 @@ data class SubReplyUiState(
     val grpcNextOffset: String? = null,
     val baseGrpcNextOffset: String? = null,
     val conversationAnchor: ReplyItem? = null,
+    val targetReplyId: Long = 0,
     // [新增] 消散动画状态
     val dissolvingIds: Set<Long> = emptySet()
 )
@@ -127,6 +128,16 @@ internal fun resolveSubReplyPageEnd(
         return false
     }
     return cursorIsEnd || fetchedReplyCount <= 0
+}
+
+internal fun resolveRoutedCommentRootReply(
+    loadedReplies: List<ReplyItem>,
+    remoteData: ReplyData?,
+    rootReplyId: Long
+): ReplyItem? {
+    if (rootReplyId <= 0L) return null
+    return loadedReplies.firstOrNull { it.rpid == rootReplyId }
+        ?: remoteData?.root?.takeIf { it.rpid == rootReplyId }
 }
 
 class VideoCommentViewModel : ViewModel() {
@@ -330,10 +341,11 @@ class VideoCommentViewModel : ViewModel() {
 
     // --- 二级评论逻辑 ---
 
-    fun openSubReply(rootReply: ReplyItem) {
+    fun openSubReply(rootReply: ReplyItem, targetReplyId: Long = 0L) {
         _subReplyState.value = SubReplyUiState(
             visible = true,
             rootReply = rootReply,
+            targetReplyId = targetReplyId.takeIf { it != rootReply.rpid } ?: 0L,
             totalCount = resolveSubReplyLoadedTotalCount(
                 rootReply = rootReply,
                 loadedReplyCount = rootReply.replies.orEmpty().size,
@@ -344,6 +356,86 @@ class VideoCommentViewModel : ViewModel() {
             upMid = _commentState.value.upMid  // [修复] 使用正确的 UP 主 mid
         )
         loadSubReplies(rootReply.oid, rootReply.rpid, 1)
+    }
+
+    fun openSubReplyFromRoute(rootReplyId: Long, targetReplyId: Long = 0L) {
+        if (rootReplyId <= 0L || currentAid <= 0L) return
+
+        resolveRoutedCommentRootReply(
+            loadedReplies = allReplies.ifEmpty { _commentState.value.replies },
+            remoteData = null,
+            rootReplyId = rootReplyId
+        )?.let { rootReply ->
+            openSubReply(rootReply, targetReplyId)
+            return
+        }
+
+        _subReplyState.value = _subReplyState.value.copy(
+            visible = false,
+            isLoading = true,
+            error = null,
+            targetReplyId = targetReplyId.takeIf { it != rootReplyId } ?: 0L
+        )
+
+        viewModelScope.launch {
+            CommentRepository.getSubCommentsForSubject(
+                oid = currentAid,
+                type = 1,
+                rootId = rootReplyId,
+                page = 1,
+                ps = SUB_REPLY_PAGE_SIZE,
+                preferRestPaging = true
+            ).onSuccess { data ->
+                val rootReply = resolveRoutedCommentRootReply(
+                    loadedReplies = emptyList(),
+                    remoteData = data,
+                    rootReplyId = rootReplyId
+                )
+                if (rootReply == null) {
+                    _subReplyState.value = _subReplyState.value.copy(
+                        isLoading = false,
+                        error = "回复可能已被删除或不可见"
+                    )
+                    return@onSuccess
+                }
+
+                val items = data.replies.orEmpty()
+                val remoteTotalCount = resolveSubReplyRemoteTotalCount(data)
+                val totalCount = resolveSubReplyLoadedTotalCount(
+                    rootReply = rootReply,
+                    loadedReplyCount = items.size,
+                    remoteReplyCount = remoteTotalCount
+                )
+                val isEnd = resolveSubReplyPageEnd(
+                    cursorIsEnd = data.cursor.isEnd,
+                    fetchedReplyCount = items.size,
+                    loadedReplyCount = items.size,
+                    remoteReplyCount = remoteTotalCount
+                )
+                val nextOffset = data.grpcNextOffset.takeIf { it.isNotBlank() }
+                _subReplyState.value = SubReplyUiState(
+                    visible = true,
+                    rootReply = rootReply,
+                    items = items,
+                    baseItems = items,
+                    totalCount = totalCount,
+                    isLoading = false,
+                    page = 1,
+                    basePage = 1,
+                    isEnd = isEnd,
+                    baseIsEnd = isEnd,
+                    upMid = _commentState.value.upMid,
+                    grpcNextOffset = nextOffset,
+                    baseGrpcNextOffset = nextOffset,
+                    targetReplyId = targetReplyId.takeIf { it != rootReplyId } ?: 0L
+                )
+            }.onFailure { error ->
+                _subReplyState.value = _subReplyState.value.copy(
+                    isLoading = false,
+                    error = error.message ?: "回复加载失败"
+                )
+            }
+        }
     }
 
     fun closeSubReply() {

--- a/app/src/main/java/com/android/purebilibili/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/android/purebilibili/navigation/AppNavigation.kt
@@ -157,7 +157,7 @@ import java.nio.charset.StandardCharsets
 // 定义路由参数结构
 object VideoRoute {
     const val base = "video"
-    const val route = "$base/{bvid}?cid={cid}&cover={cover}&startAudio={startAudio}&autoPortrait={autoPortrait}&fullscreen={fullscreen}&resumePositionMs={resumePositionMs}&commentRootRpid={commentRootRpid}"
+    const val route = "$base/{bvid}?cid={cid}&cover={cover}&startAudio={startAudio}&autoPortrait={autoPortrait}&fullscreen={fullscreen}&resumePositionMs={resumePositionMs}&commentRootRpid={commentRootRpid}&commentTargetRpid={commentTargetRpid}"
 
     internal fun resolveVideoRoutePath(
         bvid: String,
@@ -167,9 +167,10 @@ object VideoRoute {
         autoPortrait: Boolean,
         fullscreen: Boolean = false,
         resumePositionMs: Long = 0L,
-        commentRootRpid: Long = 0L
+        commentRootRpid: Long = 0L,
+        commentTargetRpid: Long = 0L
     ): String {
-        return "$base/$bvid?cid=$cid&cover=$encodedCover&startAudio=$startAudio&autoPortrait=$autoPortrait&fullscreen=$fullscreen&resumePositionMs=${resumePositionMs.coerceAtLeast(0L)}&commentRootRpid=${commentRootRpid.coerceAtLeast(0L)}"
+        return "$base/$bvid?cid=$cid&cover=$encodedCover&startAudio=$startAudio&autoPortrait=$autoPortrait&fullscreen=$fullscreen&resumePositionMs=${resumePositionMs.coerceAtLeast(0L)}&commentRootRpid=${commentRootRpid.coerceAtLeast(0L)}&commentTargetRpid=${commentTargetRpid.coerceAtLeast(0L)}"
     }
 
     // 构建 helper
@@ -181,7 +182,8 @@ object VideoRoute {
         autoPortrait: Boolean = false,
         fullscreen: Boolean = false,
         resumePositionMs: Long = 0L,
-        commentRootRpid: Long = 0L
+        commentRootRpid: Long = 0L,
+        commentTargetRpid: Long = 0L
     ): String {
         val encodedCover = Uri.encode(coverUrl)
         return resolveVideoRoutePath(
@@ -192,7 +194,8 @@ object VideoRoute {
             autoPortrait = autoPortrait,
             fullscreen = fullscreen,
             resumePositionMs = resumePositionMs,
-            commentRootRpid = commentRootRpid
+            commentRootRpid = commentRootRpid,
+            commentTargetRpid = commentTargetRpid
         )
     }
 }
@@ -213,7 +216,8 @@ internal fun resolveStandardVideoRoute(
     autoPortrait: Boolean = shouldAutoEnterPortraitForStandardVideoNavigation(),
     fullscreen: Boolean = false,
     resumePositionMs: Long = 0L,
-    commentRootRpid: Long = 0L
+    commentRootRpid: Long = 0L,
+    commentTargetRpid: Long = 0L
 ): String {
     val encodedCover = URLEncoder.encode(coverUrl, StandardCharsets.UTF_8.toString())
     return VideoRoute.resolveVideoRoutePath(
@@ -224,7 +228,8 @@ internal fun resolveStandardVideoRoute(
         autoPortrait = autoPortrait,
         fullscreen = fullscreen,
         resumePositionMs = resumePositionMs,
-        commentRootRpid = commentRootRpid
+        commentRootRpid = commentRootRpid,
+        commentTargetRpid = commentTargetRpid
     )
 }
 
@@ -879,7 +884,8 @@ fun AppNavigation(
                             bvid = action.videoId,
                             cid = 0L,
                             coverUrl = "",
-                            commentRootRpid = action.rootReplyId
+                            commentRootRpid = action.rootReplyId,
+                            commentTargetRpid = action.targetReplyId
                         ),
                         sourceRoute = currentRoute
                     )
@@ -1444,6 +1450,7 @@ fun AppNavigation(
                                 autoEnterPortraitFromRoute = videoKey.autoPortrait,
                                 resumePositionMsFromRoute = videoKey.resumePositionMs,
                                 openCommentRootRpidFromRoute = videoKey.commentRootRpid,
+                                openCommentTargetRpidFromRoute = videoKey.commentTargetRpid,
                                 sourceRouteForSharedElement = videoKey.sourceRoute,
                                 isReturningFromDetail = navigation3ReturnSession.isReturningFromDetail,
                                 isQuickReturningFromDetail = navigation3ReturnSession.isQuickReturnFromDetail,

--- a/app/src/main/java/com/android/purebilibili/navigation/MessageLinkNavigationPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/navigation/MessageLinkNavigationPolicy.kt
@@ -5,7 +5,11 @@ import com.android.purebilibili.core.util.BilibiliNavigationTargetParser
 
 internal sealed interface MessageLinkNavigationAction {
     data class Video(val videoId: String) : MessageLinkNavigationAction
-    data class VideoComment(val videoId: String, val rootReplyId: Long) : MessageLinkNavigationAction
+    data class VideoComment(
+        val videoId: String,
+        val rootReplyId: Long,
+        val targetReplyId: Long = 0L
+    ) : MessageLinkNavigationAction
     data class Dynamic(val dynamicId: String) : MessageLinkNavigationAction
     data class DynamicComment(val dynamicId: String) : MessageLinkNavigationAction
     data class Space(val mid: Long) : MessageLinkNavigationAction
@@ -19,9 +23,26 @@ internal sealed interface MessageLinkNavigationAction {
 internal fun resolveMessageLinkNavigationAction(rawLink: String): MessageLinkNavigationAction {
     resolveMessageCommentNavigationAction(rawLink)?.let { return it }
 
+    val commentLocation = resolveMessageCommentLocation(rawLink)
     return when (val target = BilibiliNavigationTargetParser.parse(rawLink)) {
-        is BilibiliNavigationTarget.Video -> MessageLinkNavigationAction.Video(target.videoId)
-        is BilibiliNavigationTarget.Dynamic -> MessageLinkNavigationAction.Dynamic(target.dynamicId)
+        is BilibiliNavigationTarget.Video -> {
+            if (commentLocation != null) {
+                MessageLinkNavigationAction.VideoComment(
+                    videoId = target.videoId,
+                    rootReplyId = commentLocation.rootReplyId,
+                    targetReplyId = commentLocation.targetReplyId
+                )
+            } else {
+                MessageLinkNavigationAction.Video(target.videoId)
+            }
+        }
+        is BilibiliNavigationTarget.Dynamic -> {
+            if (commentLocation != null) {
+                MessageLinkNavigationAction.DynamicComment(target.dynamicId)
+            } else {
+                MessageLinkNavigationAction.Dynamic(target.dynamicId)
+            }
+        }
         is BilibiliNavigationTarget.Space -> MessageLinkNavigationAction.Space(target.mid)
         is BilibiliNavigationTarget.Live -> MessageLinkNavigationAction.Live(target.roomId)
         is BilibiliNavigationTarget.BangumiSeason -> MessageLinkNavigationAction.BangumiSeason(target.seasonId)
@@ -30,6 +51,11 @@ internal fun resolveMessageLinkNavigationAction(rawLink: String): MessageLinkNav
         else -> MessageLinkNavigationAction.Web(rawLink)
     }
 }
+
+private data class MessageCommentLocation(
+    val rootReplyId: Long,
+    val targetReplyId: Long
+)
 
 private fun resolveMessageCommentNavigationAction(rawLink: String): MessageLinkNavigationAction? {
     val uri = runCatching { java.net.URI(rawLink) }.getOrNull() ?: return null
@@ -69,7 +95,8 @@ private fun resolveMessageCommentNavigationAction(rawLink: String): MessageLinkN
     return when (val target = BilibiliNavigationTargetParser.parse(fallbackLink)) {
         is BilibiliNavigationTarget.Video -> MessageLinkNavigationAction.VideoComment(
             videoId = target.videoId,
-            rootReplyId = rootReplyId
+            rootReplyId = rootReplyId,
+            targetReplyId = queryMap.firstPositiveLong("comment_id", "reply_id", "rpid", "target_id")
         )
         is BilibiliNavigationTarget.Dynamic -> MessageLinkNavigationAction.DynamicComment(
             dynamicId = target.dynamicId
@@ -81,4 +108,62 @@ private fun resolveMessageCommentNavigationAction(rawLink: String): MessageLinkN
         is BilibiliNavigationTarget.Music -> MessageLinkNavigationAction.Music(target.musicId)
         else -> null
     }
+}
+
+private fun resolveMessageCommentLocation(rawLink: String): MessageCommentLocation? {
+    val uri = runCatching { java.net.URI(rawLink) }.getOrNull() ?: return null
+    val queryMap = decodeQueryMap(uri.rawQuery)
+    val rootReplyId = queryMap.firstPositiveLong(
+        "comment_root_id",
+        "root_reply_id",
+        "root_id"
+    )
+    val targetReplyId = queryMap.firstPositiveLong(
+        "comment_id",
+        "reply_id",
+        "rpid",
+        "target_id",
+        "source_id"
+    ).takeIf { it > 0L } ?: resolveReplyIdFromFragment(uri.rawFragment)
+    val resolvedRootReplyId = when {
+        rootReplyId > 0L -> rootReplyId
+        targetReplyId > 0L -> targetReplyId
+        else -> 0L
+    }
+    if (resolvedRootReplyId <= 0L) return null
+    return MessageCommentLocation(
+        rootReplyId = resolvedRootReplyId,
+        targetReplyId = targetReplyId.takeIf { it != resolvedRootReplyId } ?: 0L
+    )
+}
+
+private fun decodeQueryMap(rawQuery: String?): Map<String, String> {
+    return rawQuery
+        ?.split("&")
+        ?.mapNotNull { part ->
+            if (part.isBlank()) return@mapNotNull null
+            val pair = part.split("=", limit = 2)
+            val key = java.net.URLDecoder.decode(pair[0], java.nio.charset.StandardCharsets.UTF_8)
+            val value = java.net.URLDecoder.decode(pair.getOrElse(1) { "" }, java.nio.charset.StandardCharsets.UTF_8)
+            key to value
+        }
+        ?.toMap()
+        .orEmpty()
+}
+
+private fun Map<String, String>.firstPositiveLong(vararg keys: String): Long {
+    return keys.firstNotNullOfOrNull { key ->
+        this[key]?.toLongOrNull()?.takeIf { it > 0L }
+    } ?: 0L
+}
+
+private fun resolveReplyIdFromFragment(rawFragment: String?): Long {
+    val fragment = rawFragment.orEmpty()
+    if (fragment.isBlank()) return 0L
+    return Regex("""reply(\d+)""", RegexOption.IGNORE_CASE)
+        .find(fragment)
+        ?.groupValues
+        ?.getOrNull(1)
+        ?.toLongOrNull()
+        ?: 0L
 }

--- a/app/src/main/java/com/android/purebilibili/navigation/ScreenRoutes.kt
+++ b/app/src/main/java/com/android/purebilibili/navigation/ScreenRoutes.kt
@@ -87,14 +87,15 @@ sealed class ScreenRoutes(val route: String) {
     object AnimationSettings : ScreenRoutes("animation_settings")  // 动画设置
 
     // [修复] 添加 aid 参数支持，用于移动端推荐流（可能只返回 aid）
-    object VideoPlayer : ScreenRoutes("video_player/{bvid}?cid={cid}&aid={aid}&commentRootRpid={commentRootRpid}") {
+    object VideoPlayer : ScreenRoutes("video_player/{bvid}?cid={cid}&aid={aid}&commentRootRpid={commentRootRpid}&commentTargetRpid={commentTargetRpid}") {
         fun createRoute(
             bvid: String,
             cid: Long = 0,
             aid: Long = 0,
-            commentRootRpid: Long = 0
+            commentRootRpid: Long = 0,
+            commentTargetRpid: Long = 0
         ): String {
-            return "video_player/$bvid?cid=$cid&aid=$aid&commentRootRpid=$commentRootRpid"
+            return "video_player/$bvid?cid=$cid&aid=$aid&commentRootRpid=$commentRootRpid&commentTargetRpid=$commentTargetRpid"
         }
     }
     

--- a/app/src/main/java/com/android/purebilibili/navigation3/BiliPaiNavKey.kt
+++ b/app/src/main/java/com/android/purebilibili/navigation3/BiliPaiNavKey.kt
@@ -285,6 +285,7 @@ internal sealed interface BiliPaiNavKey : NavKey {
         val fullscreen: Boolean = false,
         val resumePositionMs: Long = 0L,
         val commentRootRpid: Long = 0L,
+        val commentTargetRpid: Long = 0L,
         val sourceRoute: String? = null
     ) : BiliPaiNavKey {
         override val routeBase: String = "video"

--- a/app/src/main/java/com/android/purebilibili/navigation3/BiliPaiNavKeyMappingPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/navigation3/BiliPaiNavKeyMappingPolicy.kt
@@ -67,7 +67,8 @@ internal fun BiliPaiNavKey.toLegacyRoute(): String {
             autoPortrait = autoPortrait,
             fullscreen = fullscreen,
             resumePositionMs = resumePositionMs,
-            commentRootRpid = commentRootRpid
+            commentRootRpid = commentRootRpid,
+            commentTargetRpid = commentTargetRpid
         )
         is BiliPaiNavKey.ArticleDetail -> ScreenRoutes.ArticleDetail.createRoute(articleId, title)
         is BiliPaiNavKey.DynamicDetail -> ScreenRoutes.DynamicDetail.createRoute(dynamicId)
@@ -185,6 +186,7 @@ internal fun legacyRouteToBiliPaiNavKey(route: String?): BiliPaiNavKey {
                 fullscreen = query["fullscreen"]?.toBooleanStrictOrNull() ?: false,
                 resumePositionMs = query["resumePositionMs"]?.toLongOrNull() ?: 0L,
                 commentRootRpid = query["commentRootRpid"]?.toLongOrNull() ?: 0L,
+                commentTargetRpid = query["commentTargetRpid"]?.toLongOrNull() ?: 0L,
                 sourceRoute = null
             )
         }

--- a/app/src/test/java/com/android/purebilibili/MainActivityVideoRoutePolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/MainActivityVideoRoutePolicyTest.kt
@@ -8,7 +8,7 @@ class MainActivityVideoRoutePolicyTest {
     @Test
     fun notificationRoute_defaultsToAutoPortraitAndStartAudioFalse() {
         assertEquals(
-            "video/BV1abc?cid=0&cover=&startAudio=false&autoPortrait=true&fullscreen=false&resumePositionMs=0&commentRootRpid=0",
+            "video/BV1abc?cid=0&cover=&startAudio=false&autoPortrait=true&fullscreen=false&resumePositionMs=0&commentRootRpid=0&commentTargetRpid=0",
             resolveMainActivityVideoRoute(bvid = "BV1abc", cid = 0L)
         )
     }
@@ -16,7 +16,7 @@ class MainActivityVideoRoutePolicyTest {
     @Test
     fun notificationRoute_keepsCidValue() {
         assertEquals(
-            "video/BV2xyz?cid=12345&cover=&startAudio=false&autoPortrait=true&fullscreen=false&resumePositionMs=0&commentRootRpid=0",
+            "video/BV2xyz?cid=12345&cover=&startAudio=false&autoPortrait=true&fullscreen=false&resumePositionMs=0&commentRootRpid=0&commentTargetRpid=0",
             resolveMainActivityVideoRoute(bvid = "BV2xyz", cid = 12345L)
         )
     }
@@ -24,7 +24,7 @@ class MainActivityVideoRoutePolicyTest {
     @Test
     fun notificationRoute_canRequestStartInFullscreen() {
         assertEquals(
-            "video/BV9full?cid=42&cover=&startAudio=false&autoPortrait=true&fullscreen=true&resumePositionMs=0&commentRootRpid=0",
+            "video/BV9full?cid=42&cover=&startAudio=false&autoPortrait=true&fullscreen=true&resumePositionMs=0&commentRootRpid=0&commentTargetRpid=0",
             resolveMainActivityVideoRoute(
                 bvid = "BV9full",
                 cid = 42L,

--- a/app/src/test/java/com/android/purebilibili/core/store/HomeSettingsMappingPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/core/store/HomeSettingsMappingPolicyTest.kt
@@ -23,6 +23,7 @@ class HomeSettingsMappingPolicyTest {
         assertTrue(result.isBottomBarFloating)
         assertEquals(0, result.bottomBarLabelMode)
         assertEquals(SettingsManager.TopTabLabelMode.TEXT_ONLY, result.topTabLabelMode)
+        assertEquals(HomeTopRightAction.SETTINGS, result.homeTopRightAction)
         assertTrue(result.isHeaderBlurEnabled)
         assertEquals(HomeHeaderBlurMode.FOLLOW_PRESET, result.headerBlurMode)
         assertTrue(result.isBottomBarBlurEnabled)
@@ -60,6 +61,7 @@ class HomeSettingsMappingPolicyTest {
             booleanPreferencesKey("bottom_bar_floating") to false,
             intPreferencesKey("bottom_bar_label_mode") to 2,
             intPreferencesKey("top_tab_label_mode") to 1,
+            intPreferencesKey("home_top_right_action") to HomeTopRightAction.INBOX.value,
             booleanPreferencesKey("header_blur_enabled") to false,
             booleanPreferencesKey("header_collapse_enabled") to false,
             booleanPreferencesKey("bottom_bar_blur_enabled") to false,
@@ -93,6 +95,7 @@ class HomeSettingsMappingPolicyTest {
         assertFalse(result.isBottomBarFloating)
         assertEquals(2, result.bottomBarLabelMode)
         assertEquals(1, result.topTabLabelMode)
+        assertEquals(HomeTopRightAction.INBOX, result.homeTopRightAction)
         assertFalse(result.isHeaderBlurEnabled)
         assertEquals(HomeHeaderBlurMode.ALWAYS_OFF, result.headerBlurMode)
         assertFalse(result.isHeaderCollapseEnabled)
@@ -134,6 +137,17 @@ class HomeSettingsMappingPolicyTest {
         val result = mapHomeSettingsFromPreferences(prefs)
 
         assertEquals(HomeFeedCardWidthPreset.AUTO, result.homeFeedCardWidthPreset)
+    }
+
+    @Test
+    fun invalidHomeTopRightActionFallsBackToSettings() {
+        val prefs = mutablePreferencesOf(
+            intPreferencesKey("home_top_right_action") to 99
+        )
+
+        val result = mapHomeSettingsFromPreferences(prefs)
+
+        assertEquals(HomeTopRightAction.SETTINGS, result.homeTopRightAction)
     }
 
     @Test

--- a/app/src/test/java/com/android/purebilibili/feature/settings/SettingsSearchPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/settings/SettingsSearchPolicyTest.kt
@@ -370,8 +370,19 @@ class SettingsSearchPolicyTest {
             it.target == SettingsSearchTarget.BOTTOM_BAR && it.title == "顶部标签管理"
         }
 
-        assertEquals("显示/隐藏、排序、自动收缩", result?.subtitle)
+        assertEquals("显示/隐藏、排序、自动收缩、右上角入口", result?.subtitle)
         assertEquals("导航设置", result?.section)
+    }
+
+    @Test
+    fun queryByHomeTopRightMessage_hitsTopTabManagementEntry() {
+        val result = resolveSettingsSearchResults("首页右上角消息").firstOrNull {
+            it.target == SettingsSearchTarget.BOTTOM_BAR &&
+                it.focusId == SettingsSearchFocusIds.BOTTOM_BAR_TOP_TABS
+        }
+
+        assertEquals("顶部标签管理", result?.title)
+        assertEquals("显示/隐藏、排序、自动收缩、右上角入口", result?.subtitle)
     }
 
     @Test

--- a/app/src/test/java/com/android/purebilibili/feature/video/screen/VideoDetailLayoutModePolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/screen/VideoDetailLayoutModePolicyTest.kt
@@ -147,6 +147,31 @@ class VideoDetailLayoutModePolicyTest {
     }
 
     @Test
+    fun routedComment_forcesDetachedCommentThreadHostInitializationAfterAidIsReady() {
+        assertTrue(
+            shouldForceInitializeDetachedCommentThreadHostForRoute(
+                routeCommentRootRpid = 11L,
+                aid = 100L,
+                hasHandledRouteComment = false
+            )
+        )
+        assertFalse(
+            shouldForceInitializeDetachedCommentThreadHostForRoute(
+                routeCommentRootRpid = 11L,
+                aid = 0L,
+                hasHandledRouteComment = false
+            )
+        )
+        assertFalse(
+            shouldForceInitializeDetachedCommentThreadHostForRoute(
+                routeCommentRootRpid = 11L,
+                aid = 100L,
+                hasHandledRouteComment = true
+            )
+        )
+    }
+
+    @Test
     fun systemMultiWindowFullscreenPolicy_restoresMainWindowBeforeEnteringFullscreen() {
         assertTrue(
             shouldRestoreMainWindowBeforeEnteringFullscreen(

--- a/app/src/test/java/com/android/purebilibili/feature/video/ui/components/SubReplyDetailPresentationPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/ui/components/SubReplyDetailPresentationPolicyTest.kt
@@ -34,6 +34,39 @@ class SubReplyDetailPresentationPolicyTest {
     }
 
     @Test
+    fun `sub reply target list index resolves root and child positions`() {
+        val replies = listOf(
+            ReplyItem(rpid = 20L),
+            ReplyItem(rpid = 30L)
+        )
+
+        assertEquals(
+            0,
+            resolveSubReplyTargetListIndex(
+                rootReplyId = 10L,
+                visibleReplies = replies,
+                targetReplyId = 10L
+            )
+        )
+        assertEquals(
+            2,
+            resolveSubReplyTargetListIndex(
+                rootReplyId = 10L,
+                visibleReplies = replies,
+                targetReplyId = 30L
+            )
+        )
+        assertEquals(
+            null,
+            resolveSubReplyTargetListIndex(
+                rootReplyId = 10L,
+                visibleReplies = replies,
+                targetReplyId = 99L
+            )
+        )
+    }
+
+    @Test
     fun `sub reply detail reveal motion stays blur free`() {
         val spec = resolveSubReplyDetailRevealSpec(levelIndex = 2)
 

--- a/app/src/test/java/com/android/purebilibili/feature/video/ui/components/VideoCommentSheetHostPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/ui/components/VideoCommentSheetHostPolicyTest.kt
@@ -30,6 +30,22 @@ class VideoCommentSheetHostPolicyTest {
     }
 
     @Test
+    fun `comment host should initialize for routed comment even when main sheet is hidden`() {
+        assertTrue(
+            shouldInitializeVideoCommentSheetHost(
+                mainSheetVisible = false,
+                forceInitialize = true
+            )
+        )
+        assertFalse(
+            shouldInitializeVideoCommentSheetHost(
+                mainSheetVisible = false,
+                forceInitialize = false
+            )
+        )
+    }
+
+    @Test
     fun `host should prioritize thread detail whenever subreply detail is visible`() {
         assertEquals(
             VideoCommentSheetHostContent.THREAD_DETAIL,

--- a/app/src/test/java/com/android/purebilibili/feature/video/ui/pager/PortraitVideoPagerPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/ui/pager/PortraitVideoPagerPolicyTest.kt
@@ -363,6 +363,25 @@ class PortraitVideoPagerPolicyTest {
     }
 
     @Test
+    fun portraitTripleActionOverride_updatesLocalLikeAndFavoriteCounts() {
+        val resolved = resolvePortraitTripleActionOverride(
+            currentState = PortraitVideoInteractionUiState(
+                isLiked = false,
+                isFavorited = false,
+                likeCount = 8,
+                favoriteCount = 3
+            ),
+            likeSuccess = true,
+            favoriteSuccess = true
+        )
+
+        assertTrue(resolved.isLiked == true)
+        assertTrue(resolved.isFavorited == true)
+        assertEquals(9, resolved.likeCount)
+        assertEquals(4, resolved.favoriteCount)
+    }
+
+    @Test
     fun portraitRecommendationSnapshot_extractsStableBvidSetFromMixedPageItems() {
         assertEquals(
             setOf("BV_INFO", "BV_RELATED"),

--- a/app/src/test/java/com/android/purebilibili/feature/video/ui/section/VideoTriplePressPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/ui/section/VideoTriplePressPolicyTest.kt
@@ -1,5 +1,6 @@
 package com.android.purebilibili.feature.video.ui.section
 
+import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -52,5 +53,16 @@ class VideoTriplePressPolicyTest {
                 tripleCompleted = false
             )
         )
+    }
+
+    @Test
+    fun portraitLikeButton_exposesLongPressTripleCallback() {
+        val source = File("src/main/java/com/android/purebilibili/feature/video/ui/overlay/PortraitInteractionBar.kt")
+            .takeIf { it.exists() }
+            ?: File("app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/PortraitInteractionBar.kt")
+        val text = source.readText()
+
+        assertTrue(text.contains("onLikeLongClick"))
+        assertTrue(text.contains("onLongClick = onLikeLongClick"))
     }
 }

--- a/app/src/test/java/com/android/purebilibili/feature/video/viewmodel/CommentPaginationPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/viewmodel/CommentPaginationPolicyTest.kt
@@ -181,4 +181,26 @@ class CommentPaginationPolicyTest {
             )
         )
     }
+
+    @Test
+    fun `routed sub reply open only starts after aid is ready`() {
+        assertFalse(
+            shouldStartRoutedSubReplyOpen(
+                rootReplyId = 11L,
+                currentAid = 0L
+            )
+        )
+        assertFalse(
+            shouldStartRoutedSubReplyOpen(
+                rootReplyId = 0L,
+                currentAid = 100L
+            )
+        )
+        assertTrue(
+            shouldStartRoutedSubReplyOpen(
+                rootReplyId = 11L,
+                currentAid = 100L
+            )
+        )
+    }
 }

--- a/app/src/test/java/com/android/purebilibili/feature/video/viewmodel/CommentPaginationPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/viewmodel/CommentPaginationPolicyTest.kt
@@ -140,4 +140,45 @@ class CommentPaginationPolicyTest {
             )
         )
     }
+
+    @Test
+    fun `routed comment root prefers loaded root reply`() {
+        val loaded = ReplyItem(rpid = 11L)
+        val remote = ReplyData(root = ReplyItem(rpid = 11L, content = com.android.purebilibili.data.model.response.ReplyContent(message = "remote")))
+
+        assertEquals(
+            loaded,
+            resolveRoutedCommentRootReply(
+                loadedReplies = listOf(loaded),
+                remoteData = remote,
+                rootReplyId = 11L
+            )
+        )
+    }
+
+    @Test
+    fun `routed comment root falls back to remote root reply`() {
+        val remoteRoot = ReplyItem(rpid = 22L)
+
+        assertEquals(
+            remoteRoot,
+            resolveRoutedCommentRootReply(
+                loadedReplies = emptyList(),
+                remoteData = ReplyData(root = remoteRoot),
+                rootReplyId = 22L
+            )
+        )
+    }
+
+    @Test
+    fun `routed comment root ignores unrelated remote reply`() {
+        assertEquals(
+            null,
+            resolveRoutedCommentRootReply(
+                loadedReplies = emptyList(),
+                remoteData = ReplyData(root = ReplyItem(rpid = 33L)),
+                rootReplyId = 44L
+            )
+        )
+    }
 }

--- a/app/src/test/java/com/android/purebilibili/navigation/HomeVideoNavigationPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/navigation/HomeVideoNavigationPolicyTest.kt
@@ -63,7 +63,7 @@ class HomeVideoNavigationPolicyTest {
         val route = resolveHomeVideoRoute(request)
 
         assertEquals(
-            "video/BV1route?cid=88&cover=https%3A%2F%2Fimg.test.com%2Fa+b.jpg&startAudio=false&autoPortrait=true&fullscreen=false&resumePositionMs=0&commentRootRpid=0",
+            "video/BV1route?cid=88&cover=https%3A%2F%2Fimg.test.com%2Fa+b.jpg&startAudio=false&autoPortrait=true&fullscreen=false&resumePositionMs=0&commentRootRpid=0&commentTargetRpid=0",
             route
         )
     }
@@ -96,7 +96,7 @@ class HomeVideoNavigationPolicyTest {
 
         assertTrue(target is HomeNavigationTarget.Video)
         assertEquals(
-            "video/BV1route?cid=88&cover=https%3A%2F%2Fimg.test.com%2Fa+b.jpg&startAudio=false&autoPortrait=true&fullscreen=false&resumePositionMs=0&commentRootRpid=0",
+            "video/BV1route?cid=88&cover=https%3A%2F%2Fimg.test.com%2Fa+b.jpg&startAudio=false&autoPortrait=true&fullscreen=false&resumePositionMs=0&commentRootRpid=0&commentTargetRpid=0",
             (target as HomeNavigationTarget.Video).route
         )
     }

--- a/app/src/test/java/com/android/purebilibili/navigation/MessageLinkNavigationPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/navigation/MessageLinkNavigationPolicyTest.kt
@@ -7,9 +7,33 @@ import kotlin.test.assertIs
 class MessageLinkNavigationPolicyTest {
 
     @Test
-    fun resolveMessageLinkNavigationAction_routesAidDeepLinkToVideo() {
+    fun resolveMessageLinkNavigationAction_routesAidDeepLinkWithCommentRootToVideoComment() {
         val action = resolveMessageLinkNavigationAction(
             "bilibili://video/115391124741470?page=0&comment_root_id=279569905408"
+        )
+
+        val videoAction = assertIs<MessageLinkNavigationAction.VideoComment>(action)
+        assertEquals("av115391124741470", videoAction.videoId)
+        assertEquals(279569905408L, videoAction.rootReplyId)
+        assertEquals(0L, videoAction.targetReplyId)
+    }
+
+    @Test
+    fun resolveMessageLinkNavigationAction_routesWebVideoFragmentReplyToVideoComment() {
+        val action = resolveMessageLinkNavigationAction(
+            "https://www.bilibili.com/video/BV1xx411c7mD?comment_root_id=1#reply2"
+        )
+
+        val videoAction = assertIs<MessageLinkNavigationAction.VideoComment>(action)
+        assertEquals("BV1xx411c7mD", videoAction.videoId)
+        assertEquals(1L, videoAction.rootReplyId)
+        assertEquals(2L, videoAction.targetReplyId)
+    }
+
+    @Test
+    fun resolveMessageLinkNavigationAction_routesVideoDeepLinkWithoutCommentToVideo() {
+        val action = resolveMessageLinkNavigationAction(
+            "bilibili://video/115391124741470?page=0"
         )
 
         val videoAction = assertIs<MessageLinkNavigationAction.Video>(action)
@@ -24,5 +48,15 @@ class MessageLinkNavigationPolicyTest {
 
         val dynamicAction = assertIs<MessageLinkNavigationAction.DynamicComment>(action)
         assertEquals("1199344045210468386", dynamicAction.dynamicId)
+    }
+
+    @Test
+    fun resolveMessageLinkNavigationAction_routesOpusCommentLinkToDynamicComment() {
+        val action = resolveMessageLinkNavigationAction(
+            "bilibili://opus/detail/1073543151725051921?comment_root_id=265141324256&comment_on=1"
+        )
+
+        val dynamicAction = assertIs<MessageLinkNavigationAction.DynamicComment>(action)
+        assertEquals("1073543151725051921", dynamicAction.dynamicId)
     }
 }

--- a/app/src/test/java/com/android/purebilibili/navigation/VideoRoutePolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/navigation/VideoRoutePolicyTest.kt
@@ -18,7 +18,7 @@ class VideoRoutePolicyTest {
         )
 
         assertEquals(
-            "video/BV1abc?cid=233&cover=https%3A%2F%2Fimg&startAudio=true&autoPortrait=false&fullscreen=false&resumePositionMs=0&commentRootRpid=0",
+            "video/BV1abc?cid=233&cover=https%3A%2F%2Fimg&startAudio=true&autoPortrait=false&fullscreen=false&resumePositionMs=0&commentRootRpid=0&commentTargetRpid=0",
             route
         )
     }
@@ -36,7 +36,7 @@ class VideoRoutePolicyTest {
         )
 
         assertEquals(
-            "video/BV9xyz?cid=0&cover=&startAudio=false&autoPortrait=true&fullscreen=false&resumePositionMs=0&commentRootRpid=0",
+            "video/BV9xyz?cid=0&cover=&startAudio=false&autoPortrait=true&fullscreen=false&resumePositionMs=0&commentRootRpid=0&commentTargetRpid=0",
             route
         )
     }
@@ -44,7 +44,7 @@ class VideoRoutePolicyTest {
     @Test
     fun standardVideoRoute_disablesAutoPortraitByDefault() {
         assertEquals(
-            "video/BV1std?cid=77&cover=https%3A%2F%2Fimg.test%2Fcover.jpg&startAudio=false&autoPortrait=false&fullscreen=false&resumePositionMs=0&commentRootRpid=0",
+            "video/BV1std?cid=77&cover=https%3A%2F%2Fimg.test%2Fcover.jpg&startAudio=false&autoPortrait=false&fullscreen=false&resumePositionMs=0&commentRootRpid=0&commentTargetRpid=0",
             resolveStandardVideoRoute(
                 bvid = "BV1std",
                 cid = 77L,
@@ -56,7 +56,7 @@ class VideoRoutePolicyTest {
     @Test
     fun standardVideoRoute_keepsAudioModeWithoutAutoPortrait() {
         assertEquals(
-            "video/BV1audio?cid=9&cover=&startAudio=true&autoPortrait=false&fullscreen=false&resumePositionMs=0&commentRootRpid=0",
+            "video/BV1audio?cid=9&cover=&startAudio=true&autoPortrait=false&fullscreen=false&resumePositionMs=0&commentRootRpid=0&commentTargetRpid=0",
             resolveStandardVideoRoute(
                 bvid = "BV1audio",
                 cid = 9L,
@@ -79,7 +79,7 @@ class VideoRoutePolicyTest {
         )
 
         assertEquals(
-            "video/BV1resume?cid=4455&cover=&startAudio=false&autoPortrait=false&fullscreen=false&resumePositionMs=98000&commentRootRpid=0",
+            "video/BV1resume?cid=4455&cover=&startAudio=false&autoPortrait=false&fullscreen=false&resumePositionMs=98000&commentRootRpid=0&commentTargetRpid=0",
             route
         )
     }
@@ -97,7 +97,27 @@ class VideoRoutePolicyTest {
         )
 
         assertEquals(
-            "video/BV1full?cid=11&cover=&startAudio=false&autoPortrait=true&fullscreen=true&resumePositionMs=0&commentRootRpid=0",
+            "video/BV1full?cid=11&cover=&startAudio=false&autoPortrait=true&fullscreen=true&resumePositionMs=0&commentRootRpid=0&commentTargetRpid=0",
+            route
+        )
+    }
+
+    @Test
+    fun resolveVideoRoutePath_canEncodeCommentTargetReply() {
+        val route = VideoRoute.resolveVideoRoutePath(
+            bvid = "BV1reply",
+            cid = 0L,
+            encodedCover = "",
+            startAudio = false,
+            autoPortrait = false,
+            fullscreen = false,
+            resumePositionMs = 0L,
+            commentRootRpid = 11L,
+            commentTargetRpid = 22L
+        )
+
+        assertEquals(
+            "video/BV1reply?cid=0&cover=&startAudio=false&autoPortrait=false&fullscreen=false&resumePositionMs=0&commentRootRpid=11&commentTargetRpid=22",
             route
         )
     }

--- a/app/src/test/java/com/android/purebilibili/navigation3/BiliPaiNavKeyMappingPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/navigation3/BiliPaiNavKeyMappingPolicyTest.kt
@@ -19,7 +19,7 @@ class BiliPaiNavKeyMappingPolicyTest {
     @Test
     fun videoRoute_preservesNavigationArguments() {
         val route = "video/BV1xx411c7mD?cid=123&cover=https%3A%2F%2Fexample.com%2Fcover.jpg" +
-            "&startAudio=true&autoPortrait=true&fullscreen=true&resumePositionMs=456&commentRootRpid=789"
+            "&startAudio=true&autoPortrait=true&fullscreen=true&resumePositionMs=456&commentRootRpid=789&commentTargetRpid=790"
 
         val key = assertIs<BiliPaiNavKey.VideoDetail>(legacyRouteToBiliPaiNavKey(route))
 
@@ -31,6 +31,7 @@ class BiliPaiNavKeyMappingPolicyTest {
         assertEquals(true, key.fullscreen)
         assertEquals(456L, key.resumePositionMs)
         assertEquals(789L, key.commentRootRpid)
+        assertEquals(790L, key.commentTargetRpid)
     }
 
     @Test


### PR DESCRIPTION
## 概要
- 修复消息点赞/回复链接只能跳视频、不能打开对应评论线程的问题
- 增加首页右上角消息入口设置
- 支持竖屏点赞按钮长按三连

## 验证
- ./gradlew :app:testDebugUnitTest --tests 'com.android.purebilibili.navigation.MessageLinkNavigationPolicyTest'
- ./gradlew :app:testDebugUnitTest --tests 'com.android.purebilibili.feature.video.ui.components.VideoCommentSheetHostPolicyTest' --tests 'com.android.purebilibili.feature.video.viewmodel.CommentPaginationPolicyTest' --tests 'com.android.purebilibili.feature.video.screen.VideoDetailLayoutModePolicyTest'
- ./gradlew :app:testDebugUnitTest --tests 'com.android.purebilibili.core.store.HomeSettingsMappingPolicyTest' --tests 'com.android.purebilibili.feature.settings.SettingsSearchPolicyTest' --tests 'com.android.purebilibili.feature.video.ui.pager.PortraitVideoPagerPolicyTest' --tests 'com.android.purebilibili.feature.video.ui.section.VideoTriplePressPolicyTest'
- ./gradlew :app:compileDebugKotlin
- git diff --check