### PR TITLE
feat(cdn): 保留自定义规则并新增严格自定义 CDN 模式

### DIFF
--- a/app/src/main/java/com/android/purebilibili/feature/plugin/CdnRegionPlugin.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/plugin/CdnRegionPlugin.kt
@@ -599,15 +599,14 @@ class CdnRegionPlugin : PlaybackCdnPlugin {
                 location = location,
                 catalog = loadedCatalog
             )
-            val next = CdnRegionPluginCache(
+            val next = current.copy(
                 location = location,
                 selectedRegion = selection.region,
                 selectedHosts = selection.hosts,
                 fallbackRegion = "",
                 fallbackUsed = selection.fallbackUsed,
                 refreshedAtMs = System.currentTimeMillis(),
-                lastError = null,
-                healthByHost = current.healthByHost
+                lastError = null
             )
             cache = next
             CdnRegionPluginStore.write(context, next)

--- a/app/src/main/java/com/android/purebilibili/feature/plugin/CdnRegionPlugin.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/plugin/CdnRegionPlugin.kt
@@ -153,10 +153,14 @@ class CdnRegionPlugin : PlaybackCdnPlugin {
             isp = snapshot.location.isp
         )
         val regionCandidates = rewritePlaybackCdnCandidatesForRegion(originalCandidates, hosts)
-        val candidates = (customCandidates + regionCandidates + originalCandidates)
-            .distinctBy { it.videoUrl to it.audioUrl }
         return PlaybackCdnRewriteResult(
-            candidates = sortPlaybackCdnCandidatesByHealth(candidates, snapshot.healthByHost),
+            candidates = selectPlaybackCdnCandidatesForMode(
+                customCandidates = customCandidates,
+                regionCandidates = regionCandidates,
+                originalCandidates = originalCandidates,
+                strictCustomCdn = snapshot.strictCustomCdn,
+                healthByHost = snapshot.healthByHost
+            ),
             regionLabel = snapshot.selectedRegion.takeIf { hosts.isNotEmpty() }
         )
     }
