### PR TITLE
fix(player): 修复偶发的CDN fallback导致视频编码意外降级

### DIFF
--- a/app/src/main/java/com/android/purebilibili/feature/video/state/PlayerErrorRecoveryPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/state/PlayerErrorRecoveryPolicy.kt
@@ -27,7 +27,7 @@ internal fun decidePlayerErrorRecovery(
         }
     } else {
         when {
-            isDecoderLikeFailure && retryCount < 1 -> PlayerErrorRecoveryAction.RETRY_DECODER_FALLBACK
+            isDecoderLikeFailure && retryCount < 2 -> PlayerErrorRecoveryAction.RETRY_DECODER_FALLBACK
             retryCount < 1 -> PlayerErrorRecoveryAction.RETRY_NON_NETWORK
             else -> PlayerErrorRecoveryAction.GIVE_UP
         }

--- a/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/VideoCodecSessionPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/VideoCodecSessionPolicy.kt
@@ -1,5 +1,8 @@
 package com.android.purebilibili.feature.video.viewmodel
 
+import com.android.purebilibili.data.model.response.DashVideo
+import java.net.URI
+
 internal const val AVC_CODEC_KEY = "avc1"
 internal const val AV1_CODEC_KEY = "av01"
 internal const val HEVC_CODEC_KEY = "hev1"
@@ -32,9 +35,78 @@ internal fun resolveEffectiveVideoCodecPreference(
     }
 }
 
+internal fun resolveEffectiveVideoSecondCodecPreference(
+    requestCodecOverride: String?,
+    settingsSecondCodecPreference: String
+): String {
+    return if (normalizeCodecFamilyKey(requestCodecOverride) != null) {
+        AVC_CODEC_KEY
+    } else {
+        normalizeCodecFamilyKey(settingsSecondCodecPreference) ?: AVC_CODEC_KEY
+    }
+}
+
 internal fun resolveEffectiveAv1Support(
     deviceSupportsAv1: Boolean,
     sessionBlockedCodecs: Set<String>
 ): Boolean {
     return deviceSupportsAv1 && AV1_CODEC_KEY !in sessionBlockedCodecs
+}
+
+internal fun resolveNextVideoCodecFallback(
+    failedCodec: String?,
+    secondaryCodecPreference: String,
+    isHevcSupported: Boolean,
+    isAv1Supported: Boolean
+): String? {
+    val normalizedFailedCodec = normalizeCodecFamilyKey(failedCodec)
+    return listOf(secondaryCodecPreference, AVC_CODEC_KEY)
+        .mapNotNull(::normalizeCodecFamilyKey)
+        .distinct()
+        .firstOrNull { candidate ->
+            candidate != normalizedFailedCodec && when (candidate) {
+                HEVC_CODEC_KEY -> isHevcSupported
+                AV1_CODEC_KEY -> isAv1Supported
+                AVC_CODEC_KEY -> true
+                else -> false
+            }
+        }
+}
+
+internal fun resolvePlaybackVideoCodec(
+    videoUrl: String,
+    cachedDashVideos: List<DashVideo>
+): String? {
+    if (videoUrl.isBlank()) return null
+    val selectedResource = playbackResourceIdentity(videoUrl)
+    val selectedVideo = cachedDashVideos.firstOrNull { video ->
+        video.playbackUrls().any { candidateUrl ->
+            candidateUrl == videoUrl ||
+                (
+                    selectedResource != null &&
+                        playbackResourceIdentity(candidateUrl) == selectedResource
+                    )
+        }
+    }
+    return normalizeCodecFamilyKey(selectedVideo?.codecs)
+}
+
+private fun DashVideo.playbackUrls(): List<String> {
+    return buildList {
+        if (baseUrl.isNotBlank()) {
+            add(baseUrl)
+        }
+        backupUrl.orEmpty()
+            .filter { it.isNotBlank() }
+            .let(::addAll)
+    }
+}
+
+private fun playbackResourceIdentity(url: String): String? {
+    return runCatching {
+        val uri = URI(url)
+        val path = uri.rawPath.orEmpty()
+        if (path.isBlank()) return@runCatching null
+        if (uri.rawQuery.isNullOrBlank()) path else "$path?${uri.rawQuery}"
+    }.getOrNull()
 }

