### PR TITLE
fix: 进入视频详情页时不再立即写入 0 进度的播放历史

### DIFF
--- a/app/src/main/java/com/android/purebilibili/feature/video/playback/policy/PlaybackAncillaryTaskPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/playback/policy/PlaybackAncillaryTaskPolicy.kt
@@ -33,6 +33,18 @@ internal fun shouldSendPlaybackHeartbeat(
         currentCid > 0L
 }
 
+internal fun shouldSendInitialPlaybackHeartbeat(
+    isActivelyPlaying: Boolean,
+    isInBackground: Boolean,
+    currentBvid: String,
+    currentCid: Long
+): Boolean {
+    return isActivelyPlaying &&
+        !isInBackground &&
+        currentBvid.isNotBlank() &&
+        currentCid > 0L
+}
+
 internal fun resolvePlaybackHeartbeatSessionStartTsSec(
     existingStartTsSec: Long,
     nowEpochSec: Long

--- a/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/PlayerViewModel.kt
@@ -93,6 +93,7 @@ import com.android.purebilibili.feature.video.playback.policy.resolvePlaybackHea
 import com.android.purebilibili.feature.video.playback.policy.shouldHoldPlaybackResumeTransitionPosition
 import com.android.purebilibili.feature.video.playback.policy.resolvePluginPollingIntervalMs
 import com.android.purebilibili.feature.video.playback.policy.shouldRefreshOnlineCount
+import com.android.purebilibili.feature.video.playback.policy.shouldSendInitialPlaybackHeartbeat
 import com.android.purebilibili.feature.video.playback.policy.shouldSendPlaybackHeartbeat
 import com.android.purebilibili.feature.video.playback.policy.shouldFlushPlaybackHeartbeatSnapshot
 import com.android.purebilibili.feature.video.playback.policy.shouldDispatchPluginPositionUpdate
@@ -7112,8 +7113,8 @@ class PlayerViewModel : ViewModel() {
         heartbeatJob?.cancel()
         beginHeartbeatSession()
         heartbeatJob = viewModelScope.launch {
-            if (shouldSendPlaybackHeartbeat(
-                    isPlaying = true,
+            if (shouldSendInitialPlaybackHeartbeat(
+                    isActivelyPlaying = exoPlayer?.isPlaying == true,
                     isInBackground = BackgroundManager.isInBackground,
                     currentBvid = currentBvid,
                     currentCid = currentCid

--- a/app/src/test/java/com/android/purebilibili/feature/video/playback/policy/PlaybackAncillaryTaskPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/playback/policy/PlaybackAncillaryTaskPolicyTest.kt
@@ -70,6 +70,50 @@ class PlaybackAncillaryTaskPolicyTest {
     }
 
     @Test
+    fun `initial heartbeat should require actual foreground playback and valid video ids`() {
+        assertTrue(
+            shouldSendInitialPlaybackHeartbeat(
+                isActivelyPlaying = true,
+                isInBackground = false,
+                currentBvid = "BV1test",
+                currentCid = 456L
+            )
+        )
+        assertFalse(
+            shouldSendInitialPlaybackHeartbeat(
+                isActivelyPlaying = false,
+                isInBackground = false,
+                currentBvid = "BV1test",
+                currentCid = 456L
+            )
+        )
+        assertFalse(
+            shouldSendInitialPlaybackHeartbeat(
+                isActivelyPlaying = true,
+                isInBackground = true,
+                currentBvid = "BV1test",
+                currentCid = 456L
+            )
+        )
+        assertFalse(
+            shouldSendInitialPlaybackHeartbeat(
+                isActivelyPlaying = true,
+                isInBackground = false,
+                currentBvid = " ",
+                currentCid = 456L
+            )
+        )
+        assertFalse(
+            shouldSendInitialPlaybackHeartbeat(
+                isActivelyPlaying = true,
+                isInBackground = false,
+                currentBvid = "BV1test",
+                currentCid = 0L
+            )
+        )
+    }
+
+    @Test
     fun `heartbeat session start timestamp should stay stable once assigned`() {
         assertEquals(
             1_700_000_000L,


### PR DESCRIPTION
## Summary

未开启自动播放时进入视频详情页，不再立即上报一条 `played_time=0` 的播放心跳。只有在播放真正开始后，才按真实进度上报并写入观看历史。

## Why

## 这解决了什么

进入详情页后约 900ms，应用会调度 `startHeartbeat()`，其中初始心跳的判断把 `isPlaying` 硬编码为 `true`，于是无论是否真的在播放都会发送一条进度为 0 的心跳。这会用进度 0 创建/覆盖该视频的服务端观看历史；如果之前已经看过并保存了进度，原有进度会被清零。详见 #537。

## 改动

- 在 `PlaybackAncillaryTaskPolicy.kt` 新增纯函数 `shouldSendInitialPlaybackHeartbeat(...)`，仅当 `isActivelyPlaying && !isInBackground && bvid 非空 && cid > 0` 时返回 true，把"真正开始播放"与原先硬编码的"前台即上报"区分开。
- 在 `PlayerViewModel.startHeartbeat()` 中，把初始心跳的判断从 `shouldSendPlaybackHeartbeat(isPlaying = true, ...)` 换成 `shouldSendInitialPlaybackHeartbeat(isActivelyPlaying = exoPlayer?.isPlaying == true, ...)`。未开始播放时跳过这条进度为 0 的上报，且不写入 `lastReportedHeartbeatSnapshot`。
- 用户真正开始播放后，`onIsPlayingChanged(true)` 会触发 `syncHeartbeatPlaybackTracking`，随后 30 秒间隔循环经由 `shouldFlushPlaybackHeartbeatSnapshot`（要求 `playedTimeSec > 0`）按真实进度上报历史，因此既不会写入 0 进度，也不会丢失真实进度。

## 测试

- 在 `PlaybackAncillaryTaskPolicyTest.kt` 新增针对 `shouldSendInitialPlaybackHeartbeat` 的单元测试：未播放、后台、bvid 为空、cid<=0 均返回 false，仅在前台真实播放且 bvid/cid 有效时返回 true。
- 现有针对 `shouldFlushPlaybackHeartbeatSnapshot` 的用例覆盖了"进度为 0 不上报"的回归。
- 本地环境无 JDK，无法运行完整 Gradle 构建；改动为纯逻辑且新增测试是纯 Kotlin（仅依赖 `kotlin.test`），逻辑与既有的 `shouldSendPlaybackHeartbeat` 保持一致。

Fixes #537

AI was used for assistance.
