### PR TITLE
fix(player): 修正HEVC视频流获取能力漏洞

### DIFF
--- a/app/src/main/java/com/android/purebilibili/data/model/VideoQuality.kt
+++ b/app/src/main/java/com/android/purebilibili/data/model/VideoQuality.kt
@@ -58,8 +58,16 @@ enum class VideoDecodeFormat(val codecs: String, val description: String) {
     AVC("avc1", "AVC");
 
     companion object {
-        fun fromCodecs(codecs: String): VideoDecodeFormat? = 
-            values().find { codecs.startsWith(it.codecs) }
+        fun fromCodecs(codecs: String): VideoDecodeFormat? {
+            val normalized = codecs.trim().lowercase()
+            return when {
+                normalized.startsWith("dvh1") -> DVH1
+                normalized.startsWith("av01") -> AV1
+                normalized.startsWith("hev") || normalized.startsWith("hvc") -> HEVC
+                normalized.startsWith("avc") -> AVC
+                else -> null
+            }
+        }
         
         // AVC 兼容性最好，优先选择
         val preferredOrder = listOf(AVC, HEVC, AV1, DVH1)

--- a/app/src/main/java/com/android/purebilibili/data/model/response/VideoResponse.kt
+++ b/app/src/main/java/com/android/purebilibili/data/model/response/VideoResponse.kt
@@ -247,11 +247,13 @@ private fun videoPlaybackSelectionScore(
     isAv1Supported: Boolean
 ): Int {
     var score = 0
-    val codecs = video.codecs.lowercase()
+    val codecFormat = VideoDecodeFormat.fromCodecs(video.codecs)
+    val preferredFormat = VideoDecodeFormat.fromCodecs(preferCodec)
+    val secondPreferredFormat = VideoDecodeFormat.fromCodecs(secondPreferCodec)
 
-    val isAvc = codecs.startsWith("avc")
-    val isHevc = codecs.startsWith("hev")
-    val isAv1 = codecs.startsWith("av01")
+    val isAvc = codecFormat == VideoDecodeFormat.AVC
+    val isHevc = codecFormat == VideoDecodeFormat.HEVC
+    val isAv1 = codecFormat == VideoDecodeFormat.AV1
 
     val supported = when {
         isAvc -> true
@@ -264,9 +266,9 @@ private fun videoPlaybackSelectionScore(
         return -100
     }
 
-    if (codecs.contains(preferCodec, ignoreCase = true)) {
+    if (preferredFormat != null && codecFormat == preferredFormat) {
         score += 10
-    } else if (secondPreferCodec.isNotBlank() && codecs.contains(secondPreferCodec, ignoreCase = true)) {
+    } else if (secondPreferredFormat != null && codecFormat == secondPreferredFormat) {
         score += 6
     }
 

--- a/app/src/main/java/com/android/purebilibili/feature/video/playback/policy/AdaptiveDashTrackPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/playback/policy/AdaptiveDashTrackPolicy.kt
@@ -81,7 +81,25 @@ fun buildAdaptiveDashTrackSet(
         is PlaybackQualityMode.LOCKED -> supportedVideos.filter { it.id == mode.qualityId }
     }
 
-    val sortedVideos = candidateVideos.sortedWith(
+    val codecSelectedVideos = candidateVideos
+        .groupBy { it.id }
+        .values
+        .flatMap { videosAtQuality ->
+            val preferredVideos = preferredCodec?.let { codec ->
+                videosAtQuality.filter { normalizeCodecFamilyKey(it.codecs) == codec }
+            }.orEmpty()
+            val secondaryVideos = secondaryCodec?.let { codec ->
+                videosAtQuality.filter { normalizeCodecFamilyKey(it.codecs) == codec }
+            }.orEmpty()
+
+            when {
+                preferredVideos.isNotEmpty() -> preferredVideos
+                secondaryVideos.isNotEmpty() -> secondaryVideos
+                else -> videosAtQuality
+            }
+        }
+
+    val sortedVideos = codecSelectedVideos.sortedWith(
         compareByDescending<DashVideo> { it.id }
             .thenByDescending { scoreCodecPreference(it.codecs, preferredCodec, secondaryCodec) }
             .thenByDescending { it.bandwidth }


### PR DESCRIPTION
## 问题

本机播放将首选编码设置为 HEVC、次选编码设置为 AV1 后，大部分同时提供 HEVC、AV1 和 AVC 视频流的视频仍会选择 AV1 或 AVC。此问题的本质是HEVC视频流获取漏洞，首选编码设置受该漏洞影响。

同一批首页随机推荐视频中，实际观察到 10 个视频里有 8 个选择 AV1、1 个选择 HEVC、1 个选择 AVC。设备为荣耀500pro，骁龙8至尊版具备 H.264、HEVC 和 AV1 硬件解码能力，因此问题并非设备缺少对应解码器。

## 根因

本机 DASH 视频流选择器仅通过 `codecs.startsWith("hev")` 识别 HEVC。Bilibili 返回 `hvc1` 编码标识时，该轨道会被当作未知或不支持的编码，获得 `-100` 的选择分数。

此外，首选编码匹配此前直接比较 `hev1` 字符串。即使只将 `hvc1` 纳入 HEVC 能力判断，`hvc1` 仍无法获得“首选 HEVC”的权重，次选 AV1 仍可能胜出。

`hev1` 与 `hvc1` 都属于 HEVC/H.265。二者主要区别在于参数集在封装中的存放方式，不应在编码族选择阶段被视为不同解码格式。

## 修复

- 将 `hev1` 和 `hvc1` 统一映射为 `VideoDecodeFormat.HEVC`。
- 视频流能力判断改为基于 `VideoDecodeFormat` 编码族。
- 首选和次选编码改为按编码族匹配，不再直接比较 codec 字符串。

修复后的预期行为：同一画质同时存在 `hvc1.*`、`av01.*` 和 `avc1.*`，且首选 HEVC、次选 AV1 时，应选择 `hvc1.*`。

---

## 实机测试

- 设备：荣耀 500 Pro（骁龙 8 至尊版）
- 编码偏好：首选 HEVC，次选 AV1
- 测试方式：首页随机播放 10 个推荐视频
- 测试结果：10 个视频均选择 HEVC 视频流

---

## 变更文件

| 文件 | 说明 |
| :--- | :--- |
| `app/src/main/java/com/android/purebilibili/data/model/VideoQuality.kt` | 补充 `hvc1` 到 HEVC 的编码族映射 |
| `app/src/main/java/com/android/purebilibili/data/model/response/VideoResponse.kt` | 按编码族进行能力判断和首选/次选编码评分 |