@@ -223,6 +227,7 @@ class CdnRegionPlugin : PlaybackCdnPlugin {
         var catalogSnapshot by remember { mutableStateOf(catalog) }
         var probing by remember { mutableStateOf(false) }
         var customRules by remember(snapshot.customRules) { mutableStateOf(snapshot.customRules) }
+        var strictCustomCdn by remember(snapshot.strictCustomCdn) { mutableStateOf(snapshot.strictCustomCdn) }
         var customRuleError by remember { mutableStateOf<String?>(null) }
 
         LaunchedEffect(Unit) {
@@ -296,7 +301,24 @@ class CdnRegionPlugin : PlaybackCdnPlugin {
                 color = MaterialTheme.colorScheme.onSurface
             )
             Text(
-                text = "规则按顺序匹配完整播放 URL，仅应用首条命中规则。替换结果必须是 HTTPS 且指向 B 站或当前候选 CDN；失败时会自动回退原始线路。",
+                text = "规则按顺序匹配完整播放 URL，仅应用首条命中规则。替换结果必须是 HTTPS 且指向 B 站或当前候选 CDN。",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = "严格使用自定义 CDN",
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Switch(
+                    checked = strictCustomCdn,
+                    onCheckedChange = { strictCustomCdn = it }
+                )
+            }
+            Text(
+                text = "开启后，只要有自定义规则成功生成播放地址，就不再加入属地和原始线路；没有规则命中时仍会自动回退，避免无法播放。",
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
@@ -343,7 +365,10 @@ class CdnRegionPlugin : PlaybackCdnPlugin {
                     if (error != null) {
                         customRuleError = error
                     } else {
-                        val next = snapshot.copy(customRules = customRules)
+                        val next = snapshot.copy(
+                            customRules = customRules,
+                            strictCustomCdn = strictCustomCdn
+                        )
                         snapshot = next
                         cache = next
                         compiledCustomRules = compileCdnCustomRules(next.customRules)
@@ -635,7 +660,8 @@ internal data class CdnRegionPluginCache(
     val refreshedAtMs: Long = 0L,
     val lastError: String? = null,
     val healthByHost: Map<String, CdnCandidateHealth> = emptyMap(),
-    val customRules: List<CdnCustomRule> = emptyList()
+    val customRules: List<CdnCustomRule> = emptyList(),
+    val strictCustomCdn: Boolean = false
 )
 
 internal object CdnRegionPluginStore {

--- a/app/src/main/java/com/android/purebilibili/feature/plugin/CdnRegionPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/plugin/CdnRegionPolicy.kt
@@ -283,6 +283,24 @@ private fun isAllowedCustomCdnUrl(url: String, allowedHosts: Set<String>): Boole
         (host == "bilivideo.com" || host.endsWith(".bilivideo.com") || host in allowedHosts)
 }
 
+internal fun selectPlaybackCdnCandidatesForMode(
+    customCandidates: List<PlaybackCdnCandidate>,
+    regionCandidates: List<PlaybackCdnCandidate>,
+    originalCandidates: List<PlaybackCdnCandidate>,
+    strictCustomCdn: Boolean,
+    healthByHost: Map<String, CdnCandidateHealth>
+): List<PlaybackCdnCandidate> {
+    val candidates = if (strictCustomCdn && customCandidates.isNotEmpty()) {
+        customCandidates
+    } else {
+        customCandidates + regionCandidates + originalCandidates
+    }
+    return sortPlaybackCdnCandidatesByHealth(
+        candidates = candidates.distinctBy { it.videoUrl to it.audioUrl },
+        healthByHost = healthByHost
+    )
+}
+
 internal fun sortPlaybackCdnCandidatesByHealth(
     candidates: List<PlaybackCdnCandidate>,
     healthByHost: Map<String, CdnCandidateHealth>

--- a/app/src/test/java/com/android/purebilibili/feature/plugin/CdnStrictCustomModeTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/plugin/CdnStrictCustomModeTest.kt
@@ -1,0 +1,56 @@
+package com.android.purebilibili.feature.plugin
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CdnStrictCustomModeTest {
+    private val originalCandidates = buildPlaybackCdnCandidates(
+        videoUrls = listOf("https://original.bilivideo.com/video.m4s?token=1"),
+        audioUrls = listOf("https://original.bilivideo.com/audio.m4s?token=1")
+    )
+
+    private val customCandidates = rewritePlaybackCdnCandidatesForCustomRules(
+        candidates = originalCandidates,
+        rules = listOf(
+            CdnCustomRule(
+                pattern = "original\\.bilivideo\\.com",
+                replacement = "upos-sz-mirroralib.bilivideo.com"
+            )
+        )
+    )
+
+    private val regionCandidates = rewritePlaybackCdnCandidatesForRegion(
+        candidates = originalCandidates,
+        preferredHosts = listOf("upos-sz-mirrorcosov.bilivideo.com")
+    )
+
+    @Test
+    fun `strict mode returns only rewritten custom candidates`() {
+        val selected = selectPlaybackCdnCandidatesForMode(
+            customCandidates = customCandidates,
+            regionCandidates = regionCandidates,
+            originalCandidates = originalCandidates,
+            strictCustomCdn = true,
+            healthByHost = emptyMap()
+        )
+
+        assertEquals(1, selected.size)
+        assertTrue(selected.all { it.source == PlaybackCdnCandidateSource.CUSTOM })
+        assertEquals("upos-sz-mirroralib.bilivideo.com", hostFromCdnUrl(selected.single().videoUrl))
+    }
+
+    @Test
+    fun `strict mode falls back when no custom rule produced a candidate`() {
+        val selected = selectPlaybackCdnCandidatesForMode(
+            customCandidates = emptyList(),
+            regionCandidates = regionCandidates,
+            originalCandidates = originalCandidates,
+            strictCustomCdn = true,
+            healthByHost = emptyMap()
+        )
+
+        assertTrue(selected.any { it.source == PlaybackCdnCandidateSource.REGION })
+        assertTrue(selected.any { it.source == PlaybackCdnCandidateSource.ORIGINAL })
+    }
+}


### PR DESCRIPTION
## 改动说明

本 PR 改进了「CDN 属地优选」插件中的自定义 CDN 功能，包含两个相互依赖的提交：

1. 修复 IP 属地刷新后自定义规则可能被重置的问题
2. 新增「严格使用自定义 CDN」模式

## 问题背景

### IP 属地刷新可能重置用户配置

原有实现中，IP 属地刷新成功后会重新创建 `CdnRegionPluginCache`。

由于新对象没有继承已有的用户配置，以下字段可能恢复为默认值：

- `customRules` 被重置为空列表
- `strictCustomCdn` 被重置为关闭状态

这会导致用户已经保存的自定义 URL 替换规则消失，或者严格模式在刷新后自动关闭。

### 自定义 CDN 无法真正固定播放线路

原有实现会把自定义规则生成的地址加入候选列表，但最终候选中仍然包含：

- 自定义 CDN 候选
- 属地优选 CDN 候选
- 原始播放地址

因此，即使用户已经指定了一个经过实际测试、连接稳定的 CDN，播放器仍可能选择或回退到其他线路，无法真正固定使用自定义 CDN。

## 修改内容

### 1. 保留用户配置

IP 属地刷新成功后，改为基于当前缓存执行：

```kotlin
current.copy(...)
```

只更新 IP 属地相关字段，并保留现有的：

- 自定义 URL 替换规则
- 严格自定义 CDN 开关状态
- CDN 健康状态
- 未来可能新增的其他缓存字段

### 2. 新增严格自定义 CDN 模式

在 CDN 属地优选设置中新增「严格使用自定义 CDN」开关。

当严格模式开启，且至少有一条自定义规则成功生成有效播放地址时：

- 仅保留自定义 CDN 候选
- 不再混入属地优选 CDN
- 不再混入原始播放地址

当没有任何自定义规则命中时，仍然使用属地候选和原始候选作为回退，避免由于规则配置错误而导致视频完全无法播放。

## 行为说明

| 严格模式 | 存在有效自定义候选 | 最终候选 |
| --- | --- | --- |
| 关闭 | 是 | 自定义候选 + 属地候选 + 原始候选 |
| 关闭 | 否 | 属地候选 + 原始候选 |
| 开启 | 是 | 仅自定义候选 |
| 开启 | 否 | 属地候选 + 原始候选 |

## 使用场景

部分网络环境下，自动分配的 CDN 可能存在持续下载速度不足、频繁卡顿或晚高峰不稳定等问题。

用户在实际测试后确认某个 CDN 更适合当前网络时，可以通过自定义 URL 规则指定该节点，并开启严格模式，避免播放器再次切换或回退到其他较慢线路。

## 验证情况

相关实现此前已在合并测试分支中完成构建和功能验证。

当前分支已确认：

- IP 属地刷新使用 `current.copy(...)`
- `customRules` 和 `strictCustomCdn` 会在刷新后保留
- 严格模式在存在自定义候选时仅返回自定义候选
- 没有自定义候选时仍可正常回退
- 已添加严格模式候选选择相关单元测试

本次整理后未重新运行 Gradle 测试。