### PR TITLE
fix(player): 继续修复 TextureView 导致 HDR 视频只能以 SDR 渲染到屏幕

### DIFF
--- a/app/src/main/res/layout/view_player_texture.xml
+++ b/app/src/main/res/layout/view_player_texture.xml
@@ -3,4 +3,4 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    app:surface_type="texture_view" />
+    app:surface_type="surface_view" />


### PR DESCRIPTION
- 我构建的版本拉取自截止2026-07-23 1：30的仓库提交，构建了debug和smooth版，并安装在我的设备上进行测试，目前能够成功点亮HDR。我将继续使用smooth和9.9.8.8一段时间以查看是否有与之前版本不同的动效等发生变化（当然我更可能看不出来）。若无进一步pr则说明未发现重大问题。

## 问题
不管 WBI 还是 APP API 返回的 HDR 流，手机屏幕 HDR/SDR 亮度比始终为 1.00，HDR 视频实际按 SDR 显示。
## 根因

播放器布局 `view_player_texture.xml` 里 `PlayerView` 用了 `app:surface_type="texture_view"`。TextureView 把视频帧画到 GPU 纹理再走窗口合成，HDR 色彩元数据（SMPTE ST 2086、HDR10+）在合成阶段丢失。Android 上只有 SurfaceView 的独立硬件图层能把 HDR 信号传给屏幕。

## 修复

[view_player_texture.xml](app/src/main/res/layout/view_player_texture.xml) — 一行改动：

```diff
-    app:surface_type="texture_view" />
+    app:surface_type="surface_view" />
```

弹幕等 overlay 本来就在独立 Window 层，不受 SurfaceView 挖洞影响。

---

## 变更文件

| 文件 | + | - |
|------|---|---|
| `app/src/main/res/layout/view_player_texture.xml` | +1 | -1 |

---

## 测试

| 项目 | 详情 |
| :--- | :--- |
| 设备 | HONOR MEP-AN00, Android 16 |
| 账号 | 已登录，大会员有效 |
| 网络 | Wi-Fi |
| 版本 | 基于 origin/main 9.9.8.8 |

