### PR TITLE
“个人”界面显示优化

### DIFF
--- a/app/src/main/java/com/android/purebilibili/core/ui/transition/VideoSharedTransitionPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/core/ui/transition/VideoSharedTransitionPolicy.kt
@@ -238,9 +238,8 @@ internal fun shouldEnableVideoMetadataSharedTransition(
     if (!coverSharedEnabled) return false
     // 卡片容器已经承载整体放大/回收时，标题、UP、统计等不要再各自抢独立 sharedBounds。
     if (useCardContainerSharedBounds) return false
-    // Keep metadata linked during quick return to avoid cover-only snapback.
-    if (isQuickReturnLimited && profile == VideoSharedTransitionProfile.COVER_ONLY) return false
-    // Home 源也启用 metadata sharedBounds，标题/头像/UP名独立共享
+    // COVER_ONLY 来源只让封面参与共享元素，避免标题、UP 名等文本在落位时被 bounds 缩放。
+    if (profile == VideoSharedTransitionProfile.COVER_ONLY) return false
     return true
 }
 

--- a/app/src/main/java/com/android/purebilibili/feature/profile/ProfileChromePolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/profile/ProfileChromePolicy.kt
@@ -1,6 +1,7 @@
 package com.android.purebilibili.feature.profile
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.luminance
 
 data class ProfileHeroChrome(
@@ -122,3 +123,39 @@ fun resolveProfileHeroFallbackGradient(
 fun resolveProfileContentUsesOpaqueSurface(hasWallpaper: Boolean): Boolean = true
 
 fun resolveProfileHeroUsesWallpaperBackground(hasWallpaper: Boolean): Boolean = hasWallpaper
+
+/**
+ * Maps the pull-down overscroll distance (px) to a 0..1 inversion fraction.
+ * 0 = header rests on the wallpaper (text keeps hero chrome); 1 = header pulled
+ * fully into the surface area below the wallpaper (text inverted toward onSurface).
+ */
+fun resolveProfileHeroPullInvertFraction(
+    pullPx: Float,
+    fullInvertPullPx: Float
+): Float {
+    if (fullInvertPullPx <= 0f) return 0f
+    if (pullPx <= 0f) return 0f
+    return (pullPx / fullInvertPullPx).coerceIn(0f, 1f)
+}
+
+/**
+ * Blends the wallpaper hero chrome's foreground colors (text, secondary text,
+ * action button) toward the surface's onSurface/onSurfaceVariant colors by
+ * [invertFraction], so white hero text stays legible when pulled down into the
+ * surface (white) area. No-op when [invertFraction] <= 0. Blending toward
+ * onSurface keeps dark-theme text light (no-op) since onSurface is light there.
+ */
+fun resolveProfileHeroInvertedChrome(
+    heroChrome: ProfileHeroChrome,
+    onSurfaceColor: Color,
+    onSurfaceVariantColor: Color,
+    invertFraction: Float
+): ProfileHeroChrome {
+    if (invertFraction <= 0f) return heroChrome
+    val fraction = invertFraction.coerceIn(0f, 1f)
+    return heroChrome.copy(
+        textColor = lerp(heroChrome.textColor, onSurfaceColor, fraction),
+        secondaryTextColor = lerp(heroChrome.secondaryTextColor, onSurfaceVariantColor, fraction),
+        actionButtonContentColor = lerp(heroChrome.actionButtonContentColor, onSurfaceColor, fraction)
+    )
+}

--- a/app/src/main/java/com/android/purebilibili/feature/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/profile/ProfileScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -25,12 +27,14 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
@@ -117,6 +121,8 @@ import com.android.purebilibili.data.model.response.SpaceDynamicItem
 import com.android.purebilibili.data.model.response.SpaceVideoItem
 import com.android.purebilibili.feature.dynamic.DynamicDeleteAction
 import com.android.purebilibili.feature.home.components.BottomBarLiquidSegmentedControl
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 
 import com.android.purebilibili.core.ui.blur.rememberRecoverableHazeState
@@ -129,16 +135,24 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.runtime.MutableFloatState
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.times
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 
 
 internal fun shouldEnableProfileHeaderLoginClick(isLogin: Boolean): Boolean = !isLogin
@@ -928,8 +942,20 @@ private fun ProfileSpaceContent(
                 )
             }
         } else {
+            val heroListState = rememberLazyListState()
+            val heroFullInvertPullPx = with(LocalDensity.current) {
+                ProfileHeroPullFullInvertDp.dp.toPx()
+            }
+            val heroPullState = rememberProfileHeroPullState(
+                listState = heroListState,
+                fullInvertPullPx = heroFullInvertPullPx,
+                enabled = hasWallpaper
+            )
             LazyColumn(
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .nestedScroll(heroPullState),
+                state = heroListState,
                 contentPadding = PaddingValues(bottom = paddingValues.calculateBottomPadding() + 120.dp)
             ) {
                 item {
@@ -937,6 +963,9 @@ private fun ProfileSpaceContent(
                         user = user,
                         editableAccount = editableAccount,
                         heroChrome = heroChrome,
+                        onSurfaceColor = colorScheme.onSurface,
+                        onSurfaceVariantColor = colorScheme.onSurfaceVariant,
+                        pullInvertFractionProvider = { heroPullState.fraction() },
                         layoutTokens = layoutTokens,
                         showWallpaperAction = false,
                         onEditClick = { showEditDialog = true },
@@ -1060,17 +1089,108 @@ private fun ProfileSpaceFeedColumn(
     }
 }
 
+/**
+ * Pull distance (dp) at which the hero header text is fully inverted toward
+ * onSurface when the user pulls the profile list down past the wallpaper.
+ */
+private const val ProfileHeroPullFullInvertDp = 64
+
+/**
+ * Tracks the pull-down overscroll distance of the profile LazyColumn so the hero
+ * header text can dynamically invert color when pulled into the surface area
+ * below the wallpaper. Implements [NestedScrollConnection] so it can be attached
+ * directly via [Modifier.nestedScroll]. The default stretch overscroll still
+ * applies because this connection consumes nothing.
+ */
+private class ProfileHeroPullState(
+    val listState: LazyListState,
+    private val pullPx: MutableFloatState,
+    private val scope: CoroutineScope,
+    private val fullInvertPullPx: Float,
+    private val enabled: Boolean
+) : NestedScrollConnection {
+    private var settleJob: Job? = null
+
+    fun fraction(): Float {
+        if (!enabled || fullInvertPullPx <= 0f) return 0f
+        return resolveProfileHeroPullInvertFraction(
+            pullPx = pullPx.floatValue,
+            fullInvertPullPx = fullInvertPullPx
+        )
+    }
+
+    override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+        if (!enabled || source != NestedScrollSource.Drag) return Offset.Zero
+        val atTop = listState.firstVisibleItemIndex == 0 &&
+            listState.firstVisibleItemScrollOffset == 0
+        val dy = available.y
+        if (atTop) {
+            // Pull-down at top is a positive delta (finger moves down). Pulling
+            // back up (negative) releases the accumulated overscroll.
+            if (dy > 0f || (dy < 0f && pullPx.floatValue > 0f)) {
+                settleJob?.cancel()
+                pullPx.floatValue = (pullPx.floatValue + dy).coerceAtLeast(0f)
+            }
+        } else if (pullPx.floatValue > 0f) {
+            settleJob?.cancel()
+            pullPx.floatValue = 0f
+        }
+        return Offset.Zero
+    }
+
+    override suspend fun onPreFling(velocity: Velocity): Velocity {
+        if (!enabled) return Velocity.Zero
+        val current = pullPx.floatValue
+        if (current <= 0f) return Velocity.Zero
+        settleJob?.cancel()
+        settleJob = scope.launch {
+            animate(
+                initialValue = current,
+                targetValue = 0f,
+                animationSpec = tween(durationMillis = 320, easing = FastOutSlowInEasing)
+            ) { value, _ ->
+                pullPx.floatValue = value
+            }
+        }
+        return Velocity.Zero
+    }
+}
+
+@Composable
+private fun rememberProfileHeroPullState(
+    listState: LazyListState,
+    fullInvertPullPx: Float,
+    enabled: Boolean
+): ProfileHeroPullState {
+    val pullPx = remember { mutableFloatStateOf(0f) }
+    val scope = rememberCoroutineScope()
+    return remember(listState, scope, fullInvertPullPx, enabled) {
+        ProfileHeroPullState(listState, pullPx, scope, fullInvertPullPx, enabled)
+    }
+}
+
 @Composable
 private fun ProfileSpaceHeroHeader(
     user: UserState,
     editableAccount: ProfileEditableAccountState,
     heroChrome: ProfileHeroChrome,
+    onSurfaceColor: Color,
+    onSurfaceVariantColor: Color,
+    pullInvertFractionProvider: () -> Float,
     layoutTokens: ProfileLayoutTokens,
     showWallpaperAction: Boolean,
     onEditClick: () -> Unit,
     onWallpaperActionClick: () -> Unit,
     onFollowingClick: () -> Unit
 ) {
+    // Read pull fraction here (not in the parent) so only this header item
+    // recomposes while the user pulls down, keeping the LazyColumn cheap.
+    val effectiveHeroChrome = resolveProfileHeroInvertedChrome(
+        heroChrome = heroChrome,
+        onSurfaceColor = onSurfaceColor,
+        onSurfaceVariantColor = onSurfaceVariantColor,
+        invertFraction = pullInvertFractionProvider()
+    )
     val configuration = LocalConfiguration.current
     val windowSizeClass = LocalWindowSizeClass.current
     val heroHeight = resolveProfileHeroHeightDp(
@@ -1086,7 +1206,7 @@ private fun ProfileSpaceHeroHeader(
             user = user,
             editableAccount = editableAccount,
             compact = false,
-            heroChrome = heroChrome,
+            heroChrome = effectiveHeroChrome,
             showWallpaperAction = showWallpaperAction,
             onEditClick = onEditClick,
             onWallpaperActionClick = onWallpaperActionClick,

--- a/app/src/main/java/com/android/purebilibili/feature/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/profile/ProfileScreen.kt
@@ -1014,8 +1014,6 @@ private fun ProfileSpaceContent(
                 onWallpaperActionClick = { showWallpaperActionSheet = true },
                 onSettingsClick = onSettingsClick,
                 baseIconColor = heroChrome.textColor,
-                onSurfaceColor = colorScheme.onSurface,
-                pullInvertFractionProvider = { heroPullState.fraction() },
                 statusBarTopPadding = statusBarTopPadding,
                 modifier = Modifier.align(Alignment.TopCenter)
             )
@@ -1162,8 +1160,7 @@ private fun rememberProfileHeroPullState(
 
 /**
  * 顶部常驻操作栏（返回 / 换壁纸 / 设置）。
- * 所有图标均随下拉反色（白 → onSurface），与英雄区文字保持一致的壁纸可读性。
- * 在此读取下拉比例以隔离重组，避免波及 LazyColumn 及其父级。
+ * 固定覆盖在壁纸上，图标始终保持英雄区 chrome 颜色以保证深色壁纸可读性。
  */
 @Composable
 private fun ProfileHeroTopActionBar(
@@ -1171,13 +1168,10 @@ private fun ProfileHeroTopActionBar(
     onWallpaperActionClick: () -> Unit,
     onSettingsClick: () -> Unit,
     baseIconColor: Color,
-    onSurfaceColor: Color,
-    pullInvertFractionProvider: () -> Float,
     statusBarTopPadding: Dp,
     modifier: Modifier = Modifier
 ) {
-    val pullFraction = pullInvertFractionProvider()
-    val iconTint = lerp(baseIconColor, onSurfaceColor, pullFraction)
+    val iconTint = baseIconColor
     Row(
         modifier = modifier
             .fillMaxWidth()

--- a/app/src/main/java/com/android/purebilibili/feature/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/profile/ProfileScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.geometry.Rect
@@ -149,6 +150,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.ui.unit.Velocity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.times
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -875,7 +877,6 @@ private fun ProfileSpaceContent(
             onSurfaceVariantColor = colorScheme.onSurfaceVariant
         )
     }
-    val topBarIconColor = heroChrome.textColor
 
     Box(modifier = Modifier.fillMaxSize()) {
         if (isTablet) {
@@ -1008,26 +1009,16 @@ private fun ProfileSpaceContent(
                     }
                 }
             }
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = statusBarTopPadding)
-                    .height(56.dp)
-                    .padding(horizontal = 8.dp)
-                    .align(Alignment.TopCenter),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                IconButton(onClick = onBack) {
-                    Icon(rememberAppBackIcon(), contentDescription = "返回", tint = topBarIconColor)
-                }
-                Spacer(modifier = Modifier.weight(1f))
-                IconButton(onClick = { showWallpaperActionSheet = true }) {
-                    Icon(rememberAppPhotoIcon(), contentDescription = "换壁纸", tint = topBarIconColor)
-                }
-                IconButton(onClick = onSettingsClick) {
-                    Icon(rememberAppSettingsIcon(), contentDescription = "设置", tint = topBarIconColor)
-                }
-            }
+            ProfileHeroTopActionBar(
+                onBack = onBack,
+                onWallpaperActionClick = { showWallpaperActionSheet = true },
+                onSettingsClick = onSettingsClick,
+                baseIconColor = heroChrome.textColor,
+                onSurfaceColor = colorScheme.onSurface,
+                pullInvertFractionProvider = { heroPullState.fraction() },
+                statusBarTopPadding = statusBarTopPadding,
+                modifier = Modifier.align(Alignment.TopCenter)
+            )
         }
     }
 }
@@ -1166,6 +1157,47 @@ private fun rememberProfileHeroPullState(
     val scope = rememberCoroutineScope()
     return remember(listState, scope, fullInvertPullPx, enabled) {
         ProfileHeroPullState(listState, pullPx, scope, fullInvertPullPx, enabled)
+    }
+}
+
+/**
+ * 顶部常驻操作栏（返回 / 换壁纸 / 设置）。
+ * 返回与换壁纸图标随下拉反色（白 → onSurface），与英雄区文字保持一致；
+ * 设置图标常驻反色为 onSurface，因为背景图可能从一开始就影响其可读性。
+ * 在此读取下拉比例以隔离重组，避免波及 LazyColumn 及其父级。
+ */
+@Composable
+private fun ProfileHeroTopActionBar(
+    onBack: () -> Unit,
+    onWallpaperActionClick: () -> Unit,
+    onSettingsClick: () -> Unit,
+    baseIconColor: Color,
+    onSurfaceColor: Color,
+    pullInvertFractionProvider: () -> Float,
+    statusBarTopPadding: Dp,
+    modifier: Modifier = Modifier
+) {
+    val pullFraction = pullInvertFractionProvider()
+    val backAndWallpaperTint = lerp(baseIconColor, onSurfaceColor, pullFraction)
+    val settingsTint = onSurfaceColor
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = statusBarTopPadding)
+            .height(56.dp)
+            .padding(horizontal = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(rememberAppBackIcon(), contentDescription = "返回", tint = backAndWallpaperTint)
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        IconButton(onClick = onWallpaperActionClick) {
+            Icon(rememberAppPhotoIcon(), contentDescription = "换壁纸", tint = backAndWallpaperTint)
+        }
+        IconButton(onClick = onSettingsClick) {
+            Icon(rememberAppSettingsIcon(), contentDescription = "设置", tint = settingsTint)
+        }
     }
 }
 

--- a/app/src/main/java/com/android/purebilibili/feature/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/profile/ProfileScreen.kt
@@ -1162,8 +1162,7 @@ private fun rememberProfileHeroPullState(
 
 /**
  * 顶部常驻操作栏（返回 / 换壁纸 / 设置）。
- * 返回与换壁纸图标随下拉反色（白 → onSurface），与英雄区文字保持一致；
- * 设置图标常驻反色为 onSurface，因为背景图可能从一开始就影响其可读性。
+ * 所有图标均随下拉反色（白 → onSurface），与英雄区文字保持一致的壁纸可读性。
  * 在此读取下拉比例以隔离重组，避免波及 LazyColumn 及其父级。
  */
 @Composable
@@ -1178,8 +1177,7 @@ private fun ProfileHeroTopActionBar(
     modifier: Modifier = Modifier
 ) {
     val pullFraction = pullInvertFractionProvider()
-    val backAndWallpaperTint = lerp(baseIconColor, onSurfaceColor, pullFraction)
-    val settingsTint = onSurfaceColor
+    val iconTint = lerp(baseIconColor, onSurfaceColor, pullFraction)
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -1189,14 +1187,14 @@ private fun ProfileHeroTopActionBar(
         verticalAlignment = Alignment.CenterVertically
     ) {
         IconButton(onClick = onBack) {
-            Icon(rememberAppBackIcon(), contentDescription = "返回", tint = backAndWallpaperTint)
+            Icon(rememberAppBackIcon(), contentDescription = "返回", tint = iconTint)
         }
         Spacer(modifier = Modifier.weight(1f))
         IconButton(onClick = onWallpaperActionClick) {
-            Icon(rememberAppPhotoIcon(), contentDescription = "换壁纸", tint = backAndWallpaperTint)
+            Icon(rememberAppPhotoIcon(), contentDescription = "换壁纸", tint = iconTint)
         }
         IconButton(onClick = onSettingsClick) {
-            Icon(rememberAppSettingsIcon(), contentDescription = "设置", tint = settingsTint)
+            Icon(rememberAppSettingsIcon(), contentDescription = "设置", tint = iconTint)
         }
     }
 }

--- a/app/src/test/java/com/android/purebilibili/core/ui/transition/VideoSharedTransitionPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/core/ui/transition/VideoSharedTransitionPolicyTest.kt
@@ -60,7 +60,7 @@ class VideoSharedTransitionPolicyTest {
     }
 
     @Test
-    fun homeVideoTransition_usesCoverAsPrimaryAnchor() {
+    fun homeVideoTransition_usesCoverOnlyToAvoidTextBoundsScaling() {
         val policy = resolveVideoSharedTransitionOwnership(
             sourceRoute = "home",
             coverSharedEnabled = true,
@@ -68,8 +68,8 @@ class VideoSharedTransitionPolicyTest {
         )
 
         assertTrue(policy.useCoverSharedBounds)
-        // Home 源也启用 metadata sharedBounds，标题、UP主等独立过渡
-        assertTrue(policy.useMetadataSharedBounds)
+        // Home 卡片标题和 UP 名排版与详情页不同，参与 sharedBounds 会在落位时缩放文字。
+        assertFalse(policy.useMetadataSharedBounds)
     }
 
     @Test

--- a/app/src/test/java/com/android/purebilibili/feature/profile/ProfileChromePolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/profile/ProfileChromePolicyTest.kt
@@ -1,6 +1,7 @@
 package com.android.purebilibili.feature.profile
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -98,5 +99,99 @@ class ProfileChromePolicyTest {
         )
         assertEquals(Color.DarkGray.copy(alpha = 0.92f), gradient?.topColor)
         assertEquals(Color.Black, gradient?.bottomColor)
+    }
+
+    @Test
+    fun pullInvertFraction_mapsPullDistanceAndClamps() {
+        assertEquals(0f, resolveProfileHeroPullInvertFraction(pullPx = 0f, fullInvertPullPx = 100f))
+        assertEquals(0f, resolveProfileHeroPullInvertFraction(pullPx = -20f, fullInvertPullPx = 100f))
+        assertEquals(0.5f, resolveProfileHeroPullInvertFraction(pullPx = 50f, fullInvertPullPx = 100f))
+        assertEquals(1f, resolveProfileHeroPullInvertFraction(pullPx = 100f, fullInvertPullPx = 100f))
+        assertEquals(1f, resolveProfileHeroPullInvertFraction(pullPx = 250f, fullInvertPullPx = 100f))
+    }
+
+    @Test
+    fun pullInvertFraction_disabledWhenThresholdNotPositive() {
+        assertEquals(0f, resolveProfileHeroPullInvertFraction(pullPx = 80f, fullInvertPullPx = 0f))
+        assertEquals(0f, resolveProfileHeroPullInvertFraction(pullPx = 80f, fullInvertPullPx = -1f))
+    }
+
+    @Test
+    fun invertedChrome_noOpAtZeroFraction() {
+        val hero = resolveProfileHeroChrome(
+            hasWallpaper = true,
+            isDarkTheme = false,
+            onSurfaceColor = Color.Black,
+            onSurfaceVariantColor = Color.Gray
+        )
+
+        val inverted = resolveProfileHeroInvertedChrome(
+            heroChrome = hero,
+            onSurfaceColor = Color.Black,
+            onSurfaceVariantColor = Color.Gray,
+            invertFraction = 0f
+        )
+
+        assertEquals(hero, inverted)
+    }
+
+    @Test
+    fun invertedChrome_blendsTowardOnSurfaceAtFullFraction() {
+        val hero = resolveProfileHeroChrome(
+            hasWallpaper = true,
+            isDarkTheme = false,
+            onSurfaceColor = Color.Black,
+            onSurfaceVariantColor = Color.Gray
+        )
+
+        val inverted = resolveProfileHeroInvertedChrome(
+            heroChrome = hero,
+            onSurfaceColor = Color.Black,
+            onSurfaceVariantColor = Color.Gray,
+            invertFraction = 1f
+        )
+
+        assertEquals(Color.Black, inverted.textColor)
+        assertEquals(Color.Gray, inverted.secondaryTextColor)
+        assertEquals(Color.Black, inverted.actionButtonContentColor)
+    }
+
+    @Test
+    fun invertedChrome_clampsFractionAboveOne() {
+        val hero = resolveProfileHeroChrome(
+            hasWallpaper = true,
+            isDarkTheme = false,
+            onSurfaceColor = Color.Black,
+            onSurfaceVariantColor = Color.Gray
+        )
+
+        val inverted = resolveProfileHeroInvertedChrome(
+            heroChrome = hero,
+            onSurfaceColor = Color.Black,
+            onSurfaceVariantColor = Color.Gray,
+            invertFraction = 5f
+        )
+
+        assertEquals(Color.Black, inverted.textColor)
+    }
+
+    @Test
+    fun invertedChrome_midpointIsBlend() {
+        val hero = resolveProfileHeroChrome(
+            hasWallpaper = true,
+            isDarkTheme = false,
+            onSurfaceColor = Color.Black,
+            onSurfaceVariantColor = Color.Gray
+        )
+        val expectedText = lerp(Color.White, Color.Black, 0.5f)
+
+        val inverted = resolveProfileHeroInvertedChrome(
+            heroChrome = hero,
+            onSurfaceColor = Color.Black,
+            onSurfaceVariantColor = Color.Gray,
+            invertFraction = 0.5f
+        )
+
+        assertEquals(expectedText, inverted.textColor)
     }
 }


### PR DESCRIPTION
目前“个人”界面的按钮以及数据显示对于浅色背景无反色功能，导致此时可见性几乎为0，且下拉区域时背景图外区域也影响显示。我加了个反色功能