### PR TITLE
fix: 修复展开评论楼中楼时视频被灰色遮罩覆盖的问题

### DIFF
--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/components/VideoCommentSheetHost.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/components/VideoCommentSheetHost.kt
@@ -154,8 +154,12 @@ internal fun resolveVideoCommentSheetHostHeightPx(
 }
 
 internal fun resolveVideoCommentSheetHostScrimAlpha(
-    mainSheetVisible: Boolean
+    mainSheetVisible: Boolean,
+    hostContent: VideoCommentSheetHostContent = VideoCommentSheetHostContent.MAIN_LIST
 ): Float {
+    if (hostContent == VideoCommentSheetHostContent.THREAD_DETAIL) {
+        return 0f
+    }
     return if (mainSheetVisible) {
         MAIN_COMMENT_SHEET_SCRIM_ALPHA
     } else {
@@ -218,13 +222,14 @@ internal fun resolveVideoCommentSheetPresentationProgress(
 
 internal fun resolveVideoCommentSheetHostOverlayVisual(
     mainSheetVisible: Boolean,
-    presentationProgress: Float
+    presentationProgress: Float,
+    hostContent: VideoCommentSheetHostContent = VideoCommentSheetHostContent.MAIN_LIST
 ): InteractiveOverlayProgressVisual {
     return resolveInteractiveOverlayProgressVisual(
         presentationProgress = presentationProgress,
         surfaceType = InteractiveOverlaySurfaceType.BOTTOM_SHEET,
         blurActive = mainSheetVisible,
-        maxScrimAlpha = resolveVideoCommentSheetHostScrimAlpha(mainSheetVisible)
+        maxScrimAlpha = resolveVideoCommentSheetHostScrimAlpha(mainSheetVisible, hostContent)
     )
 }
 
@@ -336,10 +341,11 @@ fun VideoCommentSheetHost(
     LaunchedEffect(mainSheetVisible, hostContent, mainSheetVisibilityProgress) {
         onMainSheetVisibilityProgressChange(mainSheetVisibilityProgress)
     }
-    val overlayVisual = remember(mainSheetVisible, mainSheetVisibilityProgress) {
+    val overlayVisual = remember(mainSheetVisible, mainSheetVisibilityProgress, hostContent) {
         resolveVideoCommentSheetHostOverlayVisual(
             mainSheetVisible = mainSheetVisible,
-            presentationProgress = mainSheetVisibilityProgress
+            presentationProgress = mainSheetVisibilityProgress,
+            hostContent = hostContent
         )
     }
 

--- a/app/src/test/java/com/android/purebilibili/feature/video/ui/components/VideoCommentSheetHostPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/ui/components/VideoCommentSheetHostPolicyTest.kt
@@ -115,6 +115,17 @@ class VideoCommentSheetHostPolicyTest {
     }
 
     @Test
+    fun `thread detail should not have a grey scrim mask when main sheet is visible`() {
+        assertEquals(
+            0f,
+            resolveVideoCommentSheetHostScrimAlpha(
+                mainSheetVisible = true,
+                hostContent = VideoCommentSheetHostContent.THREAD_DETAIL
+            )
+        )
+    }
+
+    @Test
     fun `embedded thread detail should cover comment content below reserved player area`() {
         assertEquals(
             0.55f,


### PR DESCRIPTION
根据最新版只删除展开时的灰色遮罩，其他完全按照原版。此更改通过在 \hostContent == THREAD_DETAIL\ 时将 scrimAlpha 设为 0f，移除了楼中楼详情展开时的灰色蒙层遮挡。