### PR TITLE
fix(comment): 反转义评论区 HTML 实体（&#39 等）

### DIFF
--- a/app/src/main/java/com/android/purebilibili/core/util/HtmlEntityUtils.kt
+++ b/app/src/main/java/com/android/purebilibili/core/util/HtmlEntityUtils.kt
@@ -1,0 +1,66 @@
+package com.android.purebilibili.core.util
+
+/**
+ * 轻量 HTML 实体反转义工具（纯 Kotlin，无 Android 依赖）。
+ *
+ * B 站评论接口返回的文本会把特殊字符编码为 HTML 实体
+ * （`'` -> `&#39;`、`"` -> `&quot;`、`&` -> `&amp;` 等），
+ * 直接展示会出现 `&#39` 这类字面量。统一在数据解析层调用 [unescape] 清洗。
+ *
+ * 对不含实体的文本原样返回，无法识别的 `&...;` 序列保持原样，
+ * 可安全对任意文本调用。
+ */
+object HtmlEntityUtils {
+
+    private val namedEntities = mapOf(
+        "amp" to "&",
+        "lt" to "<",
+        "gt" to ">",
+        "quot" to "\"",
+        "apos" to "'",
+        "nbsp" to " "
+    )
+
+    // 命名实体 `&amp;`、十进制 `&#39;`、十六进制 `&#x2605;`；
+    // 数字实体允许省略末尾分号（兼容 `&#39` 这种写法），命名实体要求分号。
+    private val entityRegex = Regex("&(#[0-9]+|#[xX][0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]*);?")
+
+    /**
+     * 反转义常见的命名实体与数字实体（十进制 `&#39;` / 十六进制 `&#x2605;`）。
+     * 无法识别的 `&...` 序列保持原样，避免破坏普通文本中的 `&`。
+     */
+    fun unescape(input: String): String {
+        if (input.isEmpty() || '&' !in input) return input
+        return entityRegex.replace(input) { match ->
+            val token = match.groupValues[1]
+            decodeToken(token) ?: match.value
+        }
+    }
+
+    private fun decodeToken(token: String): String? {
+        namedEntities[token]?.let { return it }
+        return when {
+            token.startsWith("#x") || token.startsWith("#X") -> {
+                token.removePrefix("#x").removePrefix("#X")
+                    .toIntOrNull(16)
+                    ?.takeIf { it in 1..0x10FFFF }
+                    ?.let { codePointToString(it) }
+            }
+            token.startsWith("#") -> {
+                token.removePrefix("#").toIntOrNull()
+                    ?.takeIf { it in 1..0x10FFFF }
+                    ?.let { codePointToString(it) }
+            }
+            else -> null
+        }
+    }
+
+    private fun codePointToString(codePoint: Int): String {
+        return if (codePoint <= Char.MAX_VALUE.code) {
+            Char(codePoint).toString()
+        } else {
+            // 补充平面字符（emoji 等），用代理对表示
+            String(Character.toChars(codePoint))
+        }
+    }
+}