--- a/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/VideoPlaybackViewModel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/VideoPlaybackViewModel.kt
@@ -131,7 +131,7 @@ import com.android.purebilibili.feature.video.subtitle.mapPlayerInfoSubtitleTrac
 import com.android.purebilibili.feature.video.subtitle.normalizeBilibiliSubtitleUrl
 import com.android.purebilibili.feature.video.subtitle.resolveDefaultSubtitleLanguages
 
-private const val PLAYBACK_CDN_FIRST_FRAME_FALLBACK_TIMEOUT_MS = 2_500L
+private const val PLAYBACK_CDN_FIRST_FRAME_FALLBACK_TIMEOUT_MS = 5_000L
 
 data class CommentMentionSearchUiState(
     val query: String = "",
@@ -380,6 +380,30 @@ internal fun buildPlaybackAudioUrlCandidates(
     return buildList {
         audioUrl?.takeIf { it.isNotBlank() }?.let(::add)
         selectedAudio
+            ?.backupUrl
+            .orEmpty()
+            .filter { it.isNotBlank() }
+            .let(::addAll)
+    }.distinct()
+}
+
+internal fun buildPlaybackVideoUrlCandidates(
+    videoUrl: String,
+    quality: Int,
+    cachedDashVideos: List<DashVideo>
+): List<String> {
+    val selectedVideo = cachedDashVideos.firstOrNull { video ->
+        video.id == quality && (
+            video.baseUrl == videoUrl ||
+                video.backupUrl.orEmpty().any { backupUrl -> backupUrl == videoUrl }
+            )
+    }
+
+    return buildList {
+        if (videoUrl.isNotBlank()) {
+            add(videoUrl)
+        }
+        selectedVideo
             ?.backupUrl
             .orEmpty()
             .filter { it.isNotBlank() }
@@ -2877,9 +2901,13 @@ class VideoPlaybackViewModel : ViewModel() {
                     settingsCodecPreference = settingsCodecPreference,
                     sessionBlockedCodecs = sessionBlockedCodecs
                 )
-                val videoSecondCodecPreference = appContext?.let {
+                val settingsSecondCodecPreference = appContext?.let {
                     com.android.purebilibili.core.store.SettingsManager.getVideoSecondCodecSync(it)
                 } ?: AVC_CODEC_KEY
+                val videoSecondCodecPreference = resolveEffectiveVideoSecondCodecPreference(
+                    requestCodecOverride = playbackRequest.videoCodecOverride,
+                    settingsSecondCodecPreference = settingsSecondCodecPreference
+                )
                 val isHdrSupported = appContext?.let {
                     com.android.purebilibili.core.util.MediaUtils.isHdrSupported(it)
                 } ?: com.android.purebilibili.core.util.MediaUtils.isHdrSupported()
@@ -3674,7 +3702,7 @@ class VideoPlaybackViewModel : ViewModel() {
     }
 
     /**
-     * 解码类错误时的安全重试：强制使用 AVC，规避特定机型 HEVC/AV1 解码异常导致的卡死。
+     * 解码类错误时按用户的次选编码重试，次选不可用或再次失败时再使用 AVC。
      */
     fun retryWithCodecFallback() {
         val current = _uiState.value as? VideoPlaybackUiState.Success ?: run {
@@ -3690,18 +3718,46 @@ class VideoPlaybackViewModel : ViewModel() {
                 isPlaying = player.isPlaying
             )
         } ?: true
-        playbackSessionStore.blockVideoCodec(AV1_CODEC_KEY)
+        val failedCodec = resolvePlaybackVideoCodec(
+            videoUrl = current.playUrl,
+            cachedDashVideos = current.cachedDashVideos
+        ) ?: normalizeCodecFamilyKey(_videoCodecPreference.value)
+        val sessionBlockedCodecs = playbackSessionStore.state.value.blockedVideoCodecs
+        val secondaryCodecPreference = appContext?.let { context ->
+            com.android.purebilibili.core.store.SettingsManager.getVideoSecondCodecSync(context)
+        } ?: _videoSecondCodecPreference.value
+        val fallbackCodec = resolveNextVideoCodecFallback(
+            failedCodec = failedCodec,
+            secondaryCodecPreference = secondaryCodecPreference,
+            isHevcSupported = com.android.purebilibili.core.util.MediaUtils.isHevcSupported(),
+            isAv1Supported = resolveEffectiveAv1Support(
+                deviceSupportsAv1 = com.android.purebilibili.core.util.MediaUtils.isAv1Supported(),
+                sessionBlockedCodecs = sessionBlockedCodecs
+            )
+        ) ?: run {
+            Logger.w(
+                "PlayerVM",
+                "Codec fallback unavailable: failed=${failedCodec ?: "unknown"}"
+            )
+            return
+        }
+        if (failedCodec == AV1_CODEC_KEY) {
+            playbackSessionStore.blockVideoCodec(AV1_CODEC_KEY)
+        }
         PlaybackCooldownManager.clearForVideo(bvid)
         PlayUrlCache.invalidate(bvid, current.info.cid)
         playbackSessionStore.clearCurrentMedia()
-        Logger.w("PlayerVM", "🛟 Retrying with safe codec fallback: AVC")
+        Logger.w(
+            "PlayerVM",
+            "Codec fallback: ${failedCodec ?: "unknown"} -> $fallbackCodec, reason=decoder_error"
+        )
         loadVideo(
             bvid = bvid,
             aid = current.info.aid,
             force = true,
             autoPlay = resumePlaybackAfterRetry,
             audioLang = current.currentAudioLang,
-            videoCodecOverride = AVC_CODEC_KEY,
+            videoCodecOverride = fallbackCodec,
             cid = current.info.cid,
             fallbackResumePositionMs = fallbackResumePositionMs
         )
@@ -7452,15 +7508,11 @@ class VideoPlaybackViewModel : ViewModel() {
         cachedDashAudios: List<DashAudio>,
         adaptiveDashSource: AdaptiveDashPlaybackSource?
     ): PlaybackCdnCandidateSelection {
-        val rawVideoUrls = buildList {
-            if (videoUrl.isNotEmpty()) add(videoUrl)
-            cachedDashVideos
-                .find { it.id == quality }
-                ?.backupUrl
-                ?.filterNotNull()
-                ?.filter { it.isNotEmpty() }
-                ?.let { addAll(it) }
-        }.distinct()
+        val rawVideoUrls = buildPlaybackVideoUrlCandidates(
+            videoUrl = videoUrl,
+            quality = quality,
+            cachedDashVideos = cachedDashVideos
+        )
 
         val rawAudioUrls = buildPlaybackAudioUrlCandidates(
             audioUrl = audioUrl,

--- a/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/VideoPlaybackViewModel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/VideoPlaybackViewModel.kt
@@ -131,7 +131,7 @@ import com.android.purebilibili.feature.video.subtitle.mapPlayerInfoSubtitleTrac
 import com.android.purebilibili.feature.video.subtitle.normalizeBilibiliSubtitleUrl
 import com.android.purebilibili.feature.video.subtitle.resolveDefaultSubtitleLanguages
 
-private const val PLAYBACK_CDN_FIRST_FRAME_FALLBACK_TIMEOUT_MS = 5_000L
+private const val PLAYBACK_CDN_FIRST_FRAME_FALLBACK_TIMEOUT_MS = 2_500L
 
 data class CommentMentionSearchUiState(
     val query: String = "",

--- a/app/src/test/java/com/android/purebilibili/data/model/response/VideoResponseCodecSelectionTest.kt
+++ b/app/src/test/java/com/android/purebilibili/data/model/response/VideoResponseCodecSelectionTest.kt
@@ -28,6 +28,27 @@ class VideoResponseCodecSelectionTest {
     }
 
     @Test
+    fun `AV1 decoder fallback does not select failed HEVC again when AV1 is unavailable`() {
+        val dash = Dash(
+            video = listOf(
+                DashVideo(id = 80, baseUrl = "https://example.com/hevc.m4s", codecs = "hev1"),
+                DashVideo(id = 80, baseUrl = "https://example.com/avc.m4s", codecs = "avc1")
+            )
+        )
+
+        val selected = dash.getBestVideo(
+            targetQn = 80,
+            preferCodec = "av01",
+            secondPreferCodec = "avc1",
+            isHevcSupported = true,
+            isAv1Supported = true
+        )
+
+        assertNotNull(selected)
+        assertEquals("avc1", selected.codecs)
+    }
+
+    @Test
     fun `getBestVideo prefers lower bitrate when quality and codec are equivalent`() {
         val dash = Dash(
             video = listOf(

--- a/app/src/test/java/com/android/purebilibili/feature/video/state/PlayerErrorRecoveryPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/state/PlayerErrorRecoveryPolicyTest.kt
@@ -52,6 +52,31 @@ class PlayerErrorRecoveryPolicyTest {
     }
 
     @Test
+    fun decoderLikeFailureAllowsSecondaryThenAvcFallback() {
+        val secondFallback = decidePlayerErrorRecovery(
+            errorCode = PlaybackException.ERROR_CODE_FAILED_RUNTIME_CHECK,
+            hasCdnAlternatives = false,
+            retryCount = 1,
+            maxRetries = 3,
+            cdnSwitchCount = 0,
+            maxCdnSwitches = 2,
+            isDecoderLikeFailure = true
+        )
+        val exhausted = decidePlayerErrorRecovery(
+            errorCode = PlaybackException.ERROR_CODE_FAILED_RUNTIME_CHECK,
+            hasCdnAlternatives = false,
+            retryCount = 2,
+            maxRetries = 3,
+            cdnSwitchCount = 0,
+            maxCdnSwitches = 2,
+            isDecoderLikeFailure = true
+        )
+
+        assertEquals(PlayerErrorRecoveryAction.RETRY_DECODER_FALLBACK, secondFallback)
+        assertEquals(PlayerErrorRecoveryAction.GIVE_UP, exhausted)
+    }
+
+    @Test
     fun nonNetworkNonDecoderRetriesOnce() {
         val action = decidePlayerErrorRecovery(
             errorCode = PlaybackException.ERROR_CODE_FAILED_RUNTIME_CHECK,

--- a/app/src/test/java/com/android/purebilibili/feature/video/viewmodel/PlaybackCdnFallbackPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/viewmodel/PlaybackCdnFallbackPolicyTest.kt
@@ -1,6 +1,7 @@
 package com.android.purebilibili.feature.video.viewmodel
 
 import com.android.purebilibili.data.model.response.DashAudio
+import com.android.purebilibili.data.model.response.DashVideo
 import com.android.purebilibili.feature.plugin.CdnCandidateHealth
 import com.android.purebilibili.feature.plugin.CdnHealthEvent
 import com.android.purebilibili.feature.plugin.PlaybackCdnCandidate
@@ -12,6 +13,58 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class PlaybackCdnFallbackPolicyTest {
+
+    @Test
+    fun `video candidates keep backups on selected HEVC track when AVC is listed first`() {
+        val candidates = buildPlaybackVideoUrlCandidates(
+            videoUrl = "https://hevc.example.com/1080-base.m4s",
+            quality = 80,
+            cachedDashVideos = listOf(
+                DashVideo(
+                    id = 80,
+                    baseUrl = "https://avc.example.com/1080-base.m4s",
+                    backupUrl = listOf("https://avc.example.com/1080-backup.m4s"),
+                    codecs = "avc1.640028"
+                ),
+                DashVideo(
+                    id = 80,
+                    baseUrl = "https://hevc.example.com/1080-base.m4s",
+                    backupUrl = listOf(
+                        "https://hevc-backup-a.example.com/1080.m4s",
+                        "https://hevc-backup-b.example.com/1080.m4s"
+                    ),
+                    codecs = "hvc1.1.6.L120.90"
+                )
+            )
+        )
+
+        assertEquals(
+            listOf(
+                "https://hevc.example.com/1080-base.m4s",
+                "https://hevc-backup-a.example.com/1080.m4s",
+                "https://hevc-backup-b.example.com/1080.m4s"
+            ),
+            candidates
+        )
+    }
+
+    @Test
+    fun `video candidates do not guess another codec when selected track is unknown`() {
+        val candidates = buildPlaybackVideoUrlCandidates(
+            videoUrl = "https://selected.example.com/video.m4s",
+            quality = 80,
+            cachedDashVideos = listOf(
+                DashVideo(
+                    id = 80,
+                    baseUrl = "https://avc.example.com/1080-base.m4s",
+                    backupUrl = listOf("https://avc.example.com/1080-backup.m4s"),
+                    codecs = "avc1.640028"
+                )
+            )
+        )
+
+        assertEquals(listOf("https://selected.example.com/video.m4s"), candidates)
+    }
 
     @Test
     fun `custom candidate falls back through each original pair once`() {

--- a/app/src/test/java/com/android/purebilibili/feature/video/viewmodel/VideoCodecSessionPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/viewmodel/VideoCodecSessionPolicyTest.kt
@@ -1,0 +1,81 @@
+package com.android.purebilibili.feature.video.viewmodel
+
+import com.android.purebilibili.data.model.response.DashVideo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class VideoCodecSessionPolicyTest {
+
+    @Test
+    fun `HEVC decoder failure falls back to configured AV1 before AVC`() {
+        assertEquals(
+            AV1_CODEC_KEY,
+            resolveNextVideoCodecFallback(
+                failedCodec = "hvc1.1.6.L120.90",
+                secondaryCodecPreference = AV1_CODEC_KEY,
+                isHevcSupported = true,
+                isAv1Supported = true
+            )
+        )
+    }
+
+    @Test
+    fun `AV1 decoder failure falls back to AVC`() {
+        assertEquals(
+            AVC_CODEC_KEY,
+            resolveNextVideoCodecFallback(
+                failedCodec = "av01.0.08M.08",
+                secondaryCodecPreference = AV1_CODEC_KEY,
+                isHevcSupported = true,
+                isAv1Supported = true
+            )
+        )
+    }
+
+    @Test
+    fun `unsupported secondary AV1 falls back to AVC`() {
+        assertEquals(
+            AVC_CODEC_KEY,
+            resolveNextVideoCodecFallback(
+                failedCodec = HEVC_CODEC_KEY,
+                secondaryCodecPreference = AV1_CODEC_KEY,
+                isHevcSupported = true,
+                isAv1Supported = false
+            )
+        )
+    }
+
+    @Test
+    fun `codec fallback request uses AVC as final secondary`() {
+        assertEquals(
+            AVC_CODEC_KEY,
+            resolveEffectiveVideoSecondCodecPreference(
+                requestCodecOverride = AV1_CODEC_KEY,
+                settingsSecondCodecPreference = AV1_CODEC_KEY
+            )
+        )
+        assertEquals(
+            AV1_CODEC_KEY,
+            resolveEffectiveVideoSecondCodecPreference(
+                requestCodecOverride = null,
+                settingsSecondCodecPreference = AV1_CODEC_KEY
+            )
+        )
+    }
+
+    @Test
+    fun `rewritten CDN url resolves codec from matching media resource`() {
+        val codec = resolvePlaybackVideoCodec(
+            videoUrl = "https://cn-zjhz-cm-01-11.bilivideo.com/upgcxcode/10/20/video.m4s?deadline=1",
+            cachedDashVideos = listOf(
+                DashVideo(
+                    id = 80,
+                    baseUrl = "https://upos-sz-mirrorali.bilivideo.com/upgcxcode/10/20/video.m4s?deadline=1",
+                    codecs = "hvc1.1.6.L120.90"
+                )
+            )
+        )
+
+        assertEquals(HEVC_CODEC_KEY, codec)
+    }
+}


### PR DESCRIPTION
# fix(player): 修复偶发的CDN fallback导致视频编码意外降级

## 背景

已包含HEVC/hvc1 修复和HDR SurfaceView 修复时，普通播放模式会根据用户设置优先选择 HEVC、其次选择 AV1。但在首帧加载触发 CDN fallback 后，播放器偶发从已经选中的 HEVC 轨道切换到同画质的 AVC/H.264 轨道问题。
实机日志显示，播放器最初正确创建 HEVC 解码器，而 AVC 解码器总是在 CDN fallback 后约 159～262ms 启动，说明编码变化发生在换线阶段，并非播放接口缺少 HEVC 流。

## 根因

旧逻辑生成备用地址时只按画质 ID 查找轨道：

```kotlin
cachedDashVideos.find { it.id == quality }?.backupUrl
```

同一画质通常同时存在 AVC、HEVC 和 AV1 轨道。当 AVC 排在列表前面时，代码会把“当前 HEVC 主地址”和“同画质 AVC 备用地址”拼成一组候选，导致网络换线同时改变 codec。

## 修改内容

- CDN 候选按“画质 + 当前 URL”精确定位当前 `DashVideo`。
- 仅使用当前轨道自己的备用 URL，CDN 换线不再隐式改变编码。
- 无法定位当前轨道时只保留当前 URL，不猜测同画质的其他编码轨道。
- 保留原有 2.5 秒首帧 CDN fallback 门槛，避免实验性 DASH 等路径的首帧换线被延迟到 5 秒。
- 只有明确的解码器错误才允许切换编码。
- 解码回退遵守用户偏好，按“首选编码 → 次选编码 → AVC”执行：
  - 首选 HEVC、次选 AV1 时：`HEVC → AV1 → AVC`。
  - AV1 轨道不存在时直接回退 AVC，不重新选择已经失败的 HEVC。
- 解码回退预算允许最多两次，以覆盖次选编码和最终 AVC 兜底。

## 行为变化

| 场景 | 修改前 | 修改后 |
| --- | --- | --- |
| HEVC 主地址首帧超时 | 可能换到同画质 AVC 备用地址 | 只切换当前 HEVC 轨道的备用地址 |
| 当前轨道没有备用地址 | 可能猜测其他编码轨道 | 保持当前地址 |
| HEVC 解码器明确报错 | 直接或无序降级 AVC | 优先尝试用户设置的次选 AV1，再回退 AVC |
| AV1 不存在 | 可能重新选回失败的 HEVC | 直接回退 AVC |

## 测试

- `PlaybackCdnFallbackPolicyTest`
- `VideoCodecSessionPolicyTest`
- `PlayerErrorRecoveryPolicyTest`
- `VideoResponseCodecSelectionTest`
- `:app:compileDebugKotlin`

上述定向测试和 Kotlin 编译均已通过。

## 实机验证

- 首选编码：HEVC。
- 次选编码：AV1。
- 已复现旧版本在 CDN fallback 后切换到 AVC。
- 修复版本回归后，普通模式 CDN 换线保持 HEVC，未再观察到网络换线导致的 H.264 降级。
