### PR TITLE
fix: 移除回复展开遮罩 & 修复液态玻璃开关形状

### DIFF
--- a/app/src/main/java/com/android/purebilibili/core/ui/components/AppAdaptiveSwitchPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/core/ui/components/AppAdaptiveSwitchPolicy.kt
@@ -22,7 +22,6 @@ internal fun resolveAppAdaptiveSwitchTreatment(
     return when {
         uiPreset == UiPreset.MD3 && androidNativeVariant == AndroidNativeVariant.MIUIX -> AppAdaptiveSwitchTreatment.MIUIX
         uiPreset == UiPreset.MD3 -> AppAdaptiveSwitchTreatment.MATERIAL
-        settingsLiquidGlassEnabled -> AppAdaptiveSwitchTreatment.LIQUID_GLASS
         else -> AppAdaptiveSwitchTreatment.CUPERTINO
     }
 }

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/components/VideoCommentSheetHost.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/components/VideoCommentSheetHost.kt
@@ -163,13 +163,10 @@ internal fun resolveVideoCommentSheetHostHeightPx(
 }
 
 internal fun resolveVideoCommentSheetHostScrimAlpha(
-    mainSheetVisible: Boolean
+    mainSheetVisible: Boolean,
+    hostContent: VideoCommentSheetHostContent = VideoCommentSheetHostContent.MAIN_LIST
 ): Float {
-    return if (mainSheetVisible) {
-        MAIN_COMMENT_SHEET_SCRIM_ALPHA
-    } else {
-        resolveVideoSubReplySheetScrimAlpha()
-    }
+    return 0f
 }
 
 internal fun shouldApplyVideoCommentThreadStatusBarPadding(
@@ -187,14 +184,16 @@ internal fun shouldInitializeVideoCommentSheetHost(
 }
 
 internal fun shouldDismissVideoCommentSheetHostOnBackdropTap(
-    mainSheetVisible: Boolean
+    mainSheetVisible: Boolean,
+    hostContent: VideoCommentSheetHostContent = VideoCommentSheetHostContent.MAIN_LIST
 ): Boolean {
-    return mainSheetVisible
+    return mainSheetVisible && hostContent != VideoCommentSheetHostContent.THREAD_DETAIL
 }
 
 internal fun shouldInterceptVideoCommentSheetHostBackdropTap(
-    mainSheetVisible: Boolean
-): Boolean = mainSheetVisible
+    mainSheetVisible: Boolean,
+    hostContent: VideoCommentSheetHostContent = VideoCommentSheetHostContent.MAIN_LIST
+): Boolean = mainSheetVisible && hostContent != VideoCommentSheetHostContent.THREAD_DETAIL
 
 internal fun shouldHandleVideoCommentSheetVerticalDrag(
     dragAmountPx: Float,
@@ -275,13 +274,14 @@ internal fun resolveVideoCommentSheetPresentationProgress(
 
 internal fun resolveVideoCommentSheetHostOverlayVisual(
     mainSheetVisible: Boolean,
-    presentationProgress: Float
+    presentationProgress: Float,
+    hostContent: VideoCommentSheetHostContent = VideoCommentSheetHostContent.MAIN_LIST
 ): InteractiveOverlayProgressVisual {
     return resolveInteractiveOverlayProgressVisual(
         presentationProgress = presentationProgress,
         surfaceType = InteractiveOverlaySurfaceType.BOTTOM_SHEET,
         blurActive = mainSheetVisible,
-        maxScrimAlpha = resolveVideoCommentSheetHostScrimAlpha(mainSheetVisible)
+        maxScrimAlpha = resolveVideoCommentSheetHostScrimAlpha(mainSheetVisible, hostContent)
     )
 }
 
@@ -333,7 +333,8 @@ fun VideoCommentSheetHost(
     val hostVisible = hostContent != VideoCommentSheetHostContent.HIDDEN
     val scrimAlpha = resolveVideoCommentSheetHostScrimAlpha(mainSheetVisible = mainSheetVisible)
     val dismissOnBackdropTap = shouldDismissVideoCommentSheetHostOnBackdropTap(
-        mainSheetVisible = mainSheetVisible
+        mainSheetVisible = mainSheetVisible,
+        hostContent = hostContent
     )
     val applyThreadStatusBarPadding = shouldApplyVideoCommentThreadStatusBarPadding(
         mainSheetVisible = mainSheetVisible,
@@ -408,10 +409,11 @@ fun VideoCommentSheetHost(
             }
         }
     }
-    val overlayVisual = remember(mainSheetVisible, mainSheetVisibilityProgress) {
+    val overlayVisual = remember(mainSheetVisible, mainSheetVisibilityProgress, hostContent) {
         resolveVideoCommentSheetHostOverlayVisual(
             mainSheetVisible = mainSheetVisible,
-            presentationProgress = mainSheetVisibilityProgress
+            presentationProgress = mainSheetVisibilityProgress,
+            hostContent = hostContent
         )
     }
 
@@ -542,7 +544,8 @@ fun VideoCommentSheetHost(
         exit = bottomSheetScrimExitTransition(uiPreset, androidNativeVariant)
     ) {
         val interceptBackdropTap = shouldInterceptVideoCommentSheetHostBackdropTap(
-            mainSheetVisible = mainSheetVisible
+            mainSheetVisible = mainSheetVisible,
+            hostContent = hostContent
         )
         BoxWithConstraints(
             modifier = Modifier

--- a/app/src/test/java/com/android/purebilibili/core/ui/components/AppAdaptiveSwitchPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/core/ui/components/AppAdaptiveSwitchPolicyTest.kt
@@ -12,9 +12,9 @@ import kotlin.test.assertTrue
 class AppAdaptiveSwitchPolicyTest {
 
     @Test
-    fun `ios liquid glass settings use liquid switch treatment`() {
+    fun `ios liquid glass settings use cupertino switch treatment`() {
         assertEquals(
-            AppAdaptiveSwitchTreatment.LIQUID_GLASS,
+            AppAdaptiveSwitchTreatment.CUPERTINO,
             resolveAppAdaptiveSwitchTreatment(
                 uiPreset = UiPreset.IOS,
                 settingsLiquidGlassEnabled = true

--- a/app/src/test/java/com/android/purebilibili/feature/video/ui/components/VideoCommentSheetHostPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/ui/components/VideoCommentSheetHostPolicyTest.kt
@@ -73,7 +73,7 @@ class VideoCommentSheetHostPolicyTest {
                 topReservedPx = 450
             )
         )
-        assertEquals(0.5f, resolveVideoCommentSheetHostScrimAlpha(mainSheetVisible = true))
+        assertEquals(0f, resolveVideoCommentSheetHostScrimAlpha(mainSheetVisible = true))
     }
 
     @Test
@@ -93,10 +93,9 @@ class VideoCommentSheetHostPolicyTest {
 
         assertEquals(0f, hidden.scrimAlpha)
         assertFalse(hidden.blurEnabled)
-        assertEquals(0.25f, half.scrimAlpha)
+        assertEquals(0f, half.scrimAlpha)
         assertTrue(half.forceLowBlurBudget)
-        assertTrue(half.scrimAlpha < shown.scrimAlpha)
-        assertEquals(0.5f, shown.scrimAlpha)
+        assertEquals(0f, shown.scrimAlpha)
         assertFalse(shown.forceLowBlurBudget)
     }
 
@@ -112,6 +111,17 @@ class VideoCommentSheetHostPolicyTest {
             )
         )
         assertEquals(0f, resolveVideoCommentSheetHostScrimAlpha(mainSheetVisible = false))
+    }
+
+    @Test
+    fun `thread detail should not have a grey scrim mask when main sheet is visible`() {
+        assertEquals(
+            0f,
+            resolveVideoCommentSheetHostScrimAlpha(
+                mainSheetVisible = true,
+                hostContent = VideoCommentSheetHostContent.THREAD_DETAIL
+            )
+        )
     }
 
     @Test
@@ -217,22 +227,38 @@ class VideoCommentSheetHostPolicyTest {
     fun `backdrop tap dismissal only applies to main comment sheet`() {
         assertTrue(
             shouldDismissVideoCommentSheetHostOnBackdropTap(
-                mainSheetVisible = true
+                mainSheetVisible = true,
+                hostContent = VideoCommentSheetHostContent.MAIN_LIST
             )
         )
         assertFalse(
             shouldDismissVideoCommentSheetHostOnBackdropTap(
-                mainSheetVisible = false
+                mainSheetVisible = true,
+                hostContent = VideoCommentSheetHostContent.THREAD_DETAIL
+            )
+        )
+        assertFalse(
+            shouldDismissVideoCommentSheetHostOnBackdropTap(
+                mainSheetVisible = false,
+                hostContent = VideoCommentSheetHostContent.MAIN_LIST
             )
         )
         assertTrue(
             shouldInterceptVideoCommentSheetHostBackdropTap(
-                mainSheetVisible = true
+                mainSheetVisible = true,
+                hostContent = VideoCommentSheetHostContent.MAIN_LIST
             )
         )
         assertFalse(
             shouldInterceptVideoCommentSheetHostBackdropTap(
-                mainSheetVisible = false
+                mainSheetVisible = true,
+                hostContent = VideoCommentSheetHostContent.THREAD_DETAIL
+            )
+        )
+        assertFalse(
+            shouldInterceptVideoCommentSheetHostBackdropTap(
+                mainSheetVisible = false,
+                hostContent = VideoCommentSheetHostContent.MAIN_LIST
             )
         )
     }


### PR DESCRIPTION
去除了评论区‘回复’展开时的灰色遮罩（个人认为有点影响观看体验），并在查看评论详情时可以直接操作视频而不是点击视频区域后关闭，修复打开‘底栏液态玻璃’选项后按钮形状改变的问题。