--- a/app/src/main/java/com/android/purebilibili/data/model/response/ResponseModels.kt
+++ b/app/src/main/java/com/android/purebilibili/data/model/response/ResponseModels.kt
@@ -509,6 +509,7 @@ object FlexibleBooleanSerializer : KSerializer<Boolean> {
 
 @Serializable
 data class ReplyContent(
+    @Serializable(with = UnescapedStringSerializer::class)
     val message: String = "",
     val device: String? = "",
     val emote: Map<String, ReplyEmote>? = null,

--- a/app/src/main/java/com/android/purebilibili/data/model/response/UnescapedStringSerializer.kt
+++ b/app/src/main/java/com/android/purebilibili/data/model/response/UnescapedStringSerializer.kt
@@ -1,0 +1,30 @@
+package com.android.purebilibili.data.model.response
+
+import com.android.purebilibili.core.util.HtmlEntityUtils
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * 反转义 B 站评论正文中的 HTML 实体（`&#39;` `&quot;` `&amp;` 等）。
+ *
+ * 仅作用于反序列化：REST/JSON 返回的 message 字段会携带 HTML 实体，
+ * 这里在解析时统一清洗，避免 UI 直接展示 `&#39` 这类字面量（#583）。
+ * 序列化原样输出，不影响请求构造。
+ */
+object UnescapedStringSerializer : KSerializer<String> {
+    override val descriptor = PrimitiveSerialDescriptor(
+        "com.android.purebilibili.data.model.response.UnescapedString",
+        PrimitiveKind.STRING
+    )
+
+    override fun serialize(encoder: Encoder, value: String) {
+        encoder.encodeString(value)
+    }
+
+    override fun deserialize(decoder: Decoder): String {
+        return HtmlEntityUtils.unescape(decoder.decodeString())
+    }
+}

--- a/app/src/main/java/com/android/purebilibili/data/repository/CommentGrpcRepository.kt
+++ b/app/src/main/java/com/android/purebilibili/data/repository/CommentGrpcRepository.kt
@@ -3,6 +3,7 @@ package com.android.purebilibili.data.repository
 import com.android.purebilibili.core.network.grpc.BiliGrpcClient
 import com.android.purebilibili.core.network.grpc.ProtoWire
 import com.android.purebilibili.core.util.FormatUtils
+import com.android.purebilibili.core.util.HtmlEntityUtils
 import com.android.purebilibili.data.model.response.ReplyCardLabel
 import com.android.purebilibili.data.model.response.ReplyConfig
 import com.android.purebilibili.data.model.response.ReplyContent
@@ -452,7 +453,7 @@ internal object CommentGrpcRepository {
 
         ProtoWire.parseFields(bytes).forEach { field ->
             when (field.number) {
-                1 -> message = ProtoWire.stringValue(field)
+                1 -> message = HtmlEntityUtils.unescape(ProtoWire.stringValue(field))
                 3 -> parseMapEntry(field.bytes) { key, value ->
                     parseEmote(value, key)?.let { emotes[key.ifBlank { it.text }] = it }
                 }

--- a/app/src/test/java/com/android/purebilibili/core/util/HtmlEntityUtilsTest.kt
+++ b/app/src/test/java/com/android/purebilibili/core/util/HtmlEntityUtilsTest.kt
@@ -51,4 +51,25 @@ class HtmlEntityUtilsTest {
     fun `unescape returns empty string for empty input`() {
         assertEquals("", HtmlEntityUtils.unescape(""))
     }
+
+    @Test
+    fun `unescape decodes nbsp entity to space`() {
+        assertEquals("a b", HtmlEntityUtils.unescape("a&nbsp;b"))
+    }
+
+    @Test
+    fun `unescape decodes uppercase hex entity`() {
+        assertEquals("★", HtmlEntityUtils.unescape("&#X2605;"))
+    }
+
+    @Test
+    fun `unescape decodes named entity without trailing semicolon`() {
+        assertEquals("a & b", HtmlEntityUtils.unescape("a &amp b"))
+    }
+
+    @Test
+    fun `unescape preserves a real-world bilibili comment with mixed content`() {
+        val raw = "我说&#39;这&#34;话&amp;那[doge]★"
+        assertEquals("我说'这\"话&那[doge]★", HtmlEntityUtils.unescape(raw))
+    }
 }

--- a/app/src/test/java/com/android/purebilibili/core/util/HtmlEntityUtilsTest.kt
+++ b/app/src/test/java/com/android/purebilibili/core/util/HtmlEntityUtilsTest.kt
@@ -1,0 +1,54 @@
+package com.android.purebilibili.core.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HtmlEntityUtilsTest {
+
+    @Test
+    fun `unescape decodes single quote entity from bilibili comments`() {
+        // 复现 #583：评论区单引号被编码为 &#39;
+        assertEquals("I'm here", HtmlEntityUtils.unescape("I&#39;m here"))
+    }
+
+    @Test
+    fun `unescape decodes single quote entity without trailing semicolon`() {
+        assertEquals("I'm", HtmlEntityUtils.unescape("I&#39m"))
+    }
+
+    @Test
+    fun `unescape decodes common named entities`() {
+        assertEquals(
+            "a & b < c > d \"e\" 'f'",
+            HtmlEntityUtils.unescape("a &amp; b &lt; c &gt; d &quot;e&quot; &apos;f&apos;")
+        )
+    }
+
+    @Test
+    fun `unescape decodes decimal and hex numeric entities`() {
+        assertEquals("'$", HtmlEntityUtils.unescape("&#39;&#36;"))
+        assertEquals("★", HtmlEntityUtils.unescape("&#9733;"))
+        assertEquals("★", HtmlEntityUtils.unescape("&#x2605;"))
+    }
+
+    @Test
+    fun `unescape decodes supplementary code points as surrogate pairs`() {
+        assertEquals("😀", HtmlEntityUtils.unescape("&#x1F600;"))
+    }
+
+    @Test
+    fun `unescape leaves plain text and emote shortcodes untouched`() {
+        assertEquals("hello [doge] 世界", HtmlEntityUtils.unescape("hello [doge] 世界"))
+    }
+
+    @Test
+    fun `unescape leaves lone ampersand and unknown entities untouched`() {
+        assertEquals("AT&T", HtmlEntityUtils.unescape("AT&T"))
+        assertEquals("a &unknown; b", HtmlEntityUtils.unescape("a &unknown; b"))
+    }
+
+    @Test
+    fun `unescape returns empty string for empty input`() {
+        assertEquals("", HtmlEntityUtils.unescape(""))
+    }
+}


### PR DESCRIPTION
## What

为评论正文解析增加 HTML 实体反转义，避免 UI 直接显示 `&#39` 等字面量。

- 新增 `core/util/HtmlEntityUtils`：纯 Kotlin、无 Android 依赖的轻量反转义工具。
- `CommentGrpcRepository.parseContent` 解析 `message` 时调用 `unescape`。
- `ReplyContent.message` 通过 `UnescapedStringSerializer` 在反序列化时反转义。
- 新增 `HtmlEntityUtilsTest` 单元测试。

## Why

修复 #583。B 站评论接口返回的 `message` 把特殊字符编码为 HTML 实体（`'` → `&#39;`、`"` → `&quot;`、`&` → `&amp;`），此前解析时未反转义，评论区直接显示实体字面量（如 `&#39`）。

## How

- `HtmlEntityUtils.unescape` 覆盖命名实体（`&amp; &lt; &gt; &quot; &apos; &nbsp;`）与十进制/十六进制数字实体（`&#39;` `&#x2605;` `&#x1F600;`），数字实体兼容省略末尾分号；无法识别的 `&...` 序列原样保留，对普通文本安全（含 emoji 代理对）。
- 两条评论数据路径分别覆盖：
  - gRPC 路径直接构造 `ReplyContent`、不经反序列化 → 在 `parseContent` 手动 `unescape`（覆盖 MainList/DetailList/DialogList）。
  - REST/JSON 路径经 kotlinx.serialization 反序列化 → `UnescapedStringSerializer` 在 `deserialize` 时 `unescape`，覆盖视频/番剧/动态/消息等所有消费方。
  - 两条路径各自由对应改动覆盖，不会重复反转义。
- 遵循 AGENTS.md「优先小而聚焦的改动」与 STRUCTURE_GUIDELINES：工具下沉 `core/util`，序列化器放 `data/model/response`，依赖方向 `data -> core` 正确；`UnescapedStringSerializer` 与仓库既有 `FlexibleStringSerializer` 等同模式。

## Testing

- 单元测试：`HtmlEntityUtilsTest` 覆盖 `&#39;`/`&#39`（#583 场景）、命名实体、十进制/十六进制/大写十六进制、emoji 代理对、nbsp、无分号命名实体、真实混合评论、普通文本/表情 shortcode、未知实体、空输入等边界。
- 覆盖率：预期覆盖 `HtmlEntityUtils` 全部分支（`unescape`/`decodeToken`/`codePointToString`/命名表/`#x`/`#X`/`#`/else）。
- Lint / 测试运行状态：**本机未安装 JDK，未本地运行** `./gradlew :app:lintDebug` / `:app:testDebugUnitTest` / 覆盖率工具。改动均为最小化、常规写法，并附聚焦单测，烦请 CI 复核；如 CI 报错我会立即跟进修复。
- 未做设备端验证（评论数据依赖登录态与网络）。

## Related Issues

Closes #583
