### PR TITLE
feat(player): 增加 Hi-Res、杜比全景声与 AAC 音质选择

### DIFF
--- a/app/src/main/java/com/android/purebilibili/core/player/HiResCompatibleRenderersFactory.kt
+++ b/app/src/main/java/com/android/purebilibili/core/player/HiResCompatibleRenderersFactory.kt
@@ -1,0 +1,115 @@
+package com.android.purebilibili.core.player
+
+import android.content.Context
+import android.os.Handler
+import androidx.annotation.OptIn
+import androidx.media3.common.Format
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.DefaultRenderersFactory
+import androidx.media3.exoplayer.Renderer
+import androidx.media3.exoplayer.audio.AudioRendererEventListener
+import androidx.media3.exoplayer.audio.AudioSink
+import androidx.media3.exoplayer.audio.MediaCodecAudioRenderer
+import androidx.media3.exoplayer.mediacodec.MediaCodecAdapter
+import androidx.media3.exoplayer.mediacodec.MediaCodecInfo
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+
+internal const val HI_RES_FLAC_MIN_CODEC_INPUT_SIZE_BYTES = 1024 * 1024
+
+internal fun resolveHiResCodecMaxInputSize(
+    defaultMaxInputSize: Int,
+    sampleMimeTypes: List<String?>
+): Int {
+    val containsFlac = sampleMimeTypes.any { mimeType ->
+        mimeType.equals(MimeTypes.AUDIO_FLAC, ignoreCase = true)
+    }
+    return if (containsFlac) {
+        maxOf(defaultMaxInputSize, HI_RES_FLAC_MIN_CODEC_INPUT_SIZE_BYTES)
+    } else {
+        defaultMaxInputSize
+    }
+}
+
+/**
+ * 为部分系统 FLAC 解码器预留更大的输入缓冲区。
+ *
+ * 某些设备会给 `c2.android.flac.decoder` 分配 32 KiB 输入缓冲，但 B 站 Hi-Res
+ * 音轨的单帧可能超过该大小，最终触发 Media3 `InsufficientCapacityException`。
+ */
+@OptIn(UnstableApi::class)
+internal class HiResCompatibleRenderersFactory(
+    context: Context
+) : DefaultRenderersFactory(context) {
+
+    override fun buildAudioRenderers(
+        context: Context,
+        extensionRendererMode: Int,
+        mediaCodecSelector: MediaCodecSelector,
+        enableDecoderFallback: Boolean,
+        audioSink: AudioSink,
+        eventHandler: Handler,
+        eventListener: AudioRendererEventListener,
+        out: ArrayList<Renderer>
+    ) {
+        val firstAudioRendererIndex = out.size
+        super.buildAudioRenderers(
+            context,
+            extensionRendererMode,
+            mediaCodecSelector,
+            enableDecoderFallback,
+            audioSink,
+            eventHandler,
+            eventListener,
+            out
+        )
+        val mediaCodecRendererIndex = (firstAudioRendererIndex until out.size)
+            .firstOrNull { index -> out[index].javaClass == MediaCodecAudioRenderer::class.java }
+            ?: return
+        out[mediaCodecRendererIndex] = HiResCompatibleMediaCodecAudioRenderer(
+            context = context,
+            codecAdapterFactory = codecAdapterFactory,
+            mediaCodecSelector = mediaCodecSelector,
+            enableDecoderFallback = enableDecoderFallback,
+            eventHandler = eventHandler,
+            eventListener = eventListener,
+            audioSink = audioSink
+        )
+    }
+}
+
+@OptIn(UnstableApi::class)
+private class HiResCompatibleMediaCodecAudioRenderer(
+    context: Context,
+    codecAdapterFactory: MediaCodecAdapter.Factory,
+    mediaCodecSelector: MediaCodecSelector,
+    enableDecoderFallback: Boolean,
+    eventHandler: Handler,
+    eventListener: AudioRendererEventListener,
+    audioSink: AudioSink
+) : MediaCodecAudioRenderer(
+    context,
+    codecAdapterFactory,
+    mediaCodecSelector,
+    enableDecoderFallback,
+    eventHandler,
+    eventListener,
+    audioSink
+) {
+
+    override fun getCodecMaxInputSize(
+        codecInfo: MediaCodecInfo,
+        format: Format,
+        streamFormats: Array<Format>
+    ): Int {
+        return resolveHiResCodecMaxInputSize(
+            defaultMaxInputSize = super.getCodecMaxInputSize(
+                codecInfo,
+                format,
+                streamFormats
+            ),
+            sampleMimeTypes = listOf(format.sampleMimeType) +
+                streamFormats.map { streamFormat -> streamFormat.sampleMimeType }
+        )
+    }
+}

--- a/app/src/main/java/com/android/purebilibili/core/store/SettingsManager.kt
+++ b/app/src/main/java/com/android/purebilibili/core/store/SettingsManager.kt
@@ -6351,6 +6351,7 @@ object SettingsManager {
             StringShareablePreferenceDefinition(KEY_VIDEO_CODEC, SettingsShareSection.PLAYBACK),
             StringShareablePreferenceDefinition(KEY_VIDEO_SECOND_CODEC, SettingsShareSection.PLAYBACK),
             IntShareablePreferenceDefinition(KEY_AUDIO_QUALITY, SettingsShareSection.PLAYBACK),
+            IntShareablePreferenceDefinition(KEY_DEFAULT_AUDIO_QUALITY, SettingsShareSection.PLAYBACK),
             BooleanShareablePreferenceDefinition(KEY_AUTO_HIGHEST_QUALITY, SettingsShareSection.PLAYBACK),
             BooleanShareablePreferenceDefinition(KEY_SPONSOR_BLOCK_ENABLED, SettingsShareSection.PLAYBACK),
             BooleanShareablePreferenceDefinition(KEY_SPONSOR_BLOCK_AUTO_SKIP, SettingsShareSection.PLAYBACK),

--- a/app/src/main/java/com/android/purebilibili/core/store/SettingsManager.kt
+++ b/app/src/main/java/com/android/purebilibili/core/store/SettingsManager.kt
@@ -66,6 +66,8 @@ import kotlinx.serialization.json.jsonPrimitive
 import java.io.File
 import kotlin.math.abs
 
+const val DEFAULT_AUDIO_QUALITY_FOLLOW_LAST = -2
+
 // 声明 DataStore 扩展属性
 internal val Context.settingsDataStore by preferencesDataStore(name = "settings_prefs")
 
@@ -4668,6 +4670,7 @@ object SettingsManager {
     private val KEY_VIDEO_CODEC = stringPreferencesKey("video_codec_preference")
     private val KEY_VIDEO_SECOND_CODEC = stringPreferencesKey("video_second_codec_preference")
     private val KEY_AUDIO_QUALITY = intPreferencesKey("audio_quality_preference")
+    private val KEY_DEFAULT_AUDIO_QUALITY = intPreferencesKey("default_audio_quality")
     private val KEY_SUBSCRIBED_COLLECTION_IDS = stringPreferencesKey("subscribed_collection_ids")
     private val KEY_COLLECTION_SORT_PREFERENCES = stringPreferencesKey("collection_sort_preferences")
     
@@ -4867,6 +4870,27 @@ object SettingsManager {
     fun getAudioQualitySync(context: Context): Int {
         return context.getSharedPreferences("quality_settings", Context.MODE_PRIVATE)
             .getInt("audio_quality", -1)
+    }
+
+    // 新视频的默认音质；默认跟随播放器上次手动选择。
+    fun getDefaultAudioQuality(context: Context): Flow<Int> = context.settingsDataStore.data
+        .map { preferences ->
+            preferences[KEY_DEFAULT_AUDIO_QUALITY] ?: DEFAULT_AUDIO_QUALITY_FOLLOW_LAST
+        }
+
+    suspend fun setDefaultAudioQuality(context: Context, value: Int) {
+        context.settingsDataStore.edit { preferences ->
+            preferences[KEY_DEFAULT_AUDIO_QUALITY] = value
+        }
+        context.getSharedPreferences("quality_settings", Context.MODE_PRIVATE)
+            .edit()
+            .putInt("default_audio_quality", value)
+            .commit()
+    }
+
+    fun getDefaultAudioQualitySync(context: Context): Int {
+        return context.getSharedPreferences("quality_settings", Context.MODE_PRIVATE)
+            .getInt("default_audio_quality", DEFAULT_AUDIO_QUALITY_FOLLOW_LAST)
     }
 
     // --- 评论默认排序 (1=回复,2=最新,3=最热,4=点赞) ---

--- a/app/src/main/java/com/android/purebilibili/core/util/MediaUtils.kt
+++ b/app/src/main/java/com/android/purebilibili/core/util/MediaUtils.kt
@@ -26,6 +26,13 @@ object MediaUtils {
     }
 
     /**
+     * 检查设备是否具备杜比全景声音轨使用的 E-AC-3/JOC 解码器。
+     */
+    fun isDolbyAtmosAudioSupported(): Boolean {
+        return hasDecoder("audio/eac3") || hasDecoder("audio/eac3-joc")
+    }
+
+    /**
      * Check if HDR (HDR10/HLG) video is supported
      * HDR requires both decoder support and display capability
      */

--- a/app/src/main/java/com/android/purebilibili/feature/audio/screen/MusicPlayerContent.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/audio/screen/MusicPlayerContent.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -94,7 +95,11 @@ import com.android.purebilibili.feature.audio.lyrics.resolveLyricFocusScrollOffs
 import com.android.purebilibili.feature.audio.player.MusicPlayerUiState
 import com.android.purebilibili.feature.home.components.BottomBarLiquidSegmentedControl
 import com.android.purebilibili.feature.home.components.kernelSuMiuixFloatingDockSurface
+import com.android.purebilibili.feature.video.playback.audio.AudioQualityOption
 import com.android.purebilibili.feature.video.player.PlayMode
+import com.android.purebilibili.feature.video.ui.components.AudioQualitySelectionMenu
+import com.android.purebilibili.feature.video.ui.components.DolbyBadge
+import com.android.purebilibili.feature.video.ui.components.HiResBadge
 import io.github.alexzhirkevich.cupertino.icons.CupertinoIcons
 import io.github.alexzhirkevich.cupertino.icons.filled.BackwardEnd
 import io.github.alexzhirkevich.cupertino.icons.filled.ForwardEnd
@@ -135,6 +140,12 @@ internal fun MusicPlayerContent(
     onCollectionClick: (() -> Unit)? = null,
     onSleepTimerClick: (() -> Unit)? = null,
     sleepTimerLabel: String = "定时关闭",
+    audioQualityLabel: String = "音质",
+    audioQualityOptions: List<AudioQualityOption> = emptyList(),
+    requestedAudioQuality: Int = -1,
+    isHiResAudioSelected: Boolean = false,
+    isDolbyAudioSelected: Boolean = false,
+    onAudioQualitySelected: ((Int) -> Unit)? = null,
     onPipClick: (() -> Unit)? = null,
     onToggleOrientation: (() -> Unit)? = null,
     orientationActionLabel: String = "横屏",
@@ -149,6 +160,7 @@ internal fun MusicPlayerContent(
     var artworkBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
     var showQueue by remember { mutableStateOf(false) }
     var showActions by remember { mutableStateOf(false) }
+    var showAudioQuality by remember { mutableStateOf(false) }
     var showLyricsSearch by remember { mutableStateOf(false) }
     var progressSeekRevision by remember { mutableIntStateOf(0) }
     var lyricsControlsVisible by remember(state.title) { mutableStateOf(true) }
@@ -238,6 +250,12 @@ internal fun MusicPlayerContent(
                                 onPrevious = onPrevious,
                                 onNext = onNext,
                                 onPlayModeChange = onPlayModeChange,
+                                audioQualityLabel = audioQualityLabel,
+                                isHiResAudioSelected = isHiResAudioSelected,
+                                isDolbyAudioSelected = isDolbyAudioSelected,
+                                onAudioQualityClick = onAudioQualitySelected?.let {
+                                    { showAudioQuality = true }
+                                },
                                 glassTintColor = backgroundColor,
                                 modifier = Modifier.padding(bottom = 70.dp)
                             )
@@ -329,6 +347,12 @@ internal fun MusicPlayerContent(
                     onPrevious = onPrevious,
                     onNext = onNext,
                     onPlayModeChange = onPlayModeChange,
+                    audioQualityLabel = audioQualityLabel,
+                    isHiResAudioSelected = isHiResAudioSelected,
+                    isDolbyAudioSelected = isDolbyAudioSelected,
+                    onAudioQualityClick = onAudioQualitySelected?.let {
+                        { showAudioQuality = true }
+                    },
                     glassTintColor = backgroundColor,
                     modifier = Modifier.weight(1f)
                 )
@@ -424,6 +448,18 @@ internal fun MusicPlayerContent(
             }
             Spacer(Modifier.navigationBarsPadding().height(12.dp))
         }
+    }
+
+    if (showAudioQuality && onAudioQualitySelected != null) {
+        AudioQualitySelectionMenu(
+            options = audioQualityOptions,
+            requestedAudioQuality = requestedAudioQuality,
+            onAudioQualitySelected = { quality ->
+                onAudioQualitySelected(quality)
+                showAudioQuality = false
+            },
+            onDismiss = { showAudioQuality = false }
+        )
     }
 
     if (showQueue) {
@@ -599,6 +635,10 @@ private fun PlayerPage(
     onPrevious: (() -> Unit)?,
     onNext: (() -> Unit)?,
     onPlayModeChange: (PlayMode) -> Unit,
+    audioQualityLabel: String,
+    isHiResAudioSelected: Boolean,
+    isDolbyAudioSelected: Boolean,
+    onAudioQualityClick: (() -> Unit)?,
     glassTintColor: Color,
     modifier: Modifier = Modifier
 ) {
@@ -641,6 +681,15 @@ private fun PlayerPage(
                 Text(it, color = Color(0xFFFF9B92), style = MaterialTheme.typography.bodySmall)
             }
         }
+        onAudioQualityClick?.let { action ->
+            Spacer(Modifier.height(14.dp))
+            MusicAudioQualityControl(
+                label = audioQualityLabel,
+                isHiResSelected = isHiResAudioSelected,
+                isDolbySelected = isDolbyAudioSelected,
+                onClick = action
+            )
+        }
         Spacer(Modifier.height(14.dp))
         MusicProgress(state, onSeek)
         Spacer(Modifier.height(8.dp))
@@ -652,6 +701,45 @@ private fun PlayerPage(
             glassTintColor = glassTintColor,
             onPlayModeChange = onPlayModeChange
         )
+    }
+}
+
+@Composable
+private fun MusicAudioQualityControl(
+    label: String,
+    isHiResSelected: Boolean,
+    isDolbySelected: Boolean,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 48.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(MusicContentColor.copy(alpha = 0.12f))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = "音质",
+            color = MusicContentColor.copy(alpha = 0.72f),
+            style = MaterialTheme.typography.labelLarge
+        )
+        Spacer(Modifier.weight(1f))
+        Text(
+            text = label.ifBlank { "音质" },
+            color = MusicContentColor,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.SemiBold
+        )
+        if (isHiResSelected) {
+            HiResBadge()
+        }
+        if (isDolbySelected) {
+            DolbyBadge()
+        }
     }
 }
 

--- a/app/src/main/java/com/android/purebilibili/feature/bangumi/BangumiPlayerScreen.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/bangumi/BangumiPlayerScreen.kt
@@ -7,6 +7,7 @@ import android.content.ContextWrapper
 import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.widget.Toast
+import com.android.purebilibili.core.player.HiResCompatibleRenderersFactory
 import com.android.purebilibili.core.ui.LocalNavigationBackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -94,9 +95,12 @@ fun BangumiPlayerScreen(
     
     // 创建 ExoPlayer
     val exoPlayer = remember {
-        ExoPlayer.Builder(context).build().apply {
-            playWhenReady = true
-        }
+        ExoPlayer.Builder(context)
+            .setRenderersFactory(HiResCompatibleRenderersFactory(context))
+            .build()
+            .apply {
+                playWhenReady = true
+            }
     }
     val miniPlayerManager = remember(context) {
         MiniPlayerManager.getInstance(context.applicationContext)

--- a/app/src/main/java/com/android/purebilibili/feature/bangumi/BangumiPlayerScreen.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/bangumi/BangumiPlayerScreen.kt
@@ -513,6 +513,10 @@ fun BangumiPlayerScreen(
                     isLoggedIn = successState?.isLoggedIn == true,
                     isVip = successState?.isVip == true,
                     onQualityChange = { viewModel.changeQuality(it) },
+                    requestedAudioQuality = successState?.requestedAudioQuality ?: -1,
+                    selectedAudioQuality = successState?.selectedAudioQuality ?: -1,
+                    availableAudioQualities = successState?.availableAudioQualities.orEmpty(),
+                    onAudioQualityChange = viewModel::changeAudioQuality,
                     onBack = if (isFullscreenMode) { { toggleOrientation() } } else onBack,
                     onToggleFullscreen = { toggleOrientation() },
                     sponsorSegment = sponsorSegment,
@@ -521,7 +525,10 @@ fun BangumiPlayerScreen(
                     onSponsorDismiss = { viewModel.dismissSponsorSkipButton() },
                     //  倍速控制
                     currentSpeed = currentSpeed,
-                    onSpeedChange = { currentSpeed = it },
+                    onSpeedChange = {
+                        currentSpeed = it
+                        viewModel.applyPlaybackSpeedFromUi(it)
+                    },
                     //  弹幕设置
                     danmakuOpacity = danmakuOpacity,
                     danmakuFontScale = danmakuFontScale,

--- a/app/src/main/java/com/android/purebilibili/feature/bangumi/BangumiPlayerViewModel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/bangumi/BangumiPlayerViewModel.kt
@@ -724,7 +724,7 @@ class BangumiPlayerViewModel : BasePlayerViewModel() {
         val selectedLabel = state.availableAudioQualities
             .firstOrNull { it.preferenceId == state.selectedAudioQuality }
             ?.label
-            ?: "自动"
+            ?: "高品质 AAC"
         val message = when (state.audioFallbackReason) {
             AudioFallbackReason.SPEED_INCOMPATIBLE ->
                 "当前倍速暂不支持所选音质，已临时使用 $selectedLabel"

--- a/app/src/main/java/com/android/purebilibili/feature/bangumi/BangumiPlayerViewModel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/bangumi/BangumiPlayerViewModel.kt
@@ -734,6 +734,8 @@ class BangumiPlayerViewModel : BasePlayerViewModel() {
                 "当前倍速暂不支持所选音质，已临时使用 $selectedLabel"
             AudioFallbackReason.REQUESTED_UNAVAILABLE ->
                 "当前视频不支持所选音质，已使用 $selectedLabel"
+            AudioFallbackReason.DECODER_ERROR ->
+                "当前设备无法稳定解码所选音质，已临时使用 $selectedLabel"
             AudioFallbackReason.NO_PLAYABLE_AUDIO -> "当前视频没有可用音轨"
             null -> "✓ 已切换至 $selectedLabel"
         }

--- a/app/src/main/java/com/android/purebilibili/feature/bangumi/BangumiPlayerViewModel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/bangumi/BangumiPlayerViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.media3.exoplayer.ExoPlayer
 import com.android.purebilibili.core.player.BasePlayerViewModel
 import com.android.purebilibili.core.network.NetworkModule
+import com.android.purebilibili.core.store.SettingsManager
 import com.android.purebilibili.core.store.TokenManager
 import com.android.purebilibili.data.model.response.*
 import com.android.purebilibili.data.repository.ActionRepository
@@ -13,6 +14,11 @@ import com.android.purebilibili.feature.video.player.ExternalPlaylistSource
 import com.android.purebilibili.feature.video.player.PlaylistItem
 import com.android.purebilibili.feature.video.player.PlaylistManager
 import com.android.purebilibili.feature.video.controller.PlaybackProgressManager
+import com.android.purebilibili.feature.video.playback.audio.AudioFallbackReason
+import com.android.purebilibili.feature.video.playback.audio.AudioQualityOption
+import com.android.purebilibili.feature.video.playback.audio.resolveAudioStreamSelection
+import com.android.purebilibili.feature.video.playback.audio.resolveRequestedAudioQuality
+import com.android.purebilibili.feature.video.playback.policy.shouldRefreshPremiumAudioForPlaybackSpeedChange
 import com.android.purebilibili.feature.video.usecase.VideoInteractionUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -68,6 +74,11 @@ sealed class BangumiPlayerState {
         val quality: Int,
         val acceptQuality: List<Int>,
         val acceptDescription: List<String>,
+        val cachedDash: Dash? = null,
+        val requestedAudioQuality: Int = -1,
+        val selectedAudioQuality: Int = -1,
+        val availableAudioQualities: List<AudioQualityOption> = emptyList(),
+        val audioFallbackReason: AudioFallbackReason? = null,
         val isLoggedIn: Boolean = false,
         val isVip: Boolean = false,
         val isLiked: Boolean = false,
@@ -138,6 +149,14 @@ class BangumiPlayerViewModel : BasePlayerViewModel() {
 
     private val _userCoinBalance = MutableStateFlow<Double?>(null)
     val userCoinBalance = _userCoinBalance.asStateFlow()
+
+    private fun resolveConfiguredAudioQuality(): Int {
+        val context = NetworkModule.appContext ?: return -1
+        return resolveRequestedAudioQuality(
+            defaultAudioQuality = SettingsManager.getDefaultAudioQualitySync(context),
+            rememberedAudioQuality = SettingsManager.getAudioQualitySync(context)
+        )
+    }
     
     private var currentSeasonId: Long = 0
     private var currentEpId: Long = 0
@@ -351,13 +370,21 @@ class BangumiPlayerViewModel : BasePlayerViewModel() {
             var videoUrl: String? = null
             var audioUrl: String? = null
             var durlSegmentUrls: List<String> = emptyList()
+            val requestedAudioQuality = resolveConfiguredAudioQuality()
+            val audioSelection = playData.dash?.let { dash ->
+                resolveAudioStreamSelection(
+                    dash = dash,
+                    requestedAudioQuality = requestedAudioQuality,
+                    playbackSpeed = exoPlayer?.playbackParameters?.speed ?: 1.0f
+                )
+            }
             
             if (playData.dash != null) {
                 // DASH 格式
                 val dash = playData.dash
                 //  [修复] 优先使用 AVC 编码，确保所有设备都能解码
                 val video = dash.getBestVideo(playData.quality, preferCodec = "avc1")
-                val audio = dash.getBestAudio()
+                val audio = audioSelection?.selected?.track
                 
                 com.android.purebilibili.core.util.Logger.d("BangumiPlayerVM", "📹 DASH videos: ${dash.video.size}, audios: ${dash.audio?.size ?: 0}")
                 
@@ -445,6 +472,11 @@ class BangumiPlayerViewModel : BasePlayerViewModel() {
                 quality = playData.quality,
                 acceptQuality = playData.acceptQuality ?: emptyList(),
                 acceptDescription = playData.acceptDescription ?: emptyList(),
+                cachedDash = playData.dash,
+                requestedAudioQuality = audioSelection?.requestedPreferenceId ?: requestedAudioQuality,
+                selectedAudioQuality = audioSelection?.selectedPreferenceId ?: -1,
+                availableAudioQualities = audioSelection?.availableOptions.orEmpty(),
+                audioFallbackReason = audioSelection?.fallbackReason,
                 isLoggedIn = isLoggedIn,
                 isVip = isVip
             )
@@ -550,11 +582,19 @@ class BangumiPlayerViewModel : BasePlayerViewModel() {
                 val videoUrl: String?
                 val audioUrl: String?
                 val durlSegmentUrls: List<String>
+                val dash = playData.dash
+                val audioSelection = dash?.let {
+                    resolveAudioStreamSelection(
+                        dash = it,
+                        requestedAudioQuality = currentState.requestedAudioQuality,
+                        playbackSpeed = exoPlayer?.playbackParameters?.speed ?: 1.0f
+                    )
+                }
                 
-                if (playData.dash != null) {
+                if (dash != null) {
                     //  [修复] 优先使用 AVC 编码，确保所有设备都能解码
-                    val video = playData.dash.getBestVideo(qualityId, preferCodec = "avc1")
-                    val audio = playData.dash.getBestAudio()
+                    val video = dash.getBestVideo(qualityId, preferCodec = "avc1")
+                    val audio = audioSelection?.selected?.track
                     videoUrl = video?.getValidUrl()
                     audioUrl = audio?.getValidUrl()
                     durlSegmentUrls = emptyList()
@@ -575,11 +615,17 @@ class BangumiPlayerViewModel : BasePlayerViewModel() {
                 _uiState.value = currentState.copy(
                     playUrl = videoUrl,
                     audioUrl = audioUrl,
-                    quality = playData.quality
+                    quality = playData.quality,
+                    cachedDash = dash,
+                    requestedAudioQuality = currentState.requestedAudioQuality,
+                    selectedAudioQuality = audioSelection?.selectedPreferenceId ?: -1,
+                    availableAudioQualities = audioSelection?.availableOptions.orEmpty(),
+                    audioFallbackReason = audioSelection?.fallbackReason
                 )
                 
                 //  [修复] 切换清晰度时使用 resetPlayer=false 减少闪烁，并传入 Referer
                 val referer = "https://www.bilibili.com/bangumi/play/ep${currentState.currentEpisode.id}"
+                val playWhenReady = exoPlayer?.playWhenReady ?: true
                 if (audioUrl.isNullOrEmpty() && durlSegmentUrls.size > 1) {
                     playSegmentedVideo(
                         segmentUrls = durlSegmentUrls,
@@ -590,8 +636,104 @@ class BangumiPlayerViewModel : BasePlayerViewModel() {
                 } else {
                     playDashVideo(videoUrl, audioUrl, currentPos, resetPlayer = false, referer = referer)
                 }
+                exoPlayer?.playWhenReady = playWhenReady
             }
         }
+    }
+
+    /**
+     * 切换音质。只有播放器源成功替换后才写入长期记忆。
+     */
+    fun changeAudioQuality(audioQuality: Int) {
+        viewModelScope.launch {
+            val switched = switchAudioQuality(audioQuality)
+            if (!switched) {
+                _toastEvent.send("音质切换失败，请稍后重试")
+                return@launch
+            }
+
+            NetworkModule.appContext?.let { context ->
+                SettingsManager.setAudioQuality(context, audioQuality)
+            }
+            sendAudioSelectionToast()
+        }
+    }
+
+    /**
+     * 处理 Hi-Res/杜比在高倍速下的临时回退，并在回到兼容倍速时恢复用户选择。
+     */
+    fun applyPlaybackSpeedFromUi(speed: Float) {
+        val player = exoPlayer ?: return
+        val previousSpeed = player.playbackParameters.speed
+        val normalizedSpeed = speed.coerceAtLeast(0.1f)
+        player.setPlaybackSpeed(normalizedSpeed)
+
+        val currentState = _uiState.value as? BangumiPlayerState.Success ?: return
+        if (!shouldRefreshPremiumAudioForPlaybackSpeedChange(
+                requestedAudioQuality = currentState.requestedAudioQuality,
+                previousPlaybackSpeed = previousSpeed,
+                nextPlaybackSpeed = normalizedSpeed
+            )
+        ) {
+            return
+        }
+
+        viewModelScope.launch {
+            switchAudioQuality(currentState.requestedAudioQuality)
+        }
+    }
+
+    private fun switchAudioQuality(audioQuality: Int): Boolean {
+        val currentState = _uiState.value as? BangumiPlayerState.Success ?: return false
+        val player = exoPlayer ?: return false
+        val dash = currentState.cachedDash ?: return false
+        val videoUrl = currentState.playUrl?.takeIf { it.isNotBlank() } ?: return false
+        val selection = resolveAudioStreamSelection(
+            dash = dash,
+            requestedAudioQuality = audioQuality,
+            playbackSpeed = player.playbackParameters.speed
+        )
+        val audioUrl = selection.selected?.track?.getValidUrl()
+            ?.takeIf { it.isNotBlank() }
+            ?: return false
+        val currentPosition = player.currentPosition.coerceAtLeast(0L)
+        val playWhenReady = player.playWhenReady
+        val referer =
+            "https://www.bilibili.com/bangumi/play/ep${currentState.currentEpisode.id}"
+
+        playDashVideo(
+            videoUrl = videoUrl,
+            audioUrl = audioUrl,
+            seekToMs = currentPosition,
+            resetPlayer = false,
+            referer = referer
+        )
+        player.playWhenReady = playWhenReady
+        _uiState.value = currentState.copy(
+            audioUrl = audioUrl,
+            requestedAudioQuality = audioQuality,
+            selectedAudioQuality = selection.selectedPreferenceId,
+            availableAudioQualities = selection.availableOptions,
+            audioFallbackReason = selection.fallbackReason
+        )
+        return true
+    }
+
+    private suspend fun sendAudioSelectionToast() {
+        val state = _uiState.value as? BangumiPlayerState.Success ?: return
+        val selectedLabel = state.availableAudioQualities
+            .firstOrNull { it.preferenceId == state.selectedAudioQuality }
+            ?.label
+            ?: "自动"
+        val message = when (state.audioFallbackReason) {
+            AudioFallbackReason.SPEED_INCOMPATIBLE ->
+                "当前倍速暂不支持所选音质，已临时使用 $selectedLabel"
+            AudioFallbackReason.REQUESTED_UNAVAILABLE ->
+                "当前视频不支持所选音质，已使用 $selectedLabel"
+            AudioFallbackReason.NO_PLAYABLE_AUDIO -> "当前视频没有可用音轨"
+            null -> "✓ 已切换至 $selectedLabel"
+        }
+        _toastEvent.send(message)
     }
     
     /**

--- a/app/src/main/java/com/android/purebilibili/feature/bangumi/BangumiPlayerViewModel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/bangumi/BangumiPlayerViewModel.kt
@@ -7,6 +7,7 @@ import com.android.purebilibili.core.player.BasePlayerViewModel
 import com.android.purebilibili.core.network.NetworkModule
 import com.android.purebilibili.core.store.SettingsManager
 import com.android.purebilibili.core.store.TokenManager
+import com.android.purebilibili.core.util.MediaUtils
 import com.android.purebilibili.data.model.response.*
 import com.android.purebilibili.data.repository.ActionRepository
 import com.android.purebilibili.data.repository.BangumiRepository
@@ -375,7 +376,8 @@ class BangumiPlayerViewModel : BasePlayerViewModel() {
                 resolveAudioStreamSelection(
                     dash = dash,
                     requestedAudioQuality = requestedAudioQuality,
-                    playbackSpeed = exoPlayer?.playbackParameters?.speed ?: 1.0f
+                    playbackSpeed = exoPlayer?.playbackParameters?.speed ?: 1.0f,
+                    isDolbyAudioSupported = MediaUtils.isDolbyAtmosAudioSupported()
                 )
             }
             
@@ -587,7 +589,8 @@ class BangumiPlayerViewModel : BasePlayerViewModel() {
                     resolveAudioStreamSelection(
                         dash = it,
                         requestedAudioQuality = currentState.requestedAudioQuality,
-                        playbackSpeed = exoPlayer?.playbackParameters?.speed ?: 1.0f
+                        playbackSpeed = exoPlayer?.playbackParameters?.speed ?: 1.0f,
+                        isDolbyAudioSupported = MediaUtils.isDolbyAtmosAudioSupported()
                     )
                 }
                 
@@ -691,7 +694,8 @@ class BangumiPlayerViewModel : BasePlayerViewModel() {
         val selection = resolveAudioStreamSelection(
             dash = dash,
             requestedAudioQuality = audioQuality,
-            playbackSpeed = player.playbackParameters.speed
+            playbackSpeed = player.playbackParameters.speed,
+            isDolbyAudioSupported = MediaUtils.isDolbyAtmosAudioSupported()
         )
         val audioUrl = selection.selected?.track?.getValidUrl()
             ?.takeIf { it.isNotBlank() }
@@ -724,7 +728,7 @@ class BangumiPlayerViewModel : BasePlayerViewModel() {
         val selectedLabel = state.availableAudioQualities
             .firstOrNull { it.preferenceId == state.selectedAudioQuality }
             ?.label
-            ?: "高品质 AAC"
+            ?: "AAC"
         val message = when (state.audioFallbackReason) {
             AudioFallbackReason.SPEED_INCOMPATIBLE ->
                 "当前倍速暂不支持所选音质，已临时使用 $selectedLabel"

--- a/app/src/main/java/com/android/purebilibili/feature/bangumi/ui/player/BangumiPlayerComponents.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/bangumi/ui/player/BangumiPlayerComponents.kt
@@ -50,7 +50,6 @@ import androidx.media3.common.Player
 import androidx.media3.common.VideoSize
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
-import androidx.media3.common.PlaybackParameters
 import androidx.media3.ui.PlayerView
 import com.android.purebilibili.core.plugin.PluginManager
 import com.android.purebilibili.data.model.response.Page
@@ -74,6 +73,8 @@ import com.android.purebilibili.feature.video.ui.gesture.resolveGestureLevelKind
 import com.android.purebilibili.feature.video.ui.gesture.resolveGestureLevelOverlaySpec
 import com.android.purebilibili.feature.video.ui.gesture.resolveGestureLevelOverlayStyle
 import com.android.purebilibili.feature.video.ui.overlay.PlaybackDebugInfo
+import com.android.purebilibili.feature.video.playback.audio.AudioQualityOption
+import com.android.purebilibili.feature.video.ui.section.resolveLongPressPlaybackParameters
 import com.android.purebilibili.feature.video.ui.section.VideoOutputRouter
 import com.android.purebilibili.feature.video.ui.section.VideoGestureMode
 import com.android.purebilibili.feature.video.ui.section.resolveSystemStreamVolumeFromGesture
@@ -124,6 +125,10 @@ fun BangumiPlayerView(
     isLoggedIn: Boolean = false,
     isVip: Boolean = false,
     onQualityChange: (Int) -> Unit = {},
+    requestedAudioQuality: Int = -1,
+    selectedAudioQuality: Int = -1,
+    availableAudioQualities: List<AudioQualityOption> = emptyList(),
+    onAudioQualityChange: (Int) -> Unit = {},
     onBack: () -> Unit,
     onToggleFullscreen: () -> Unit,
     sponsorSegment: SponsorSegment? = null,
@@ -318,12 +323,15 @@ fun BangumiPlayerView(
     Box(
         modifier = modifier
             .background(Color.Black)
-            .pointerInput(isScreenLocked, longPressSpeed, exoPlayer) {
+            .pointerInput(isScreenLocked, longPressSpeed, requestedAudioQuality, exoPlayer) {
                 detectDragGesturesAfterLongPress(
                     onDragStart = {
                         if (isScreenLocked) return@detectDragGesturesAfterLongPress
                         longPressOriginalPlaybackParameters = exoPlayer.playbackParameters
-                        exoPlayer.playbackParameters = PlaybackParameters(longPressSpeed)
+                        exoPlayer.playbackParameters = resolveLongPressPlaybackParameters(
+                            requestedSpeed = longPressSpeed,
+                            currentAudioQuality = requestedAudioQuality
+                        )
                     },
                     onDragEnd = {
                         exoPlayer.playbackParameters = longPressOriginalPlaybackParameters
@@ -606,6 +614,11 @@ fun BangumiPlayerView(
             isLoggedIn = isLoggedIn,
             isVip = isVip,
             onQualityChange = onQualityChange,
+            requestedAudioQuality = requestedAudioQuality,
+            selectedAudioQuality = selectedAudioQuality,
+            availableAudioQualities = availableAudioQualities,
+            onAudioQualityChange = onAudioQualityChange,
+            onPlaybackSpeedChange = onSpeedChange,
             onBack = onBack,
             onToggleFullscreen = onToggleFullscreen,
             danmakuEnabled = danmakuEnabled,

--- a/app/src/main/java/com/android/purebilibili/feature/bangumi/ui/player/BangumiPlayerOverlayHost.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/bangumi/ui/player/BangumiPlayerOverlayHost.kt
@@ -18,6 +18,7 @@ import com.android.purebilibili.feature.video.ui.overlay.PlaybackDebugInfo
 import com.android.purebilibili.feature.video.ui.overlay.SubtitleControlCallbacks
 import com.android.purebilibili.feature.video.ui.overlay.SubtitleControlUiState
 import com.android.purebilibili.feature.video.ui.overlay.VideoPlayerOverlay
+import com.android.purebilibili.feature.video.playback.audio.AudioQualityOption
 
 @Composable
 internal fun BangumiPlayerOverlayHost(
@@ -44,6 +45,11 @@ internal fun BangumiPlayerOverlayHost(
     isLoggedIn: Boolean,
     isVip: Boolean,
     onQualityChange: (Int) -> Unit,
+    requestedAudioQuality: Int,
+    selectedAudioQuality: Int,
+    availableAudioQualities: List<AudioQualityOption>,
+    onAudioQualityChange: (Int) -> Unit,
+    onPlaybackSpeedChange: (Float) -> Unit,
     onBack: () -> Unit,
     onToggleFullscreen: () -> Unit,
     danmakuEnabled: Boolean,
@@ -117,6 +123,11 @@ internal fun BangumiPlayerOverlayHost(
         currentAudioUrl = currentAudioUrl,
         debugInfo = debugInfo,
         isVip = isVip,
+        currentAudioQuality = requestedAudioQuality,
+        selectedAudioQuality = selectedAudioQuality,
+        availableAudioQualities = availableAudioQualities,
+        onAudioQualityChange = onAudioQualityChange,
+        onPlaybackSpeedChange = onPlaybackSpeedChange,
         isLiked = isLiked,
         isCoined = coinCount > 0,
         coinCount = coinCount,

--- a/app/src/main/java/com/android/purebilibili/feature/settings/PlaybackSettingsSelectionPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/settings/PlaybackSettingsSelectionPolicy.kt
@@ -72,7 +72,7 @@ internal fun resolveDefaultAudioQualityOptions(): List<PlaybackSegmentOption<Int
         PlaybackSegmentOption(DEFAULT_AUDIO_QUALITY_FOLLOW_LAST, "跟随上次"),
         PlaybackSegmentOption(30251, "Hi-Res 无损"),
         PlaybackSegmentOption(30250, "杜比全景声"),
-        PlaybackSegmentOption(-1, "高品质 AAC")
+        PlaybackSegmentOption(-1, "AAC")
     )
 }
 

--- a/app/src/main/java/com/android/purebilibili/feature/settings/PlaybackSettingsSelectionPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/settings/PlaybackSettingsSelectionPolicy.kt
@@ -70,11 +70,20 @@ internal fun resolveDefaultPlaybackQualityOptions(): List<PlaybackSegmentOption<
 internal fun resolveDefaultAudioQualityOptions(): List<PlaybackSegmentOption<Int>> {
     return listOf(
         PlaybackSegmentOption(DEFAULT_AUDIO_QUALITY_FOLLOW_LAST, "跟随上次"),
-        PlaybackSegmentOption(-1, "自动"),
-        PlaybackSegmentOption(30280, "192K"),
-        PlaybackSegmentOption(30250, "杜比"),
-        PlaybackSegmentOption(30251, "Hi-Res")
+        PlaybackSegmentOption(30251, "Hi-Res 无损"),
+        PlaybackSegmentOption(30250, "杜比全景声"),
+        PlaybackSegmentOption(-1, "高品质 AAC")
     )
+}
+
+internal fun normalizeDefaultAudioQualityOption(value: Int): Int {
+    return when (value) {
+        DEFAULT_AUDIO_QUALITY_FOLLOW_LAST,
+        -1,
+        30250,
+        30251 -> value
+        else -> -1
+    }
 }
 
 internal fun resolveDefaultQualitySubtitle(

--- a/app/src/main/java/com/android/purebilibili/feature/settings/PlaybackSettingsSelectionPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/settings/PlaybackSettingsSelectionPolicy.kt
@@ -2,6 +2,7 @@ package com.android.purebilibili.feature.settings
 
 import com.android.purebilibili.core.store.FullscreenAspectRatio
 import com.android.purebilibili.core.store.FullscreenMode
+import com.android.purebilibili.core.store.DEFAULT_AUDIO_QUALITY_FOLLOW_LAST
 import com.android.purebilibili.core.store.HomeFeedCardWidthPreset
 import com.android.purebilibili.core.store.PortraitPlayerCollapseMode
 import com.android.purebilibili.core.store.SettingsManager
@@ -63,6 +64,16 @@ internal fun resolveDefaultPlaybackQualityOptions(): List<PlaybackSegmentOption<
         PlaybackSegmentOption(64, "720P"),
         PlaybackSegmentOption(32, "480P"),
         PlaybackSegmentOption(16, "360P")
+    )
+}
+
+internal fun resolveDefaultAudioQualityOptions(): List<PlaybackSegmentOption<Int>> {
+    return listOf(
+        PlaybackSegmentOption(DEFAULT_AUDIO_QUALITY_FOLLOW_LAST, "跟随上次"),
+        PlaybackSegmentOption(-1, "自动"),
+        PlaybackSegmentOption(30280, "192K"),
+        PlaybackSegmentOption(30250, "杜比"),
+        PlaybackSegmentOption(30251, "Hi-Res")
     )
 }
 

--- a/app/src/main/java/com/android/purebilibili/feature/settings/SettingsSearchPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/settings/SettingsSearchPolicy.kt
@@ -83,7 +83,7 @@ private val SETTINGS_SEARCH_INDEX: List<SettingsSearchEntry> = listOf(
         title = "播放与画质",
         subtitle = "解码、画质、字幕、倍速、连播与网络策略",
         section = "设置",
-        aliases = listOf("播放", "解码", "画质", "默认画质", "最高画质", "自动最高画质", "省流量", "定向流量", "字幕", "倍速", "自动连播")
+        aliases = listOf("播放", "解码", "画质", "音质", "默认画质", "默认音质", "Hi-Res", "杜比", "最高画质", "自动最高画质", "省流量", "定向流量", "字幕", "倍速", "自动连播")
     ),
     SettingsSearchEntry(
         target = SettingsSearchTarget.FULLSCREEN_GESTURE,
@@ -302,6 +302,9 @@ private val SETTINGS_SEARCH_INDEX: List<SettingsSearchEntry> = listOf(
             "默认画质",
             "无线网络默认画质",
             "流量默认画质",
+            "默认音质",
+            "Hi-Res",
+            "杜比音质",
             "省流量模式",
             "定向流量",
             "b站定向流量",
@@ -596,9 +599,9 @@ private val SETTINGS_SEARCH_INDEX: List<SettingsSearchEntry> = listOf(
     SettingsSearchEntry(
         target = SettingsSearchTarget.PLAYBACK,
         title = "网络与画质",
-        subtitle = "自动最高画质、默认画质、定向流量",
+        subtitle = "自动最高画质、默认画质、默认音质、定向流量",
         section = "播放设置",
-        aliases = listOf("网络与画质", "自动最高画质", "默认画质", "无线网络默认画质", "流量默认画质", "定向流量", "b站定向流量"),
+        aliases = listOf("网络与画质", "自动最高画质", "默认画质", "无线网络默认画质", "流量默认画质", "默认音质", "音质", "Hi-Res", "杜比音质", "跟随上次选择", "定向流量", "b站定向流量"),
         focusId = SettingsSearchFocusIds.PLAYBACK_NETWORK
     ),
     SettingsSearchEntry(

--- a/app/src/main/java/com/android/purebilibili/feature/settings/screen/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/settings/screen/PlaybackSettingsScreen.kt
@@ -746,6 +746,11 @@ fun PlaybackSettingsContent(
                         .getWifiQuality(context).collectAsStateWithLifecycle(initialValue = 80)
                     val mobileQuality by com.android.purebilibili.core.store.SettingsManager
                         .getMobileQuality(context).collectAsStateWithLifecycle(initialValue = 64)
+                    val defaultAudioQuality by com.android.purebilibili.core.store.SettingsManager
+                        .getDefaultAudioQuality(context)
+                        .collectAsStateWithLifecycle(
+                            initialValue = com.android.purebilibili.core.store.DEFAULT_AUDIO_QUALITY_FOLLOW_LAST
+                        )
                     val autoHighestQualityEnabled by com.android.purebilibili.core.store.SettingsManager
                         .getAutoHighestQuality(context).collectAsStateWithLifecycle(initialValue = false)
                     val directedTrafficEnabled by com.android.purebilibili.core.store.SettingsManager
@@ -755,11 +760,18 @@ fun PlaybackSettingsContent(
                     val isVip = TokenManager.isVipCache
 
                     val qualityOptions = resolveDefaultPlaybackQualityOptions()
+                    val audioQualityOptions = resolveDefaultAudioQualityOptions()
 
                     fun getQualityLabel(id: Int): String = resolveSelectionLabel(
                         options = qualityOptions,
                         selectedValue = id,
                         fallbackLabel = "720P"
+                    )
+
+                    fun getAudioQualityLabel(id: Int): String = resolveSelectionLabel(
+                        options = audioQualityOptions,
+                        selectedValue = id,
+                        fallbackLabel = "跟随上次"
                     )
 
                     IOSGroup {
@@ -860,6 +872,28 @@ fun PlaybackSettingsContent(
                                 scope.launch {
                                     com.android.purebilibili.core.store.SettingsManager
                                         .setMobileQuality(context, qualityId)
+                                }
+                            }
+                        )
+
+                        IOSDivider()
+
+                        IOSSlidingSegmentedSetting(
+                            title = "默认音质：${getAudioQualityLabel(defaultAudioQuality)}",
+                            subtitle = if (
+                                defaultAudioQuality ==
+                                com.android.purebilibili.core.store.DEFAULT_AUDIO_QUALITY_FOLLOW_LAST
+                            ) {
+                                "新视频跟随播放器上次手动选择"
+                            } else {
+                                "具体默认音质优先于上次手动选择；当前视频仍可临时切换"
+                            },
+                            options = audioQualityOptions,
+                            selectedValue = defaultAudioQuality,
+                            onSelectionChange = { audioQuality ->
+                                scope.launch {
+                                    com.android.purebilibili.core.store.SettingsManager
+                                        .setDefaultAudioQuality(context, audioQuality)
                                 }
                             }
                         )

--- a/app/src/main/java/com/android/purebilibili/feature/settings/screen/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/settings/screen/PlaybackSettingsScreen.kt
@@ -761,6 +761,8 @@ fun PlaybackSettingsContent(
 
                     val qualityOptions = resolveDefaultPlaybackQualityOptions()
                     val audioQualityOptions = resolveDefaultAudioQualityOptions()
+                    val normalizedDefaultAudioQuality =
+                        normalizeDefaultAudioQualityOption(defaultAudioQuality)
 
                     fun getQualityLabel(id: Int): String = resolveSelectionLabel(
                         options = qualityOptions,
@@ -879,9 +881,9 @@ fun PlaybackSettingsContent(
                         IOSDivider()
 
                         IOSSlidingSegmentedSetting(
-                            title = "默认音质：${getAudioQualityLabel(defaultAudioQuality)}",
+                            title = "默认音质：${getAudioQualityLabel(normalizedDefaultAudioQuality)}",
                             subtitle = if (
-                                defaultAudioQuality ==
+                                normalizedDefaultAudioQuality ==
                                 com.android.purebilibili.core.store.DEFAULT_AUDIO_QUALITY_FOLLOW_LAST
                             ) {
                                 "新视频跟随播放器上次手动选择"
@@ -889,7 +891,7 @@ fun PlaybackSettingsContent(
                                 "具体默认音质优先于上次手动选择；当前视频仍可临时切换"
                             },
                             options = audioQualityOptions,
-                            selectedValue = defaultAudioQuality,
+                            selectedValue = normalizedDefaultAudioQuality,
                             onSelectionChange = { audioQuality ->
                                 scope.launch {
                                     com.android.purebilibili.core.store.SettingsManager

--- a/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamModels.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamModels.kt
@@ -1,0 +1,45 @@
+package com.android.purebilibili.feature.video.playback.audio
+
+import com.android.purebilibili.data.model.response.DashAudio
+
+const val AUDIO_QUALITY_FOLLOW_LAST_SELECTED = -2
+const val AUDIO_QUALITY_AUTO = -1
+const val AUDIO_QUALITY_DOLBY = 30250
+const val AUDIO_QUALITY_HI_RES = 30251
+
+enum class AudioStreamKind {
+    STANDARD,
+    DOLBY,
+    HI_RES
+}
+
+enum class AudioFallbackReason {
+    REQUESTED_UNAVAILABLE,
+    SPEED_INCOMPATIBLE,
+    NO_PLAYABLE_AUDIO
+}
+
+data class AudioStreamCandidate(
+    val preferenceId: Int,
+    val kind: AudioStreamKind,
+    val label: String,
+    val track: DashAudio
+)
+
+data class AudioQualityOption(
+    val preferenceId: Int,
+    val kind: AudioStreamKind?,
+    val label: String,
+    val isHiRes: Boolean = false
+)
+
+data class AudioSelectionDecision(
+    val requestedPreferenceId: Int,
+    val effectivePreferenceId: Int,
+    val selected: AudioStreamCandidate?,
+    val availableOptions: List<AudioQualityOption>,
+    val fallbackReason: AudioFallbackReason?
+) {
+    val selectedPreferenceId: Int
+        get() = selected?.preferenceId ?: AUDIO_QUALITY_AUTO
+}

--- a/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamModels.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamModels.kt
@@ -43,5 +43,9 @@ data class AudioSelectionDecision(
     val fallbackReason: AudioFallbackReason?
 ) {
     val selectedPreferenceId: Int
-        get() = selected?.preferenceId ?: AUDIO_QUALITY_AUTO
+        get() = when (selected?.kind) {
+            AudioStreamKind.HI_RES -> AUDIO_QUALITY_HI_RES
+            AudioStreamKind.DOLBY -> AUDIO_QUALITY_DOLBY
+            AudioStreamKind.STANDARD, null -> AUDIO_QUALITY_AUTO
+        }
 }

--- a/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamModels.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamModels.kt
@@ -31,7 +31,8 @@ data class AudioQualityOption(
     val preferenceId: Int,
     val kind: AudioStreamKind?,
     val label: String,
-    val isHiRes: Boolean = false
+    val isHiRes: Boolean = false,
+    val isDolby: Boolean = false
 )
 
 data class AudioSelectionDecision(

--- a/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamModels.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamModels.kt
@@ -17,6 +17,7 @@ enum class AudioStreamKind {
 enum class AudioFallbackReason {
     REQUESTED_UNAVAILABLE,
     SPEED_INCOMPATIBLE,
+    DECODER_ERROR,
     NO_PLAYABLE_AUDIO
 }
 

--- a/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamModels.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamModels.kt
@@ -1,8 +1,9 @@
 package com.android.purebilibili.feature.video.playback.audio
 
 import com.android.purebilibili.data.model.response.DashAudio
+import com.android.purebilibili.core.store.DEFAULT_AUDIO_QUALITY_FOLLOW_LAST
 
-const val AUDIO_QUALITY_FOLLOW_LAST_SELECTED = -2
+const val AUDIO_QUALITY_FOLLOW_LAST_SELECTED = DEFAULT_AUDIO_QUALITY_FOLLOW_LAST
 const val AUDIO_QUALITY_AUTO = -1
 const val AUDIO_QUALITY_DOLBY = 30250
 const val AUDIO_QUALITY_HI_RES = 30251

--- a/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamModels.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamModels.kt
@@ -35,6 +35,12 @@ data class AudioQualityOption(
     val isDolby: Boolean = false
 )
 
+data class AudioQualityControlPresentation(
+    val label: String,
+    val showHiResBadge: Boolean,
+    val showDolbyBadge: Boolean
+)
+
 data class AudioSelectionDecision(
     val requestedPreferenceId: Int,
     val effectivePreferenceId: Int,

--- a/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicy.kt
@@ -1,17 +1,26 @@
 package com.android.purebilibili.feature.video.playback.audio
 
 import com.android.purebilibili.data.model.response.Dash
-import com.android.purebilibili.data.model.response.DashAudio
 import com.android.purebilibili.feature.video.playback.policy.resolveSpeedCompatibleAudioQualityPreference
 
 fun resolveRequestedAudioQuality(
     defaultAudioQuality: Int,
     rememberedAudioQuality: Int
 ): Int {
-    return if (defaultAudioQuality == AUDIO_QUALITY_FOLLOW_LAST_SELECTED) {
+    val resolvedPreference = if (defaultAudioQuality == AUDIO_QUALITY_FOLLOW_LAST_SELECTED) {
         rememberedAudioQuality
     } else {
         defaultAudioQuality
+    }
+    return normalizeAudioQualityPreference(resolvedPreference)
+}
+
+fun normalizeAudioQualityPreference(preferenceId: Int): Int {
+    return when (preferenceId) {
+        AUDIO_QUALITY_HI_RES,
+        AUDIO_QUALITY_DOLBY,
+        AUDIO_QUALITY_AUTO -> preferenceId
+        else -> AUDIO_QUALITY_AUTO
     }
 }
 
@@ -22,7 +31,7 @@ fun collectAudioStreamCandidates(dash: Dash): List<AudioStreamCandidate> {
             AudioStreamCandidate(
                 preferenceId = track.id,
                 kind = AudioStreamKind.STANDARD,
-                label = resolveStandardAudioLabel(track),
+                label = "高品质 AAC",
                 track = track
             )
         }
@@ -64,7 +73,8 @@ fun buildAvailableAudioQualityOptions(
 ): List<AudioQualityOption> {
     if (candidates.isEmpty()) return emptyList()
 
-    val explicitOptions = candidates
+    val premiumOptions = candidates
+        .filter { it.kind != AudioStreamKind.STANDARD }
         .groupBy { it.preferenceId }
         .mapNotNull { (_, groupedCandidates) ->
             groupedCandidates.maxByOrNull { it.track.bandwidth }
@@ -84,16 +94,16 @@ fun buildAvailableAudioQualityOptions(
         }
 
     val hasStandardAudio = candidates.any { it.kind == AudioStreamKind.STANDARD }
-    return if (hasStandardAudio) {
+    return premiumOptions + if (hasStandardAudio) {
         listOf(
             AudioQualityOption(
                 preferenceId = AUDIO_QUALITY_AUTO,
-                kind = null,
-                label = "自动（普通最佳）"
+                kind = AudioStreamKind.STANDARD,
+                label = "高品质 AAC"
             )
-        ) + explicitOptions
+        )
     } else {
-        explicitOptions
+        emptyList()
     }
 }
 
@@ -102,11 +112,12 @@ fun resolveAudioStreamSelection(
     requestedAudioQuality: Int,
     playbackSpeed: Float = 1.0f
 ): AudioSelectionDecision {
+    val normalizedRequestedAudioQuality = normalizeAudioQualityPreference(requestedAudioQuality)
     val candidates = collectAudioStreamCandidates(dash)
     val availableOptions = buildAvailableAudioQualityOptions(candidates)
     if (candidates.isEmpty()) {
         return AudioSelectionDecision(
-            requestedPreferenceId = requestedAudioQuality,
+            requestedPreferenceId = normalizedRequestedAudioQuality,
             effectivePreferenceId = AUDIO_QUALITY_AUTO,
             selected = null,
             availableOptions = emptyList(),
@@ -115,7 +126,7 @@ fun resolveAudioStreamSelection(
     }
 
     val effectivePreference = resolveSpeedCompatibleAudioQualityPreference(
-        requestedAudioQuality = requestedAudioQuality,
+        requestedAudioQuality = normalizedRequestedAudioQuality,
         playbackSpeed = playbackSpeed
     )
     val bestStandard = candidates
@@ -132,7 +143,7 @@ fun resolveAudioStreamSelection(
     val selected = exactSelection ?: bestStandard
     val fallbackReason = when {
         selected == null -> AudioFallbackReason.NO_PLAYABLE_AUDIO
-        effectivePreference != requestedAudioQuality ->
+        effectivePreference != normalizedRequestedAudioQuality ->
             AudioFallbackReason.SPEED_INCOMPATIBLE
         effectivePreference != AUDIO_QUALITY_AUTO && exactSelection == null ->
             AudioFallbackReason.REQUESTED_UNAVAILABLE
@@ -140,26 +151,12 @@ fun resolveAudioStreamSelection(
     }
 
     return AudioSelectionDecision(
-        requestedPreferenceId = requestedAudioQuality,
+        requestedPreferenceId = normalizedRequestedAudioQuality,
         effectivePreferenceId = effectivePreference,
         selected = selected,
         availableOptions = availableOptions,
         fallbackReason = fallbackReason
     )
-}
-
-private fun resolveStandardAudioLabel(track: DashAudio): String {
-    return when (track.id) {
-        30280 -> "192K"
-        30232 -> "132K"
-        30216 -> "64K"
-        else -> {
-            val bitrateKbps = track.bandwidth
-                .takeIf { it > 0 }
-                ?.div(1000)
-            bitrateKbps?.let { "${it}K" } ?: "音质 ${track.id}"
-        }
-    }
 }
 
 private fun audioKindOrder(kind: AudioStreamKind): Int {

--- a/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicy.kt
@@ -78,7 +78,8 @@ fun buildAvailableAudioQualityOptions(
                 preferenceId = candidate.preferenceId,
                 kind = candidate.kind,
                 label = candidate.label,
-                isHiRes = candidate.kind == AudioStreamKind.HI_RES
+                isHiRes = candidate.kind == AudioStreamKind.HI_RES,
+                isDolby = candidate.kind == AudioStreamKind.DOLBY
             )
         }
 

--- a/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicy.kt
@@ -24,34 +24,41 @@ fun normalizeAudioQualityPreference(preferenceId: Int): Int {
     }
 }
 
-fun collectAudioStreamCandidates(dash: Dash): List<AudioStreamCandidate> {
+fun collectAudioStreamCandidates(
+    dash: Dash,
+    isDolbyAudioSupported: Boolean = true
+): List<AudioStreamCandidate> {
     val standard = dash.audio.orEmpty()
         .filter { it.getValidUrl().isNotBlank() }
         .map { track ->
             AudioStreamCandidate(
                 preferenceId = track.id,
                 kind = AudioStreamKind.STANDARD,
-                label = "高品质 AAC",
+                label = "AAC",
                 track = track
             )
         }
-    val dolby = dash.dolby
-        ?.takeIf { it.type > 0 }
-        ?.audio
-        .orEmpty()
-        .filter { track ->
-            track.getValidUrl().isNotBlank() &&
-                track.id == AUDIO_QUALITY_DOLBY &&
-                track.codecs.isDolbyAtmosCodec()
-        }
-        .map { track ->
-            AudioStreamCandidate(
-                preferenceId = AUDIO_QUALITY_DOLBY,
-                kind = AudioStreamKind.DOLBY,
-                label = "杜比全景声",
-                track = track
-            )
-        }
+    val dolby = if (isDolbyAudioSupported) {
+        dash.dolby
+            ?.takeIf { it.type > 0 }
+            ?.audio
+            .orEmpty()
+            .filter { track ->
+                track.getValidUrl().isNotBlank() &&
+                    track.id == AUDIO_QUALITY_DOLBY &&
+                    track.codecs.isDolbyAtmosCodec()
+            }
+            .map { track ->
+                AudioStreamCandidate(
+                    preferenceId = AUDIO_QUALITY_DOLBY,
+                    kind = AudioStreamKind.DOLBY,
+                    label = "杜比全景声",
+                    track = track
+                )
+            }
+    } else {
+        emptyList()
+    }
     val hiRes = dash.flac?.audio
         ?.takeIf { it.getValidUrl().isNotBlank() }
         ?.let { track ->
@@ -106,7 +113,7 @@ fun buildAvailableAudioQualityOptions(
             AudioQualityOption(
                 preferenceId = AUDIO_QUALITY_AUTO,
                 kind = AudioStreamKind.STANDARD,
-                label = "高品质 AAC"
+                label = "AAC"
             )
         )
     } else {
@@ -117,10 +124,14 @@ fun buildAvailableAudioQualityOptions(
 fun resolveAudioStreamSelection(
     dash: Dash,
     requestedAudioQuality: Int,
-    playbackSpeed: Float = 1.0f
+    playbackSpeed: Float = 1.0f,
+    isDolbyAudioSupported: Boolean = true
 ): AudioSelectionDecision {
     val normalizedRequestedAudioQuality = normalizeAudioQualityPreference(requestedAudioQuality)
-    val candidates = collectAudioStreamCandidates(dash)
+    val candidates = collectAudioStreamCandidates(
+        dash = dash,
+        isDolbyAudioSupported = isDolbyAudioSupported
+    )
     val availableOptions = buildAvailableAudioQualityOptions(candidates)
     if (candidates.isEmpty()) {
         return AudioSelectionDecision(

--- a/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicy.kt
@@ -35,8 +35,15 @@ fun collectAudioStreamCandidates(dash: Dash): List<AudioStreamCandidate> {
                 track = track
             )
         }
-    val dolby = dash.dolby?.audio.orEmpty()
-        .filter { it.getValidUrl().isNotBlank() }
+    val dolby = dash.dolby
+        ?.takeIf { it.type > 0 }
+        ?.audio
+        .orEmpty()
+        .filter { track ->
+            track.getValidUrl().isNotBlank() &&
+                track.id == AUDIO_QUALITY_DOLBY &&
+                track.codecs.isDolbyAtmosCodec()
+        }
         .map { track ->
             AudioStreamCandidate(
                 preferenceId = AUDIO_QUALITY_DOLBY,
@@ -157,6 +164,33 @@ fun resolveAudioStreamSelection(
         availableOptions = availableOptions,
         fallbackReason = fallbackReason
     )
+}
+
+fun resolveAudioQualityControlPresentation(
+    options: List<AudioQualityOption>,
+    selectedAudioQuality: Int
+): AudioQualityControlPresentation {
+    val selectedOption = options.firstOrNull { it.preferenceId == selectedAudioQuality }
+    val label = when (selectedOption?.preferenceId) {
+        AUDIO_QUALITY_HI_RES -> "音质"
+        AUDIO_QUALITY_DOLBY -> "杜比"
+        else -> selectedOption?.label?.takeIf { it.isNotBlank() } ?: "音质"
+    }
+    return AudioQualityControlPresentation(
+        label = label,
+        showHiResBadge = selectedOption?.isHiRes == true,
+        showDolbyBadge = selectedOption?.isDolby == true
+    )
+}
+
+private fun String.isDolbyAtmosCodec(): Boolean {
+    val normalized = lowercase()
+        .replace("_", "-")
+        .replace(" ", "")
+    return normalized.contains("ec-3") ||
+        normalized.contains("e-ac-3") ||
+        normalized.contains("eac3") ||
+        normalized == "ec3"
 }
 
 private fun audioKindOrder(kind: AudioStreamKind): Int {

--- a/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicy.kt
@@ -1,0 +1,170 @@
+package com.android.purebilibili.feature.video.playback.audio
+
+import com.android.purebilibili.data.model.response.Dash
+import com.android.purebilibili.data.model.response.DashAudio
+import com.android.purebilibili.feature.video.playback.policy.resolveSpeedCompatibleAudioQualityPreference
+
+fun resolveRequestedAudioQuality(
+    defaultAudioQuality: Int,
+    rememberedAudioQuality: Int
+): Int {
+    return if (defaultAudioQuality == AUDIO_QUALITY_FOLLOW_LAST_SELECTED) {
+        rememberedAudioQuality
+    } else {
+        defaultAudioQuality
+    }
+}
+
+fun collectAudioStreamCandidates(dash: Dash): List<AudioStreamCandidate> {
+    val standard = dash.audio.orEmpty()
+        .filter { it.getValidUrl().isNotBlank() }
+        .map { track ->
+            AudioStreamCandidate(
+                preferenceId = track.id,
+                kind = AudioStreamKind.STANDARD,
+                label = resolveStandardAudioLabel(track),
+                track = track
+            )
+        }
+    val dolby = dash.dolby?.audio.orEmpty()
+        .filter { it.getValidUrl().isNotBlank() }
+        .map { track ->
+            AudioStreamCandidate(
+                preferenceId = AUDIO_QUALITY_DOLBY,
+                kind = AudioStreamKind.DOLBY,
+                label = "杜比全景声",
+                track = track
+            )
+        }
+    val hiRes = dash.flac?.audio
+        ?.takeIf { it.getValidUrl().isNotBlank() }
+        ?.let { track ->
+            AudioStreamCandidate(
+                preferenceId = AUDIO_QUALITY_HI_RES,
+                kind = AudioStreamKind.HI_RES,
+                label = "Hi-Res 无损",
+                track = track
+            )
+        }
+        ?.let(::listOf)
+        .orEmpty()
+
+    return (hiRes + dolby + standard)
+        .distinctBy { candidate ->
+            Triple(
+                candidate.preferenceId,
+                candidate.kind,
+                candidate.track.getValidUrl()
+            )
+        }
+}
+
+fun buildAvailableAudioQualityOptions(
+    candidates: List<AudioStreamCandidate>
+): List<AudioQualityOption> {
+    if (candidates.isEmpty()) return emptyList()
+
+    val explicitOptions = candidates
+        .groupBy { it.preferenceId }
+        .mapNotNull { (_, groupedCandidates) ->
+            groupedCandidates.maxByOrNull { it.track.bandwidth }
+        }
+        .sortedWith(
+            compareBy<AudioStreamCandidate> { audioKindOrder(it.kind) }
+                .thenByDescending { it.track.bandwidth }
+        )
+        .map { candidate ->
+            AudioQualityOption(
+                preferenceId = candidate.preferenceId,
+                kind = candidate.kind,
+                label = candidate.label,
+                isHiRes = candidate.kind == AudioStreamKind.HI_RES
+            )
+        }
+
+    val hasStandardAudio = candidates.any { it.kind == AudioStreamKind.STANDARD }
+    return if (hasStandardAudio) {
+        listOf(
+            AudioQualityOption(
+                preferenceId = AUDIO_QUALITY_AUTO,
+                kind = null,
+                label = "自动（普通最佳）"
+            )
+        ) + explicitOptions
+    } else {
+        explicitOptions
+    }
+}
+
+fun resolveAudioStreamSelection(
+    dash: Dash,
+    requestedAudioQuality: Int,
+    playbackSpeed: Float = 1.0f
+): AudioSelectionDecision {
+    val candidates = collectAudioStreamCandidates(dash)
+    val availableOptions = buildAvailableAudioQualityOptions(candidates)
+    if (candidates.isEmpty()) {
+        return AudioSelectionDecision(
+            requestedPreferenceId = requestedAudioQuality,
+            effectivePreferenceId = AUDIO_QUALITY_AUTO,
+            selected = null,
+            availableOptions = emptyList(),
+            fallbackReason = AudioFallbackReason.NO_PLAYABLE_AUDIO
+        )
+    }
+
+    val effectivePreference = resolveSpeedCompatibleAudioQualityPreference(
+        requestedAudioQuality = requestedAudioQuality,
+        playbackSpeed = playbackSpeed
+    )
+    val bestStandard = candidates
+        .filter { it.kind == AudioStreamKind.STANDARD }
+        .maxByOrNull { it.track.bandwidth }
+
+    val exactSelection = if (effectivePreference == AUDIO_QUALITY_AUTO) {
+        bestStandard
+    } else {
+        candidates
+            .filter { it.preferenceId == effectivePreference }
+            .maxByOrNull { it.track.bandwidth }
+    }
+    val selected = exactSelection ?: bestStandard
+    val fallbackReason = when {
+        selected == null -> AudioFallbackReason.NO_PLAYABLE_AUDIO
+        effectivePreference != requestedAudioQuality ->
+            AudioFallbackReason.SPEED_INCOMPATIBLE
+        effectivePreference != AUDIO_QUALITY_AUTO && exactSelection == null ->
+            AudioFallbackReason.REQUESTED_UNAVAILABLE
+        else -> null
+    }
+
+    return AudioSelectionDecision(
+        requestedPreferenceId = requestedAudioQuality,
+        effectivePreferenceId = effectivePreference,
+        selected = selected,
+        availableOptions = availableOptions,
+        fallbackReason = fallbackReason
+    )
+}
+
+private fun resolveStandardAudioLabel(track: DashAudio): String {
+    return when (track.id) {
+        30280 -> "192K"
+        30232 -> "132K"
+        30216 -> "64K"
+        else -> {
+            val bitrateKbps = track.bandwidth
+                .takeIf { it > 0 }
+                ?.div(1000)
+            bitrateKbps?.let { "${it}K" } ?: "音质 ${track.id}"
+        }
+    }
+}
+
+private fun audioKindOrder(kind: AudioStreamKind): Int {
+    return when (kind) {
+        AudioStreamKind.HI_RES -> 0
+        AudioStreamKind.DOLBY -> 1
+        AudioStreamKind.STANDARD -> 2
+    }
+}

--- a/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicy.kt
@@ -183,7 +183,7 @@ fun resolveAudioQualityControlPresentation(
 ): AudioQualityControlPresentation {
     val selectedOption = options.firstOrNull { it.preferenceId == selectedAudioQuality }
     val label = when (selectedOption?.preferenceId) {
-        AUDIO_QUALITY_HI_RES -> "音质"
+        AUDIO_QUALITY_HI_RES -> "Hi-Res"
         AUDIO_QUALITY_DOLBY -> "杜比"
         else -> selectedOption?.label?.takeIf { it.isNotBlank() } ?: "音质"
     }

--- a/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/PremiumAudioPlaybackFailurePolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/playback/audio/PremiumAudioPlaybackFailurePolicy.kt
@@ -1,0 +1,24 @@
+package com.android.purebilibili.feature.video.playback.audio
+
+import androidx.media3.common.PlaybackException
+
+internal fun isPremiumAudioPlaybackFailure(
+    errorCode: Int,
+    selectedAudioQuality: Int,
+    rendererName: String?,
+    rendererSampleMimeType: String?
+): Boolean {
+    if (selectedAudioQuality != AUDIO_QUALITY_HI_RES) return false
+
+    val rendererLooksLikeAudio = rendererName.orEmpty().contains("audio", ignoreCase = true) ||
+        rendererSampleMimeType.orEmpty().startsWith("audio/", ignoreCase = true)
+    if (!rendererLooksLikeAudio) return false
+
+    return errorCode in setOf(
+        PlaybackException.ERROR_CODE_DECODER_INIT_FAILED,
+        PlaybackException.ERROR_CODE_DECODING_FAILED,
+        PlaybackException.ERROR_CODE_AUDIO_TRACK_INIT_FAILED,
+        PlaybackException.ERROR_CODE_AUDIO_TRACK_WRITE_FAILED,
+        PlaybackException.ERROR_CODE_FAILED_RUNTIME_CHECK
+    )
+}

--- a/app/src/main/java/com/android/purebilibili/feature/video/playback/policy/AdaptiveDashTrackPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/playback/policy/AdaptiveDashTrackPolicy.kt
@@ -3,6 +3,10 @@ package com.android.purebilibili.feature.video.playback.policy
 import com.android.purebilibili.data.model.response.Dash
 import com.android.purebilibili.data.model.response.DashAudio
 import com.android.purebilibili.data.model.response.DashVideo
+import com.android.purebilibili.feature.video.playback.audio.AUDIO_QUALITY_AUTO
+import com.android.purebilibili.feature.video.playback.audio.AudioStreamKind
+import com.android.purebilibili.feature.video.playback.audio.collectAudioStreamCandidates
+import com.android.purebilibili.feature.video.playback.audio.resolveAudioStreamSelection
 import com.android.purebilibili.feature.video.viewmodel.normalizeCodecFamilyKey
 
 data class AdaptiveDashTrackSet(
@@ -105,14 +109,17 @@ fun buildAdaptiveDashTrackSet(
             .thenByDescending { it.bandwidth }
     )
 
-    val sortedAudios = dash.audio
-        .orEmpty()
-        .filter { it.getValidUrl().isNotBlank() }
-        .sortedWith(
-            compareByDescending<DashAudio> {
-                if (preferredAudioQuality > 0 && it.id == preferredAudioQuality) 1 else 0
-            }.thenByDescending { it.bandwidth }
-        )
+    val sortedAudios = if (preferredAudioQuality == AUDIO_QUALITY_AUTO) {
+        collectAudioStreamCandidates(dash)
+            .filter { it.kind == AudioStreamKind.STANDARD }
+            .map { it.track }
+            .sortedByDescending { it.bandwidth }
+    } else {
+        resolveAudioStreamSelection(
+            dash = dash,
+            requestedAudioQuality = preferredAudioQuality
+        ).selected?.track?.let(::listOf).orEmpty()
+    }
 
     return AdaptiveDashTrackSet(
         videoTracks = sortedVideos,

--- a/app/src/main/java/com/android/purebilibili/feature/video/playback/policy/AdaptiveDashTrackPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/playback/policy/AdaptiveDashTrackPolicy.kt
@@ -60,7 +60,8 @@ fun buildAdaptiveDashTrackSet(
     preferredVideoCodec: String,
     secondaryVideoCodec: String,
     isHevcSupported: Boolean,
-    isAv1Supported: Boolean
+    isAv1Supported: Boolean,
+    isDolbyAudioSupported: Boolean = true
 ): AdaptiveDashTrackSet {
     val preferredCodec = normalizeCodecFamilyKey(preferredVideoCodec)
     val secondaryCodec = normalizeCodecFamilyKey(secondaryVideoCodec)
@@ -117,7 +118,8 @@ fun buildAdaptiveDashTrackSet(
     } else {
         resolveAudioStreamSelection(
             dash = dash,
-            requestedAudioQuality = preferredAudioQuality
+            requestedAudioQuality = preferredAudioQuality,
+            isDolbyAudioSupported = isDolbyAudioSupported
         ).selected?.track?.let(::listOf).orEmpty()
     }
 

--- a/app/src/main/java/com/android/purebilibili/feature/video/player/MiniPlayerManager.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/player/MiniPlayerManager.kt
@@ -42,6 +42,7 @@ import coil.size.Scale
 import coil.transform.RoundedCornersTransformation
 import com.android.purebilibili.R
 import com.android.purebilibili.core.network.NetworkModule
+import com.android.purebilibili.core.player.HiResCompatibleRenderersFactory
 import com.android.purebilibili.core.player.PlaybackMediaCache
 import com.android.purebilibili.core.player.PlayerVolumeController
 import com.android.purebilibili.core.store.SettingsManager
@@ -1632,6 +1633,7 @@ class MiniPlayerManager private constructor(private val context: Context) :
             val audioFocusEnabled = SettingsManager.getAudioFocusEnabledSync(context)
 
             _player = ExoPlayer.Builder(context)
+                .setRenderersFactory(HiResCompatibleRenderersFactory(context))
                 .setMediaSourceFactory(DefaultMediaSourceFactory(dataSourceFactory))
                 .setAudioAttributes(
                     audioAttributes,

--- a/app/src/main/java/com/android/purebilibili/feature/video/screen/AudioModeMusicPlayer.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/screen/AudioModeMusicPlayer.kt
@@ -28,6 +28,7 @@ import com.android.purebilibili.feature.audio.player.MusicQueueItemUi
 import com.android.purebilibili.feature.audio.screen.MusicPlayerContent
 import com.android.purebilibili.feature.audio.viewmodel.MusicViewModel
 import com.android.purebilibili.feature.video.player.PlaylistManager
+import com.android.purebilibili.feature.video.playback.audio.resolveAudioQualityControlPresentation
 import com.android.purebilibili.feature.video.ui.components.CollectionSheet
 import com.android.purebilibili.feature.video.ui.components.PagesSelector
 import com.android.purebilibili.feature.video.viewmodel.VideoPlaybackUiState
@@ -164,6 +165,15 @@ internal fun AudioModeMusicPlayer(
     }
     val currentIndex = playlistIndex.takeIf { it in queue.indices } ?: 0
     val coverUrl = queue.getOrNull(currentIndex)?.coverUrl ?: FormatUtils.fixImageUrl(info.pic)
+    val audioQualityPresentation = remember(
+        successState.availableAudioQualities,
+        successState.selectedAudioQuality
+    ) {
+        resolveAudioQualityControlPresentation(
+            options = successState.availableAudioQualities,
+            selectedAudioQuality = successState.selectedAudioQuality
+        )
+    }
 
     MusicPlayerContent(
         state = MusicPlayerUiState(
@@ -215,6 +225,12 @@ internal fun AudioModeMusicPlayer(
         },
         onSleepTimerClick = { showSleepTimerDialog = true },
         sleepTimerLabel = formatAudioModeSleepTimerButtonLabel(sleepTimerMinutes),
+        audioQualityLabel = audioQualityPresentation.label,
+        audioQualityOptions = successState.availableAudioQualities,
+        requestedAudioQuality = successState.requestedAudioQuality,
+        isHiResAudioSelected = audioQualityPresentation.showHiResBadge,
+        isDolbyAudioSelected = audioQualityPresentation.showDolbyBadge,
+        onAudioQualitySelected = viewModel::setAudioQuality,
         onPipClick = if (showPipButton) onEnterPip else null,
         onToggleOrientation = onToggleOrientation,
         orientationActionLabel = orientationActionLabel,

--- a/app/src/main/java/com/android/purebilibili/feature/video/state/PlayerErrorRecoveryPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/state/PlayerErrorRecoveryPolicy.kt
@@ -3,6 +3,7 @@ package com.android.purebilibili.feature.video.state
 import androidx.media3.common.PlaybackException
 
 internal enum class PlayerErrorRecoveryAction {
+    FALLBACK_PREMIUM_AUDIO,
     SWITCH_CDN,
     RETRY_NETWORK,
     RETRY_DECODER_FALLBACK,
@@ -17,8 +18,12 @@ internal fun decidePlayerErrorRecovery(
     maxRetries: Int,
     cdnSwitchCount: Int,
     maxCdnSwitches: Int,
-    isDecoderLikeFailure: Boolean
+    isDecoderLikeFailure: Boolean,
+    isPremiumAudioFailure: Boolean = false
 ): PlayerErrorRecoveryAction {
+    if (isPremiumAudioFailure) {
+        return PlayerErrorRecoveryAction.FALLBACK_PREMIUM_AUDIO
+    }
     return if (isNetworkPlaybackError(errorCode)) {
         when {
             hasCdnAlternatives && cdnSwitchCount < maxCdnSwitches -> PlayerErrorRecoveryAction.SWITCH_CDN

--- a/app/src/main/java/com/android/purebilibili/feature/video/state/VideoPlayerState.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/state/VideoPlayerState.kt
@@ -27,6 +27,7 @@ import androidx.media3.common.Player
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.analytics.AnalyticsListener
+import androidx.media3.exoplayer.ExoPlaybackException
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import coil.imageLoader
@@ -36,6 +37,7 @@ import coil.size.Scale
 import coil.transform.RoundedCornersTransformation
 import com.android.purebilibili.R
 import com.android.purebilibili.core.network.NetworkModule
+import com.android.purebilibili.core.player.HiResCompatibleRenderersFactory
 import com.android.purebilibili.core.player.PlaybackMediaCache
 import com.android.purebilibili.core.util.FormatUtils
 import com.android.purebilibili.core.util.Logger
@@ -43,6 +45,7 @@ import com.android.purebilibili.core.util.NetworkUtils
 import com.android.purebilibili.core.store.SettingsManager
 import com.android.purebilibili.core.store.PlaybackCompletionBehavior
 import com.android.purebilibili.feature.video.playback.policy.resolvePlaybackWakeMode
+import com.android.purebilibili.feature.video.playback.audio.isPremiumAudioPlaybackFailure
 import com.android.purebilibili.feature.video.playback.session.resolvePlaybackPauseDecision
 import com.android.purebilibili.feature.video.playback.session.resolvePlaybackResumeDecision
 import com.android.purebilibili.feature.video.playback.session.PendingPlaybackUserAction
@@ -838,11 +841,11 @@ fun rememberVideoPlayerState(
             //  根据设置选择 RenderersFactory
             val renderersFactory = if (hwDecodeEnabled) {
                 // 默认 Factory，优先使用硬件解码
-                androidx.media3.exoplayer.DefaultRenderersFactory(context)
+                HiResCompatibleRenderersFactory(context)
                     .setExtensionRendererMode(androidx.media3.exoplayer.DefaultRenderersFactory.EXTENSION_RENDERER_MODE_PREFER)
             } else {
                 // 强制使用软件解码
-                androidx.media3.exoplayer.DefaultRenderersFactory(context)
+                HiResCompatibleRenderersFactory(context)
                     .setExtensionRendererMode(androidx.media3.exoplayer.DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF)
                     .setEnableDecoderFallback(true)
             }
@@ -1126,6 +1129,17 @@ fun rememberVideoPlayerState(
                 val currentState = viewModel.uiState.value
                 val hasCdnAlternatives = currentState is com.android.purebilibili.feature.video.viewmodel.VideoPlaybackUiState.Success 
                     && currentState.cdnCount > 1
+                val exoPlaybackError = error as? ExoPlaybackException
+                val isPremiumAudioFailure =
+                    currentState is VideoPlaybackUiState.Success &&
+                        isPremiumAudioPlaybackFailure(
+                            errorCode = error.errorCode,
+                            selectedAudioQuality = currentState.selectedAudioQuality,
+                            rendererName = exoPlaybackError?.rendererName,
+                            rendererSampleMimeType = exoPlaybackError
+                                ?.rendererFormat
+                                ?.sampleMimeType
+                        )
 
                 val action = decidePlayerErrorRecovery(
                     errorCode = error.errorCode,
@@ -1137,10 +1151,15 @@ fun rememberVideoPlayerState(
                     isDecoderLikeFailure = isDecoderLikeFailure(
                         errorMessage = error.message,
                         causeClassName = causeName
-                    )
+                    ),
+                    isPremiumAudioFailure = isPremiumAudioFailure
                 )
 
                 when (action) {
+                    PlayerErrorRecoveryAction.FALLBACK_PREMIUM_AUDIO -> {
+                        viewModel.fallbackFromPremiumAudioPlaybackError()
+                    }
+
                     PlayerErrorRecoveryAction.SWITCH_CDN -> {
                         retryCountRef.cdnSwitchCount++
                         com.android.purebilibili.core.util.Logger.d(

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/components/AudioQualitySelectionMenu.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/components/AudioQualitySelectionMenu.kt
@@ -1,0 +1,155 @@
+package com.android.purebilibili.feature.video.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.android.purebilibili.feature.video.playback.audio.AudioQualityOption
+import io.github.alexzhirkevich.cupertino.icons.CupertinoIcons
+import io.github.alexzhirkevich.cupertino.icons.filled.*
+import io.github.alexzhirkevich.cupertino.icons.outlined.*
+
+private val HiResGold = Color(0xFFFFD36A)
+
+@Composable
+fun HiResBadge(
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier,
+        color = Color(0xFF332A14).copy(alpha = 0.9f),
+        contentColor = HiResGold,
+        shape = RoundedCornerShape(4.dp),
+        border = androidx.compose.foundation.BorderStroke(0.75.dp, HiResGold.copy(alpha = 0.9f))
+    ) {
+        Text(
+            text = "Hi-Res",
+            fontSize = 8.sp,
+            fontWeight = FontWeight.Bold,
+            lineHeight = 9.sp,
+            modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp)
+        )
+    }
+}
+
+@Composable
+fun AudioQualitySelectionMenu(
+    options: List<AudioQualityOption>,
+    selectedAudioQuality: Int,
+    onAudioQualitySelected: (Int) -> Unit,
+    onDismiss: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.5f))
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onDismiss
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Surface(
+            modifier = Modifier
+                .widthIn(min = 200.dp, max = 280.dp)
+                .heightIn(max = 400.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = {}
+                ),
+            color = Color(0xFF2B2B2B),
+            shape = RoundedCornerShape(12.dp),
+            tonalElevation = 8.dp
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(vertical = 8.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                Text(
+                    text = "音质选择",
+                    color = Color.White,
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
+                )
+                HorizontalDivider(color = Color.White.copy(alpha = 0.1f))
+                options.forEach { option ->
+                    val isSelected = option.preferenceId == selectedAudioQuality
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable(enabled = !isSelected) {
+                                onAudioQualitySelected(option.preferenceId)
+                            }
+                            .background(
+                                if (isSelected) {
+                                    MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)
+                                } else {
+                                    Color.Transparent
+                                }
+                            )
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Start
+                    ) {
+                        Text(
+                            text = option.label,
+                            color = if (isSelected) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                Color.White.copy(alpha = 0.9f)
+                            },
+                            fontSize = 14.sp,
+                            fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal
+                        )
+                        if (option.isHiRes) {
+                            Spacer(modifier = Modifier.width(8.dp))
+                            HiResBadge()
+                        }
+                        Spacer(modifier = Modifier.weight(1f))
+                        if (isSelected) {
+                            Icon(
+                                imageVector = CupertinoIcons.Default.Checkmark,
+                                contentDescription = "当前音质",
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(18.dp)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/components/AudioQualitySelectionMenu.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/components/AudioQualitySelectionMenu.kt
@@ -63,7 +63,7 @@ fun HiResBadge(
 @Composable
 fun AudioQualitySelectionMenu(
     options: List<AudioQualityOption>,
-    selectedAudioQuality: Int,
+    requestedAudioQuality: Int,
     onAudioQualitySelected: (Int) -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -106,10 +106,11 @@ fun AudioQualitySelectionMenu(
                 )
                 HorizontalDivider(color = Color.White.copy(alpha = 0.1f))
                 options.forEach { option ->
-                    val isSelected = option.preferenceId == selectedAudioQuality
+                    val isSelected = option.preferenceId == requestedAudioQuality
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
+                            .heightIn(min = 48.dp)
                             .clickable(enabled = !isSelected) {
                                 onAudioQualitySelected(option.preferenceId)
                             }

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/components/AudioQualitySelectionMenu.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/components/AudioQualitySelectionMenu.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.android.purebilibili.feature.video.playback.audio.AudioQualityOption
 import io.github.alexzhirkevich.cupertino.icons.CupertinoIcons
 import io.github.alexzhirkevich.cupertino.icons.filled.*
@@ -184,5 +186,25 @@ fun AudioQualitySelectionMenu(
                 }
             }
         }
+    }
+}
+
+@Composable
+fun AudioQualitySelectionMenuDialog(
+    options: List<AudioQualityOption>,
+    requestedAudioQuality: Int,
+    onAudioQualitySelected: (Int) -> Unit,
+    onDismiss: () -> Unit
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        AudioQualitySelectionMenu(
+            options = options,
+            requestedAudioQuality = requestedAudioQuality,
+            onAudioQualitySelected = onAudioQualitySelected,
+            onDismiss = onDismiss
+        )
     }
 }

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/components/AudioQualitySelectionMenu.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/components/AudioQualitySelectionMenu.kt
@@ -38,20 +38,48 @@ import io.github.alexzhirkevich.cupertino.icons.filled.*
 import io.github.alexzhirkevich.cupertino.icons.outlined.*
 
 private val HiResGold = Color(0xFFFFD36A)
+private val DolbyBlue = Color(0xFF8DCDFF)
 
 @Composable
 fun HiResBadge(
     modifier: Modifier = Modifier
 ) {
+    AudioFormatBadge(
+        text = "Hi-Res",
+        accentColor = HiResGold,
+        backgroundColor = Color(0xFF332A14),
+        modifier = modifier
+    )
+}
+
+@Composable
+fun DolbyBadge(
+    modifier: Modifier = Modifier
+) {
+    AudioFormatBadge(
+        text = "DOLBY",
+        accentColor = DolbyBlue,
+        backgroundColor = Color(0xFF142A3A),
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun AudioFormatBadge(
+    text: String,
+    accentColor: Color,
+    backgroundColor: Color,
+    modifier: Modifier = Modifier
+) {
     Surface(
         modifier = modifier,
-        color = Color(0xFF332A14).copy(alpha = 0.9f),
-        contentColor = HiResGold,
+        color = backgroundColor.copy(alpha = 0.9f),
+        contentColor = accentColor,
         shape = RoundedCornerShape(4.dp),
-        border = androidx.compose.foundation.BorderStroke(0.75.dp, HiResGold.copy(alpha = 0.9f))
+        border = androidx.compose.foundation.BorderStroke(0.75.dp, accentColor.copy(alpha = 0.9f))
     ) {
         Text(
-            text = "Hi-Res",
+            text = text,
             fontSize = 8.sp,
             fontWeight = FontWeight.Bold,
             lineHeight = 9.sp,
@@ -138,6 +166,10 @@ fun AudioQualitySelectionMenu(
                         if (option.isHiRes) {
                             Spacer(modifier = Modifier.width(8.dp))
                             HiResBadge()
+                        }
+                        if (option.isDolby) {
+                            Spacer(modifier = Modifier.width(8.dp))
+                            DolbyBadge()
                         }
                         Spacer(modifier = Modifier.weight(1f))
                         if (isSelected) {

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/components/VideoSettingsPanel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/components/VideoSettingsPanel.kt
@@ -692,9 +692,8 @@ fun VideoSettingsPanel(
                 SettingsDivider()
             }
 
-            // 音频音质只展示当前播放资源真实返回的可切换项。
-            if (availableAudioQualities.count { it.preferenceId != -1 } >= 2) {
-                item {
+            // 音质入口始终保留，具体选项仍以当前播放资源真实返回的数据为准。
+            item {
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -761,8 +760,6 @@ fun VideoSettingsPanel(
                     }
                 }
                 SettingsDivider()
-            }
-                item { SettingsDivider() }
             }
 
              // [New] 音频语言选择 (AI Translation)

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/components/VideoSettingsPanel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/components/VideoSettingsPanel.kt
@@ -752,6 +752,9 @@ fun VideoSettingsPanel(
                                     if (option.isHiRes) {
                                         HiResBadge()
                                     }
+                                    if (option.isDolby) {
+                                        DolbyBadge()
+                                    }
                                 }
                             }
                         }

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/components/VideoSettingsPanel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/components/VideoSettingsPanel.kt
@@ -57,6 +57,7 @@ import com.android.purebilibili.data.model.response.AiAudioInfo
 import com.android.purebilibili.feature.plugin.CdnLineDiagnostic
 import com.android.purebilibili.feature.anime4k.Anime4KBypassReason
 import com.android.purebilibili.feature.anime4k.Anime4KPreset
+import com.android.purebilibili.feature.video.playback.audio.AudioQualityOption
 import com.android.purebilibili.core.ui.AppSurfaceTokens
 import top.yukonga.miuix.kmp.basic.BasicComponent
 import top.yukonga.miuix.kmp.basic.BasicComponentDefaults
@@ -196,6 +197,7 @@ fun VideoSettingsPanel(
     currentSecondCodec: String = "avc1",
     onSecondCodecChange: (String) -> Unit = {},
     currentAudioQuality: Int = -1,
+    availableAudioQualities: List<AudioQualityOption> = emptyList(),
     onAudioQualityChange: (Int) -> Unit = {},
     anime4kEnabled: Boolean = false,
     anime4kAvailable: Boolean = false,
@@ -690,8 +692,9 @@ fun VideoSettingsPanel(
                 SettingsDivider()
             }
 
-            // [New] 音频画质选择
-            item {
+            // 音频音质只展示当前播放资源真实返回的可切换项。
+            if (availableAudioQualities.count { it.preferenceId != -1 } >= 2) {
+                item {
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -713,15 +716,10 @@ fun VideoSettingsPanel(
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         
-                        val audioLabel = when(currentAudioQuality) {
-                            -1 -> "自动"
-                            30280 -> "192K"
-                            30232 -> "132K"
-                            30216 -> "64K"
-                            30250 -> "杜比全景声"
-                            30251 -> "Hi-Res无损"
-                            else -> "其他"
-                        }
+                        val audioLabel = availableAudioQualities
+                            .firstOrNull { it.preferenceId == currentAudioQuality }
+                            ?.label
+                            ?: "自动"
                         Text(
                             text = audioLabel,
                             fontSize = 13.sp,
@@ -733,26 +731,27 @@ fun VideoSettingsPanel(
                         modifier = Modifier.horizontalScroll(rememberScrollState()),
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        val audios = listOf(
-                            -1 to "自动", 
-                            30280 to "192K", 
-                            30250 to "杜比", 
-                            30251 to "Hi-Res"
-                        )
-                        audios.forEach { (code, label) ->
-                            val isSelected = currentAudioQuality == code
+                        availableAudioQualities.forEach { option ->
+                            val isSelected = currentAudioQuality == option.preferenceId
                             Surface(
-                                onClick = { onAudioQualityChange(code) },
-                                shape = RoundedCornerShape(16.dp),
+                                onClick = { onAudioQualityChange(option.preferenceId) },
+                                shape = RoundedCornerShape(24.dp),
                                 color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant,
-                                modifier = Modifier.height(32.dp)
+                                modifier = Modifier.height(48.dp)
                             ) {
-                                Box(contentAlignment = Alignment.Center, modifier = Modifier.padding(horizontal = 12.dp)) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                    modifier = Modifier.padding(horizontal = 14.dp)
+                                ) {
                                     Text(
-                                        text = label,
+                                        text = option.label,
                                         fontSize = 13.sp,
                                         color = if (isSelected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
                                     )
+                                    if (option.isHiRes) {
+                                        HiResBadge()
+                                    }
                                 }
                             }
                         }
@@ -760,7 +759,8 @@ fun VideoSettingsPanel(
                 }
                 SettingsDivider()
             }
-            item { SettingsDivider() }
+                item { SettingsDivider() }
+            }
 
              // [New] 音频语言选择 (AI Translation)
             if (aiAudioInfo?.items?.isNotEmpty() == true) {

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/BottomControlBar.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/BottomControlBar.kt
@@ -54,6 +54,7 @@ import com.android.purebilibili.feature.video.ui.components.SeekPreviewBubble
 import com.android.purebilibili.feature.video.ui.components.SeekPreviewBubblePlacement
 import com.android.purebilibili.feature.video.ui.components.SeekPreviewBubbleSimple
 import com.android.purebilibili.feature.video.ui.components.VideoAspectRatio
+import com.android.purebilibili.feature.video.ui.components.HiResBadge
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.ui.draw.clip
 import com.android.purebilibili.feature.video.subtitle.SubtitleDisplayMode
@@ -389,6 +390,9 @@ fun BottomControlBar(
     onAnime4kPresetChange: (Anime4KPreset) -> Unit = {},
     
     // Quality
+    currentAudioQualityLabel: String = "",
+    isHiResAudioSelected: Boolean = false,
+    onAudioQualityClick: () -> Unit = {},
     currentQualityLabel: String = "",
     onQualityClick: () -> Unit = {},
     
@@ -780,6 +784,26 @@ fun BottomControlBar(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(layoutPolicy.rightActionSpacingDp.dp)
             ) {
+                if (currentAudioQualityLabel.isNotEmpty()) {
+                    Row(
+                        modifier = Modifier
+                            .heightIn(min = 48.dp)
+                            .clickable(onClick = onAudioQualityClick),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        Text(
+                            text = currentAudioQualityLabel,
+                            color = Color.White,
+                            fontSize = layoutPolicy.actionTextFontSp.sp,
+                            fontWeight = FontWeight.Medium
+                        )
+                        if (isHiResAudioSelected) {
+                            HiResBadge()
+                        }
+                    }
+                }
+
                 // Quality
                 if (currentQualityLabel.isNotEmpty()) {
                     Text(

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/BottomControlBar.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/BottomControlBar.kt
@@ -54,6 +54,7 @@ import com.android.purebilibili.feature.video.ui.components.SeekPreviewBubble
 import com.android.purebilibili.feature.video.ui.components.SeekPreviewBubblePlacement
 import com.android.purebilibili.feature.video.ui.components.SeekPreviewBubbleSimple
 import com.android.purebilibili.feature.video.ui.components.VideoAspectRatio
+import com.android.purebilibili.feature.video.ui.components.DolbyBadge
 import com.android.purebilibili.feature.video.ui.components.HiResBadge
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.ui.draw.clip
@@ -392,6 +393,7 @@ fun BottomControlBar(
     // Quality
     currentAudioQualityLabel: String = "",
     isHiResAudioSelected: Boolean = false,
+    isDolbyAudioSelected: Boolean = false,
     onAudioQualityClick: () -> Unit = {},
     currentQualityLabel: String = "",
     onQualityClick: () -> Unit = {},
@@ -800,6 +802,9 @@ fun BottomControlBar(
                         )
                         if (isHiResAudioSelected) {
                             HiResBadge()
+                        }
+                        if (isDolbyAudioSelected) {
+                            DolbyBadge()
                         }
                     }
                 }

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/BottomControlBar.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/BottomControlBar.kt
@@ -391,7 +391,7 @@ fun BottomControlBar(
     onAnime4kPresetChange: (Anime4KPreset) -> Unit = {},
     
     // Quality
-    currentAudioQualityLabel: String = "",
+    currentAudioQualityLabel: String = "音质",
     isHiResAudioSelected: Boolean = false,
     isDolbyAudioSelected: Boolean = false,
     onAudioQualityClick: () -> Unit = {},
@@ -786,26 +786,24 @@ fun BottomControlBar(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(layoutPolicy.rightActionSpacingDp.dp)
             ) {
-                if (currentAudioQualityLabel.isNotEmpty()) {
-                    Row(
-                        modifier = Modifier
-                            .heightIn(min = 48.dp)
-                            .clickable(onClick = onAudioQualityClick),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(4.dp)
-                    ) {
-                        Text(
-                            text = currentAudioQualityLabel,
-                            color = Color.White,
-                            fontSize = layoutPolicy.actionTextFontSp.sp,
-                            fontWeight = FontWeight.Medium
-                        )
-                        if (isHiResAudioSelected) {
-                            HiResBadge()
-                        }
-                        if (isDolbyAudioSelected) {
-                            DolbyBadge()
-                        }
+                Row(
+                    modifier = Modifier
+                        .heightIn(min = 48.dp)
+                        .clickable(onClick = onAudioQualityClick),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Text(
+                        text = currentAudioQualityLabel.ifBlank { "音质" },
+                        color = Color.White,
+                        fontSize = layoutPolicy.actionTextFontSp.sp,
+                        fontWeight = FontWeight.Medium
+                    )
+                    if (isHiResAudioSelected) {
+                        HiResBadge()
+                    }
+                    if (isDolbyAudioSelected) {
+                        DolbyBadge()
                     }
                 }
 

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/PortraitFullscreenOverlay.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/PortraitFullscreenOverlay.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.rounded.Share
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.MoreVert
 import com.android.purebilibili.feature.video.ui.components.PlaybackSpeed
+import com.android.purebilibili.feature.video.ui.components.DolbyBadge
 import com.android.purebilibili.feature.video.ui.components.HiResBadge
 import com.android.purebilibili.feature.video.ui.components.VideoAspectRatio
 import com.android.purebilibili.core.theme.BiliPink
@@ -112,6 +113,7 @@ fun PortraitFullscreenOverlay(
     currentAudioQualityLabel: String,
     showAudioQualityChip: Boolean,
     isHiResAudioSelected: Boolean,
+    isDolbyAudioSelected: Boolean,
     currentRatio: VideoAspectRatio,
     danmakuEnabled: Boolean,
     isStatusBarHidden: Boolean,
@@ -269,6 +271,7 @@ fun PortraitFullscreenOverlay(
                         currentAudioQualityLabel = currentAudioQualityLabel,
                         showAudioQualityChip = showAudioQualityChip,
                         isHiResAudioSelected = isHiResAudioSelected,
+                        isDolbyAudioSelected = isDolbyAudioSelected,
                         currentRatioLabel = currentRatio.displayName,
                         showSubtitleChip = showSubtitleChip,
                         subtitleEnabled = subtitleEnabled,
@@ -422,6 +425,7 @@ private fun PortraitProgressControlStrip(
     currentAudioQualityLabel: String,
     showAudioQualityChip: Boolean,
     isHiResAudioSelected: Boolean,
+    isDolbyAudioSelected: Boolean,
     currentRatioLabel: String,
     showSubtitleChip: Boolean = false,
     subtitleEnabled: Boolean = false,
@@ -456,6 +460,7 @@ private fun PortraitProgressControlStrip(
                 label = currentAudioQualityLabel,
                 highlighted = false,
                 showHiResBadge = isHiResAudioSelected,
+                showDolbyBadge = isDolbyAudioSelected,
                 onClick = onAudioQualityClick
             )
             Spacer(modifier = Modifier.width(8.dp))
@@ -486,7 +491,8 @@ private fun PortraitChromeChip(
     highlighted: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    showHiResBadge: Boolean = false
+    showHiResBadge: Boolean = false,
+    showDolbyBadge: Boolean = false
 ) {
     Surface(
         onClick = onClick,
@@ -513,6 +519,10 @@ private fun PortraitChromeChip(
             if (showHiResBadge) {
                 Spacer(modifier = Modifier.width(4.dp))
                 HiResBadge()
+            }
+            if (showDolbyBadge) {
+                Spacer(modifier = Modifier.width(4.dp))
+                DolbyBadge()
             }
         }
     }

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/PortraitFullscreenOverlay.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/PortraitFullscreenOverlay.kt
@@ -111,7 +111,6 @@ fun PortraitFullscreenOverlay(
     currentSpeed: Float,
     currentQualityLabel: String,
     currentAudioQualityLabel: String,
-    showAudioQualityChip: Boolean,
     isHiResAudioSelected: Boolean,
     isDolbyAudioSelected: Boolean,
     currentRatio: VideoAspectRatio,
@@ -269,7 +268,6 @@ fun PortraitFullscreenOverlay(
                         currentSpeed = currentSpeed,
                         currentQualityLabel = currentQualityLabel,
                         currentAudioQualityLabel = currentAudioQualityLabel,
-                        showAudioQualityChip = showAudioQualityChip,
                         isHiResAudioSelected = isHiResAudioSelected,
                         isDolbyAudioSelected = isDolbyAudioSelected,
                         currentRatioLabel = currentRatio.displayName,
@@ -423,7 +421,6 @@ private fun PortraitProgressControlStrip(
     currentSpeed: Float,
     currentQualityLabel: String,
     currentAudioQualityLabel: String,
-    showAudioQualityChip: Boolean,
     isHiResAudioSelected: Boolean,
     isDolbyAudioSelected: Boolean,
     currentRatioLabel: String,
@@ -455,16 +452,14 @@ private fun PortraitProgressControlStrip(
             )
             Spacer(modifier = Modifier.width(8.dp))
         }
-        if (showAudioQualityChip) {
-            PortraitChromeChip(
-                label = currentAudioQualityLabel,
-                highlighted = false,
-                showHiResBadge = isHiResAudioSelected,
-                showDolbyBadge = isDolbyAudioSelected,
-                onClick = onAudioQualityClick
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-        }
+        PortraitChromeChip(
+            label = currentAudioQualityLabel,
+            highlighted = false,
+            showHiResBadge = isHiResAudioSelected,
+            showDolbyBadge = isDolbyAudioSelected,
+            onClick = onAudioQualityClick
+        )
+        Spacer(modifier = Modifier.width(8.dp))
         PortraitChromeChip(
             label = currentQualityLabel,
             highlighted = false,

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/PortraitFullscreenOverlay.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/PortraitFullscreenOverlay.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.rounded.Share
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.MoreVert
 import com.android.purebilibili.feature.video.ui.components.PlaybackSpeed
+import com.android.purebilibili.feature.video.ui.components.HiResBadge
 import com.android.purebilibili.feature.video.ui.components.VideoAspectRatio
 import com.android.purebilibili.core.theme.BiliPink
 import com.android.purebilibili.core.util.FormatUtils
@@ -108,6 +109,9 @@ fun PortraitFullscreenOverlay(
     // 控制状态
     currentSpeed: Float,
     currentQualityLabel: String,
+    currentAudioQualityLabel: String,
+    showAudioQualityChip: Boolean,
+    isHiResAudioSelected: Boolean,
     currentRatio: VideoAspectRatio,
     danmakuEnabled: Boolean,
     isStatusBarHidden: Boolean,
@@ -131,6 +135,7 @@ fun PortraitFullscreenOverlay(
     onSeekDragCancel: () -> Unit = {},
     onSpeedClick: () -> Unit,
     onQualityClick: () -> Unit,
+    onAudioQualityClick: () -> Unit,
     onRatioClick: () -> Unit,
     showSubtitleChip: Boolean = false,
     subtitleEnabled: Boolean = false,
@@ -261,11 +266,15 @@ fun PortraitFullscreenOverlay(
                         timeLabel = progressTimeLabel,
                         currentSpeed = currentSpeed,
                         currentQualityLabel = currentQualityLabel,
+                        currentAudioQualityLabel = currentAudioQualityLabel,
+                        showAudioQualityChip = showAudioQualityChip,
+                        isHiResAudioSelected = isHiResAudioSelected,
                         currentRatioLabel = currentRatio.displayName,
                         showSubtitleChip = showSubtitleChip,
                         subtitleEnabled = subtitleEnabled,
                         onSpeedClick = onSpeedClick,
                         onQualityClick = onQualityClick,
+                        onAudioQualityClick = onAudioQualityClick,
                         onRatioClick = onRatioClick,
                         onSubtitleClick = onSubtitleClick,
                         modifier = Modifier
@@ -410,11 +419,15 @@ private fun PortraitProgressControlStrip(
     timeLabel: String,
     currentSpeed: Float,
     currentQualityLabel: String,
+    currentAudioQualityLabel: String,
+    showAudioQualityChip: Boolean,
+    isHiResAudioSelected: Boolean,
     currentRatioLabel: String,
     showSubtitleChip: Boolean = false,
     subtitleEnabled: Boolean = false,
     onSpeedClick: () -> Unit,
     onQualityClick: () -> Unit,
+    onAudioQualityClick: () -> Unit,
     onRatioClick: () -> Unit,
     onSubtitleClick: () -> Unit = {},
     modifier: Modifier = Modifier
@@ -435,6 +448,15 @@ private fun PortraitProgressControlStrip(
                 label = "字幕",
                 highlighted = subtitleEnabled,
                 onClick = onSubtitleClick
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+        }
+        if (showAudioQualityChip) {
+            PortraitChromeChip(
+                label = currentAudioQualityLabel,
+                highlighted = false,
+                showHiResBadge = isHiResAudioSelected,
+                onClick = onAudioQualityClick
             )
             Spacer(modifier = Modifier.width(8.dp))
         }
@@ -463,7 +485,8 @@ private fun PortraitChromeChip(
     label: String,
     highlighted: Boolean,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    showHiResBadge: Boolean = false
 ) {
     Surface(
         onClick = onClick,
@@ -476,14 +499,22 @@ private fun PortraitChromeChip(
             Color.White
         }
     ) {
-        Text(
-            text = label,
-            fontSize = 12.sp,
-            fontWeight = FontWeight.SemiBold,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
-        )
+        Row(
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = label,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (showHiResBadge) {
+                Spacer(modifier = Modifier.width(4.dp))
+                HiResBadge()
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/VideoPlayerOverlay.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/VideoPlayerOverlay.kt
@@ -46,7 +46,7 @@ import com.android.purebilibili.core.util.FormatUtils
 import com.android.purebilibili.feature.video.danmaku.DanmakuCloudSyncUiState
 // Import reusable components from standalone files
 import com.android.purebilibili.feature.video.ui.components.QualitySelectionMenu
-import com.android.purebilibili.feature.video.ui.components.AudioQualitySelectionMenu
+import com.android.purebilibili.feature.video.ui.components.AudioQualitySelectionMenuDialog
 import com.android.purebilibili.feature.video.ui.components.SpeedSelectionMenuDialog
 import com.android.purebilibili.feature.video.ui.components.SpeedSelectionMenuPlacement
 import com.android.purebilibili.feature.video.ui.components.DanmakuSettingsPanel
@@ -1795,7 +1795,7 @@ fun VideoPlayerOverlay(
         }
 
         if (showAudioQualityMenu) {
-            AudioQualitySelectionMenu(
+            AudioQualitySelectionMenuDialog(
                 options = availableAudioQualities,
                 requestedAudioQuality = currentAudioQuality,
                 onAudioQualitySelected = { preferenceId ->

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/VideoPlayerOverlay.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/VideoPlayerOverlay.kt
@@ -1805,7 +1805,7 @@ fun VideoPlayerOverlay(
         if (showAudioQualityMenu) {
             AudioQualitySelectionMenu(
                 options = availableAudioQualities,
-                selectedAudioQuality = selectedAudioQuality,
+                requestedAudioQuality = currentAudioQuality,
                 onAudioQualitySelected = { preferenceId ->
                     onAudioQualityChange(preferenceId)
                     showAudioQualityMenu = false

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/VideoPlayerOverlay.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/VideoPlayerOverlay.kt
@@ -65,9 +65,8 @@ import com.android.purebilibili.data.repository.selectCastDashAudio
 import com.android.purebilibili.data.repository.selectCastDashVideo
 import com.android.purebilibili.feature.plugin.CdnLineDiagnostic
 import com.android.purebilibili.feature.video.playback.dash.buildLocalDashManifest
-import com.android.purebilibili.feature.video.playback.audio.AUDIO_QUALITY_DOLBY
-import com.android.purebilibili.feature.video.playback.audio.AUDIO_QUALITY_HI_RES
 import com.android.purebilibili.feature.video.playback.audio.AudioQualityOption
+import com.android.purebilibili.feature.video.playback.audio.resolveAudioQualityControlPresentation
 import com.android.purebilibili.feature.common.resolveIndexedVideoLazyKey
 import com.android.purebilibili.feature.video.progress.PbpRidgeSample
 import io.github.alexzhirkevich.cupertino.CupertinoActivityIndicator
@@ -694,6 +693,12 @@ fun VideoPlayerOverlay(
     val context = LocalContext.current
     val fullscreenLockButtonState = remember(isScreenLocked) {
         resolveFullscreenLockButtonVisualState(isScreenLocked = isScreenLocked)
+    }
+    val audioQualityPresentation = remember(availableAudioQualities, selectedAudioQuality) {
+        resolveAudioQualityControlPresentation(
+            options = availableAudioQualities,
+            selectedAudioQuality = selectedAudioQuality
+        )
     }
     val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
     val lifecycleState by lifecycleOwner.lifecycle.currentStateAsState()
@@ -1401,24 +1406,9 @@ fun VideoPlayerOverlay(
                     anime4kPreset = anime4kPreset,
                     onAnime4kToggle = onAnime4kToggle,
                     onAnime4kPresetChange = onAnime4kPresetChange,
-                    currentAudioQualityLabel = availableAudioQualities
-                        .firstOrNull { it.preferenceId == selectedAudioQuality }
-                        ?.let { option ->
-                            when (option.preferenceId) {
-                                AUDIO_QUALITY_HI_RES -> "音质"
-                                30250 -> "杜比"
-                                else -> option.label
-                            }
-                        }
-                        .orEmpty()
-                        .takeIf {
-                            availableAudioQualities.count { option ->
-                                option.preferenceId != -1
-                            } >= 2
-                        }
-                        .orEmpty(),
-                    isHiResAudioSelected = selectedAudioQuality == AUDIO_QUALITY_HI_RES,
-                    isDolbyAudioSelected = selectedAudioQuality == AUDIO_QUALITY_DOLBY,
+                    currentAudioQualityLabel = audioQualityPresentation.label,
+                    isHiResAudioSelected = audioQualityPresentation.showHiResBadge,
+                    isDolbyAudioSelected = audioQualityPresentation.showDolbyBadge,
                     onAudioQualityClick = { showAudioQualityMenu = true },
                     currentQualityLabel = currentQualityLabel,
                     onQualityClick = { showQualityMenu = true },

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/VideoPlayerOverlay.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/VideoPlayerOverlay.kt
@@ -46,6 +46,7 @@ import com.android.purebilibili.core.util.FormatUtils
 import com.android.purebilibili.feature.video.danmaku.DanmakuCloudSyncUiState
 // Import reusable components from standalone files
 import com.android.purebilibili.feature.video.ui.components.QualitySelectionMenu
+import com.android.purebilibili.feature.video.ui.components.AudioQualitySelectionMenu
 import com.android.purebilibili.feature.video.ui.components.SpeedSelectionMenuDialog
 import com.android.purebilibili.feature.video.ui.components.SpeedSelectionMenuPlacement
 import com.android.purebilibili.feature.video.ui.components.DanmakuSettingsPanel
@@ -64,6 +65,8 @@ import com.android.purebilibili.data.repository.selectCastDashAudio
 import com.android.purebilibili.data.repository.selectCastDashVideo
 import com.android.purebilibili.feature.plugin.CdnLineDiagnostic
 import com.android.purebilibili.feature.video.playback.dash.buildLocalDashManifest
+import com.android.purebilibili.feature.video.playback.audio.AUDIO_QUALITY_HI_RES
+import com.android.purebilibili.feature.video.playback.audio.AudioQualityOption
 import com.android.purebilibili.feature.common.resolveIndexedVideoLazyKey
 import com.android.purebilibili.feature.video.progress.PbpRidgeSample
 import io.github.alexzhirkevich.cupertino.CupertinoActivityIndicator
@@ -582,6 +585,8 @@ fun VideoPlayerOverlay(
     currentSecondCodec: String = "avc1",
     onSecondCodecChange: (String) -> Unit = {},
     currentAudioQuality: Int = -1,
+    selectedAudioQuality: Int = -1,
+    availableAudioQualities: List<AudioQualityOption> = emptyList(),
     onAudioQualityChange: (Int) -> Unit = {},
     anime4kEnabled: Boolean = false,
     anime4kAvailable: Boolean = false,
@@ -635,6 +640,7 @@ fun VideoPlayerOverlay(
     drawerHazeState: HazeState? = null,
 ) {
     var showQualityMenu by remember { mutableStateOf(false) }
+    var showAudioQualityMenu by remember { mutableStateOf(false) }
     var showSpeedMenu by remember { mutableStateOf(false) }
     var showRatioMenu by remember { mutableStateOf(false) }
     var showDanmakuSettings by remember { mutableStateOf(false) }
@@ -659,6 +665,7 @@ fun VideoPlayerOverlay(
     LaunchedEffect(bvid, cid) {
         showPageSelectorSheet = false
         showQualityMenu = false
+        showAudioQualityMenu = false
         showSpeedMenu = false
         showRatioMenu = false
         showDanmakuSettings = false
@@ -1393,6 +1400,24 @@ fun VideoPlayerOverlay(
                     anime4kPreset = anime4kPreset,
                     onAnime4kToggle = onAnime4kToggle,
                     onAnime4kPresetChange = onAnime4kPresetChange,
+                    currentAudioQualityLabel = availableAudioQualities
+                        .firstOrNull { it.preferenceId == selectedAudioQuality }
+                        ?.let { option ->
+                            when (option.preferenceId) {
+                                AUDIO_QUALITY_HI_RES -> "音质"
+                                30250 -> "杜比"
+                                else -> option.label
+                            }
+                        }
+                        .orEmpty()
+                        .takeIf {
+                            availableAudioQualities.count { option ->
+                                option.preferenceId != -1
+                            } >= 2
+                        }
+                        .orEmpty(),
+                    isHiResAudioSelected = selectedAudioQuality == AUDIO_QUALITY_HI_RES,
+                    onAudioQualityClick = { showAudioQualityMenu = true },
                     currentQualityLabel = currentQualityLabel,
                     onQualityClick = { showQualityMenu = true },
                     // 🖼️ [新增] 视频预览图数据
@@ -1776,6 +1801,18 @@ fun VideoPlayerOverlay(
                 useDialog = true
             )
         }
+
+        if (showAudioQualityMenu) {
+            AudioQualitySelectionMenu(
+                options = availableAudioQualities,
+                selectedAudioQuality = selectedAudioQuality,
+                onAudioQualitySelected = { preferenceId ->
+                    onAudioQualityChange(preferenceId)
+                    showAudioQualityMenu = false
+                },
+                onDismiss = { showAudioQualityMenu = false }
+            )
+        }
         
         // --- 7.  [新增] 倍速选择菜单 ---
         if (showSpeedMenu) {
@@ -1942,7 +1979,8 @@ fun VideoPlayerOverlay(
                     onSecondCodecChange(codec)
                     showVideoSettings = false
                 },
-                currentAudioQuality = currentAudioQuality,
+                currentAudioQuality = selectedAudioQuality,
+                availableAudioQualities = availableAudioQualities,
                 onAudioQualityChange = { quality ->
                     onAudioQualityChange(quality)
                     showVideoSettings = false

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/VideoPlayerOverlay.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/overlay/VideoPlayerOverlay.kt
@@ -65,6 +65,7 @@ import com.android.purebilibili.data.repository.selectCastDashAudio
 import com.android.purebilibili.data.repository.selectCastDashVideo
 import com.android.purebilibili.feature.plugin.CdnLineDiagnostic
 import com.android.purebilibili.feature.video.playback.dash.buildLocalDashManifest
+import com.android.purebilibili.feature.video.playback.audio.AUDIO_QUALITY_DOLBY
 import com.android.purebilibili.feature.video.playback.audio.AUDIO_QUALITY_HI_RES
 import com.android.purebilibili.feature.video.playback.audio.AudioQualityOption
 import com.android.purebilibili.feature.common.resolveIndexedVideoLazyKey
@@ -1417,6 +1418,7 @@ fun VideoPlayerOverlay(
                         }
                         .orEmpty(),
                     isHiResAudioSelected = selectedAudioQuality == AUDIO_QUALITY_HI_RES,
+                    isDolbyAudioSelected = selectedAudioQuality == AUDIO_QUALITY_DOLBY,
                     onAudioQualityClick = { showAudioQualityMenu = true },
                     currentQualityLabel = currentQualityLabel,
                     onQualityClick = { showQualityMenu = true },

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/pager/PortraitAudioPlaybackController.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/pager/PortraitAudioPlaybackController.kt
@@ -6,6 +6,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MergingMediaSource
 import com.android.purebilibili.data.model.response.Dash
+import com.android.purebilibili.core.util.MediaUtils
 import com.android.purebilibili.feature.plugin.PlaybackCdnPlugin
 import com.android.purebilibili.feature.video.playback.audio.AudioSelectionDecision
 import com.android.purebilibili.feature.video.playback.audio.collectAudioStreamCandidates
@@ -29,13 +30,15 @@ internal fun switchPortraitPlaybackAudioSource(
     requestedAudioQuality: Int,
     targetVideoQuality: Int,
     mediaId: String,
-    cdnPlugin: PlaybackCdnPlugin?
+    cdnPlugin: PlaybackCdnPlugin?,
+    isDolbyAudioSupported: Boolean = MediaUtils.isDolbyAtmosAudioSupported()
 ): PortraitAudioSourceSwitchResult? {
     if (currentVideoUrl.isBlank() || mediaId.isBlank()) return null
     val selection = resolveAudioStreamSelection(
         dash = dash,
         requestedAudioQuality = requestedAudioQuality,
-        playbackSpeed = player.playbackParameters.speed
+        playbackSpeed = player.playbackParameters.speed,
+        isDolbyAudioSupported = isDolbyAudioSupported
     )
     val selectedAudioUrl = selection.selected?.track?.getValidUrl()
         ?.takeIf { it.isNotBlank() }
@@ -47,7 +50,10 @@ internal fun switchPortraitPlaybackAudioSource(
             audioSelection = selection
         ),
         cachedDashVideos = dash.video,
-        cachedDashAudios = collectAudioStreamCandidates(dash).map { it.track },
+        cachedDashAudios = collectAudioStreamCandidates(
+            dash = dash,
+            isDolbyAudioSupported = isDolbyAudioSupported
+        ).map { it.track },
         targetQuality = targetVideoQuality,
         cdnPlugin = cdnPlugin
     )

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/pager/PortraitAudioPlaybackController.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/pager/PortraitAudioPlaybackController.kt
@@ -1,0 +1,79 @@
+package com.android.purebilibili.feature.video.ui.pager
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.exoplayer.source.MergingMediaSource
+import com.android.purebilibili.data.model.response.Dash
+import com.android.purebilibili.feature.plugin.PlaybackCdnPlugin
+import com.android.purebilibili.feature.video.playback.audio.AudioSelectionDecision
+import com.android.purebilibili.feature.video.playback.audio.collectAudioStreamCandidates
+import com.android.purebilibili.feature.video.playback.audio.resolveAudioStreamSelection
+
+internal data class PortraitAudioSourceSwitchResult(
+    val videoUrl: String,
+    val audioUrl: String,
+    val selection: AudioSelectionDecision
+)
+
+/**
+ * 复用当前视频轨，仅替换竖屏播放器的音频轨，并保留进度和播放状态。
+ */
+@androidx.annotation.OptIn(UnstableApi::class)
+internal fun switchPortraitPlaybackAudioSource(
+    player: ExoPlayer,
+    mediaSourceFactory: DefaultMediaSourceFactory,
+    dash: Dash,
+    currentVideoUrl: String,
+    requestedAudioQuality: Int,
+    targetVideoQuality: Int,
+    mediaId: String,
+    cdnPlugin: PlaybackCdnPlugin?
+): PortraitAudioSourceSwitchResult? {
+    if (currentVideoUrl.isBlank() || mediaId.isBlank()) return null
+    val selection = resolveAudioStreamSelection(
+        dash = dash,
+        requestedAudioQuality = requestedAudioQuality,
+        playbackSpeed = player.playbackParameters.speed
+    )
+    val selectedAudioUrl = selection.selected?.track?.getValidUrl()
+        ?.takeIf { it.isNotBlank() }
+        ?: return null
+    val resolvedUrls = resolvePortraitPlaybackCdnUrls(
+        streamUrls = PortraitPlaybackStreamUrls(
+            videoUrl = currentVideoUrl,
+            audioUrl = selectedAudioUrl,
+            audioSelection = selection
+        ),
+        cachedDashVideos = dash.video,
+        cachedDashAudios = collectAudioStreamCandidates(dash).map { it.track },
+        targetQuality = targetVideoQuality,
+        cdnPlugin = cdnPlugin
+    )
+    val resolvedAudioUrl = resolvedUrls.audioUrl?.takeIf { it.isNotBlank() } ?: return null
+    val videoSource = mediaSourceFactory.createMediaSource(
+        MediaItem.Builder()
+            .setUri(resolvedUrls.videoUrl)
+            .setMediaId(mediaId)
+            .build()
+    )
+    val audioSource = mediaSourceFactory.createMediaSource(
+        MediaItem.Builder()
+            .setUri(resolvedAudioUrl)
+            .setMediaId("audio_$mediaId")
+            .build()
+    )
+    val currentPosition = player.currentPosition.coerceAtLeast(0L)
+    val playWhenReady = player.playWhenReady
+
+    player.setMediaSource(MergingMediaSource(videoSource, audioSource), false)
+    player.prepare()
+    player.seekTo(currentPosition)
+    player.playWhenReady = playWhenReady
+    return PortraitAudioSourceSwitchResult(
+        videoUrl = resolvedUrls.videoUrl,
+        audioUrl = resolvedAudioUrl,
+        selection = selection
+    )
+}

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/pager/PortraitVideoLoadPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/pager/PortraitVideoLoadPolicy.kt
@@ -13,9 +13,10 @@ import com.android.purebilibili.data.model.response.DashVideo
 import com.android.purebilibili.data.model.response.PlayUrlData
 import com.android.purebilibili.data.model.response.RelatedVideo
 import com.android.purebilibili.data.model.response.ViewInfo
-import com.android.purebilibili.data.model.response.getBestAudio
 import com.android.purebilibili.data.model.response.getBestVideo
 import com.android.purebilibili.feature.plugin.PlaybackCdnPlugin
+import com.android.purebilibili.feature.video.playback.audio.AudioSelectionDecision
+import com.android.purebilibili.feature.video.playback.audio.resolveAudioStreamSelection
 import com.android.purebilibili.feature.video.viewmodel.buildPlaybackAudioUrlCandidates
 import kotlin.math.min
 
@@ -35,7 +36,8 @@ internal data class PortraitPagePlaybackIdentity(
 
 internal data class PortraitPlaybackStreamUrls(
     val videoUrl: String,
-    val audioUrl: String?
+    val audioUrl: String?,
+    val audioSelection: AudioSelectionDecision? = null
 )
 
 /**
@@ -191,7 +193,9 @@ internal fun resolvePortraitPlaybackStreamUrls(
     playData: PlayUrlData,
     targetQuality: Int = PORTRAIT_PLAYBACK_TARGET_QUALITY,
     isHevcSupported: Boolean = MediaUtils.isHevcSupported(),
-    isAv1Supported: Boolean = MediaUtils.isAv1Supported()
+    isAv1Supported: Boolean = MediaUtils.isAv1Supported(),
+    requestedAudioQuality: Int = -1,
+    playbackSpeed: Float = 1.0f
 ): PortraitPlaybackStreamUrls? {
     val dash = playData.dash
     if (dash != null) {
@@ -200,14 +204,20 @@ internal fun resolvePortraitPlaybackStreamUrls(
             isHevcSupported = isHevcSupported,
             isAv1Supported = isAv1Supported
         )
-        val dashAudio = dash.getBestAudio()
+        val audioSelection = resolveAudioStreamSelection(
+            dash = dash,
+            requestedAudioQuality = requestedAudioQuality,
+            playbackSpeed = playbackSpeed
+        )
+        val dashAudio = audioSelection.selected?.track
         val videoUrl = dashVideo?.getValidUrl()?.takeIf { it.isNotEmpty() }
             ?: playData.durl?.firstOrNull()?.url?.takeIf { it.isNotEmpty() }
         if (videoUrl.isNullOrEmpty()) return null
         val audioUrl = dashAudio?.getValidUrl()?.takeIf { it.isNotEmpty() }
         return PortraitPlaybackStreamUrls(
             videoUrl = videoUrl,
-            audioUrl = audioUrl
+            audioUrl = audioUrl,
+            audioSelection = audioSelection
         )
     }
 
@@ -245,7 +255,8 @@ internal fun resolvePortraitPlaybackCdnUrls(
         videoUrl = rewrite?.videoUrls?.firstOrNull()?.takeIf { it.isNotBlank() }
             ?: streamUrls.videoUrl,
         audioUrl = rewrite?.audioUrls?.firstOrNull()?.takeIf { it.isNotBlank() }
-            ?: streamUrls.audioUrl
+            ?: streamUrls.audioUrl,
+        audioSelection = streamUrls.audioSelection
     )
 }
 

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/pager/PortraitVideoLoadPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/pager/PortraitVideoLoadPolicy.kt
@@ -194,6 +194,7 @@ internal fun resolvePortraitPlaybackStreamUrls(
     targetQuality: Int = PORTRAIT_PLAYBACK_TARGET_QUALITY,
     isHevcSupported: Boolean = MediaUtils.isHevcSupported(),
     isAv1Supported: Boolean = MediaUtils.isAv1Supported(),
+    isDolbyAudioSupported: Boolean = MediaUtils.isDolbyAtmosAudioSupported(),
     requestedAudioQuality: Int = -1,
     playbackSpeed: Float = 1.0f
 ): PortraitPlaybackStreamUrls? {
@@ -207,7 +208,8 @@ internal fun resolvePortraitPlaybackStreamUrls(
         val audioSelection = resolveAudioStreamSelection(
             dash = dash,
             requestedAudioQuality = requestedAudioQuality,
-            playbackSpeed = playbackSpeed
+            playbackSpeed = playbackSpeed,
+            isDolbyAudioSupported = isDolbyAudioSupported
         )
         val dashAudio = audioSelection.selected?.track
         val videoUrl = dashVideo?.getValidUrl()?.takeIf { it.isNotEmpty() }

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/pager/PortraitVideoPager.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/pager/PortraitVideoPager.kt
@@ -140,6 +140,7 @@ import com.android.purebilibili.feature.video.playback.session.shouldUsePlayback
 import com.android.purebilibili.feature.video.playback.session.startPlaybackSeekInteraction
 import com.android.purebilibili.feature.video.playback.session.syncPlaybackSeekSession
 import com.android.purebilibili.feature.video.playback.session.updatePlaybackSeekInteraction
+import com.android.purebilibili.feature.video.playback.audio.AUDIO_QUALITY_DOLBY
 import com.android.purebilibili.feature.video.playback.audio.AUDIO_QUALITY_HI_RES
 import com.android.purebilibili.feature.video.playback.audio.AudioQualityOption
 import com.android.purebilibili.feature.video.playback.audio.collectAudioStreamCandidates
@@ -2845,6 +2846,7 @@ private fun VideoPageItem(
             currentAudioQualityLabel = audioQualityChipLabel,
             showAudioQualityChip = showAudioQualityChip,
             isHiResAudioSelected = selectedAudioQuality == AUDIO_QUALITY_HI_RES,
+            isDolbyAudioSelected = selectedAudioQuality == AUDIO_QUALITY_DOLBY,
             currentRatio = aspectRatio,
             danmakuEnabled = danmakuEnabled,
             isStatusBarHidden = true,

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/pager/PortraitVideoPager.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/pager/PortraitVideoPager.kt
@@ -123,6 +123,7 @@ import com.android.purebilibili.core.store.SettingsManager
 import com.android.purebilibili.core.store.TokenManager
 import com.android.purebilibili.core.util.FormatUtils
 import com.android.purebilibili.data.repository.VideoRepository
+import com.android.purebilibili.data.model.response.Dash
 import com.android.purebilibili.data.model.response.RelatedVideo
 import com.android.purebilibili.data.model.response.Stat
 import com.android.purebilibili.data.model.response.ViewInfo
@@ -139,8 +140,14 @@ import com.android.purebilibili.feature.video.playback.session.shouldUsePlayback
 import com.android.purebilibili.feature.video.playback.session.startPlaybackSeekInteraction
 import com.android.purebilibili.feature.video.playback.session.syncPlaybackSeekSession
 import com.android.purebilibili.feature.video.playback.session.updatePlaybackSeekInteraction
+import com.android.purebilibili.feature.video.playback.audio.AUDIO_QUALITY_HI_RES
+import com.android.purebilibili.feature.video.playback.audio.AudioQualityOption
+import com.android.purebilibili.feature.video.playback.audio.collectAudioStreamCandidates
+import com.android.purebilibili.feature.video.playback.audio.resolveRequestedAudioQuality
+import com.android.purebilibili.feature.video.playback.policy.shouldRefreshPremiumAudioForPlaybackSpeedChange
 import com.android.purebilibili.feature.video.ui.overlay.PlayerProgress
 import com.android.purebilibili.feature.video.ui.components.AspectRatioMenu
+import com.android.purebilibili.feature.video.ui.components.AudioQualitySelectionMenu
 import com.android.purebilibili.feature.video.ui.components.QualitySelectionMenu
 import com.android.purebilibili.feature.video.ui.components.SpeedSelectionMenuDialog
 import com.android.purebilibili.feature.video.ui.components.UpPreviewSheet
@@ -375,6 +382,25 @@ fun PortraitVideoPager(
     val portraitQualityLabel = remember(portraitDisplayedQuality) {
         resolvePortraitQualityLabel(portraitDisplayedQuality)
     }
+    val portraitInitialRememberedAudioQuality = remember(context) {
+        SettingsManager.getAudioQualitySync(context)
+    }
+    val portraitInitialAudioQuality = remember(context, portraitInitialRememberedAudioQuality) {
+        resolveRequestedAudioQuality(
+            defaultAudioQuality = SettingsManager.getDefaultAudioQualitySync(context),
+            rememberedAudioQuality = portraitInitialRememberedAudioQuality
+        )
+    }
+    var portraitRememberedAudioQuality by remember {
+        mutableIntStateOf(portraitInitialRememberedAudioQuality)
+    }
+    var portraitRequestedAudioQuality by remember {
+        mutableIntStateOf(portraitInitialAudioQuality)
+    }
+    var portraitSelectedAudioQuality by remember { mutableIntStateOf(-1) }
+    var portraitAvailableAudioQualities by remember {
+        mutableStateOf<List<AudioQualityOption>>(emptyList())
+    }
     var portraitAspectRatio by remember { mutableStateOf(VideoAspectRatio.FIT) }
     val isPortraitLoggedIn = !TokenManager.sessDataCache.isNullOrEmpty()
     val isPortraitVip = TokenManager.isVipCache
@@ -587,6 +613,8 @@ fun PortraitVideoPager(
     var currentPlayingAid by remember(initialInfo.aid, useSharedPlayer) {
         mutableStateOf(if (useSharedPlayer) initialInfo.aid else 0L)
     }
+    var portraitCachedDash by remember { mutableStateOf<Dash?>(null) }
+    var portraitCurrentVideoUrl by remember { mutableStateOf("") }
     var isLoading by remember { mutableStateOf(false) }
     var lastCommittedPage by remember(useSharedPlayer) {
         mutableIntStateOf(if (useSharedPlayer) 0 else -1)
@@ -818,6 +846,37 @@ fun PortraitVideoPager(
         }
     }
 
+    fun switchPortraitAudioQuality(
+        audioQuality: Int,
+        persistManualSelection: Boolean
+    ): Boolean {
+        val dash = portraitCachedDash ?: return false
+        val videoUrl = portraitCurrentVideoUrl.takeIf { it.isNotBlank() } ?: return false
+        val activeBvid = currentPlayingBvid?.takeIf { it.isNotBlank() } ?: return false
+        val result = switchPortraitPlaybackAudioSource(
+            player = exoPlayer,
+            mediaSourceFactory = portraitMediaSourceFactory,
+            dash = dash,
+            currentVideoUrl = videoUrl,
+            requestedAudioQuality = audioQuality,
+            targetVideoQuality = resolvePortraitPlaybackTargetQuality(portraitSelectedQuality),
+            mediaId = resolvePortraitMediaId(activeBvid, currentPlayingCid),
+            cdnPlugin = portraitPlaybackCdnPlugin
+        )
+            ?: return false
+        portraitCurrentVideoUrl = result.videoUrl
+        portraitRequestedAudioQuality = audioQuality
+        portraitSelectedAudioQuality = result.selection.selectedPreferenceId
+        portraitAvailableAudioQualities = result.selection.availableOptions
+        if (persistManualSelection) {
+            portraitRememberedAudioQuality = audioQuality
+            scope.launch {
+                SettingsManager.setAudioQuality(context, audioQuality)
+            }
+        }
+        return true
+    }
+
     fun requestPortraitPlaybackForPage(
         targetPage: Int,
         applyInitialSeekOnFirstPage: Boolean,
@@ -830,6 +889,14 @@ fun PortraitVideoPager(
         val aid = playbackIdentity.aid
         val requestedCid = playbackIdentity.cid
         val targetQuality = resolvePortraitPlaybackTargetQuality(portraitSelectedQuality)
+        val targetAudioQuality = if (forceReload) {
+            portraitRequestedAudioQuality
+        } else {
+            resolveRequestedAudioQuality(
+                defaultAudioQuality = SettingsManager.getDefaultAudioQualitySync(context),
+                rememberedAudioQuality = portraitRememberedAudioQuality
+            )
+        }
 
         if (!isPortraitPlaybackAllowed) {
             pendingAutoPlayGeneration = -1
@@ -881,7 +948,9 @@ fun PortraitVideoPager(
                     onSuccess = { (info, playData) ->
                         val streamUrls = resolvePortraitPlaybackStreamUrls(
                             playData = playData,
-                            targetQuality = targetQuality
+                            targetQuality = targetQuality,
+                            requestedAudioQuality = targetAudioQuality,
+                            playbackSpeed = exoPlayer.playbackParameters.speed
                         ) ?: run {
                                 pendingAutoPlayGeneration = -1
                                 if (shouldApplyLoadResult(
@@ -898,7 +967,10 @@ fun PortraitVideoPager(
                         val resolvedUrls = resolvePortraitPlaybackCdnUrls(
                             streamUrls = streamUrls,
                             cachedDashVideos = playData.dash?.video.orEmpty(),
-                            cachedDashAudios = playData.dash?.audio.orEmpty(),
+                            cachedDashAudios = playData.dash
+                                ?.let(::collectAudioStreamCandidates)
+                                ?.map { it.track }
+                                .orEmpty(),
                             targetQuality = targetQuality,
                             cdnPlugin = portraitPlaybackCdnPlugin
                         )
@@ -949,6 +1021,13 @@ fun PortraitVideoPager(
                         resolveAspectRatioFromDimension(info.dimension)?.let { aspectRatio ->
                             knownVideoAspectRatios[bvid] = aspectRatio
                         }
+                        portraitCachedDash = playData.dash
+                        portraitCurrentVideoUrl = resolvedUrls.videoUrl
+                        portraitRequestedAudioQuality = targetAudioQuality
+                        portraitSelectedAudioQuality =
+                            streamUrls.audioSelection?.selectedPreferenceId ?: -1
+                        portraitAvailableAudioQualities =
+                            streamUrls.audioSelection?.availableOptions.orEmpty()
                         currentPlayingCid = resolvedCid
                         currentPlayingAid = info.aid
 
@@ -1353,6 +1432,9 @@ fun PortraitVideoPager(
                 qualityLabel = portraitQualityLabel,
                 selectedQualityId = portraitSelectedQuality,
                 availableQualityIds = portraitAvailableQualityIds,
+                requestedAudioQuality = portraitRequestedAudioQuality,
+                selectedAudioQuality = portraitSelectedAudioQuality,
+                availableAudioQualities = portraitAvailableAudioQualities,
                 aspectRatio = portraitAspectRatio,
                 isLoggedIn = isPortraitLoggedIn,
                 isVip = isPortraitVip,
@@ -1365,6 +1447,28 @@ fun PortraitVideoPager(
                         applyInitialSeekOnFirstPage = false,
                         forceReload = true
                     )
+                },
+                onAudioQualitySelected = { audioQuality ->
+                    switchPortraitAudioQuality(
+                        audioQuality = audioQuality,
+                        persistManualSelection = true
+                    )
+                },
+                onPlaybackSpeedSelected = { speed ->
+                    val previousSpeed = exoPlayer.playbackParameters.speed
+                    val normalizedSpeed = speed.coerceAtLeast(0.1f)
+                    exoPlayer.playbackParameters = PlaybackParameters(normalizedSpeed, 1.0f)
+                    if (shouldRefreshPremiumAudioForPlaybackSpeedChange(
+                            requestedAudioQuality = portraitRequestedAudioQuality,
+                            previousPlaybackSpeed = previousSpeed,
+                            nextPlaybackSpeed = normalizedSpeed
+                        )
+                    ) {
+                        switchPortraitAudioQuality(
+                            audioQuality = portraitRequestedAudioQuality,
+                            persistManualSelection = false
+                        )
+                    }
                 },
                 onAspectRatioChange = { ratio ->
                     // Runtime safety is applied per-page from actual video aspect.
@@ -1489,10 +1593,15 @@ private fun VideoPageItem(
     qualityLabel: String,
     selectedQualityId: Int,
     availableQualityIds: List<Int>,
+    requestedAudioQuality: Int,
+    selectedAudioQuality: Int,
+    availableAudioQualities: List<AudioQualityOption>,
     aspectRatio: VideoAspectRatio,
     isLoggedIn: Boolean,
     isVip: Boolean,
     onQualitySelected: (Int) -> Unit,
+    onAudioQualitySelected: (Int) -> Unit,
+    onPlaybackSpeedSelected: (Float) -> Unit,
     onAspectRatioChange: (VideoAspectRatio) -> Unit,
     hasRenderedFirstFrame: Boolean,
     initialProgressPositionMs: Long,
@@ -1521,8 +1630,7 @@ private fun VideoPageItem(
     val seekBackwardSeconds by SettingsManager
         .getSeekBackwardSeconds(context)
         .collectAsStateWithLifecycle(initialValue = 10)
-    val currentAudioQuality by viewModel.audioQualityPreference.collectAsStateWithLifecycle(initialValue = -1
-        )
+    val currentAudioQuality = requestedAudioQuality
     val bvid = if (item is ViewInfo) item.bvid else (item as RelatedVideo).bvid
     val itemAid = if (item is ViewInfo) item.aid else (item as RelatedVideo).aid
     
@@ -1532,11 +1640,22 @@ private fun VideoPageItem(
         mutableFloatStateOf(exoPlayer.playbackParameters.speed)
     }
     var showSpeedMenu by rememberSaveable(bvid) { mutableStateOf(false) }
+    var showAudioQualityMenu by rememberSaveable(bvid) { mutableStateOf(false) }
     var showQualityMenu by rememberSaveable(bvid) { mutableStateOf(false) }
     var showRatioMenu by rememberSaveable(bvid) { mutableStateOf(false) }
     var showSubtitlePanel by rememberSaveable(bvid) { mutableStateOf(false) }
     var subtitleTrackAvailable by remember(bvid) { mutableStateOf(false) }
     var subtitleOverlayEnabled by remember(bvid) { mutableStateOf(false) }
+    val selectedAudioOption = availableAudioQualities
+        .firstOrNull { it.preferenceId == selectedAudioQuality }
+    val audioQualityChipLabel = when (selectedAudioQuality) {
+        AUDIO_QUALITY_HI_RES -> "无损"
+        30250 -> "杜比"
+        else -> selectedAudioOption?.label.orEmpty()
+    }
+    val showAudioQualityChip = availableAudioQualities.count {
+        it.preferenceId != -1
+    } >= 2
     val subtitleAutoPreference by SettingsManager
         .getSubtitleAutoPreference(context)
         .collectAsStateWithLifecycle(initialValue = SubtitleAutoPreference.OFF)
@@ -1763,6 +1882,7 @@ private fun VideoPageItem(
             showDetailSheet = false
             showUpPreview = false
             showSubtitlePanel = false
+            showAudioQualityMenu = false
             showQualityMenu = false
             showRatioMenu = false
             showSpeedMenu = false
@@ -2722,6 +2842,9 @@ private fun VideoPageItem(
             
             currentSpeed = currentPlaybackSpeed,
             currentQualityLabel = qualityLabel,
+            currentAudioQualityLabel = audioQualityChipLabel,
+            showAudioQualityChip = showAudioQualityChip,
+            isHiResAudioSelected = selectedAudioQuality == AUDIO_QUALITY_HI_RES,
             currentRatio = aspectRatio,
             danmakuEnabled = danmakuEnabled,
             isStatusBarHidden = true,
@@ -2794,6 +2917,7 @@ private fun VideoPageItem(
             onSpeedClick = {
                 if (isCurrentPage) {
                     showSpeedMenu = true
+                    showAudioQualityMenu = false
                     showSubtitlePanel = false
                     onPortraitOverlayVisibleChange(true)
                 }
@@ -2801,6 +2925,15 @@ private fun VideoPageItem(
             onQualityClick = {
                 if (isCurrentPage) {
                     showQualityMenu = true
+                    showAudioQualityMenu = false
+                    showSubtitlePanel = false
+                    onPortraitOverlayVisibleChange(true)
+                }
+            },
+            onAudioQualityClick = {
+                if (isCurrentPage && showAudioQualityChip) {
+                    showAudioQualityMenu = true
+                    showQualityMenu = false
                     showSubtitlePanel = false
                     onPortraitOverlayVisibleChange(true)
                 }
@@ -2808,6 +2941,7 @@ private fun VideoPageItem(
             onRatioClick = {
                 if (isCurrentPage) {
                     showRatioMenu = true
+                    showAudioQualityMenu = false
                     showSubtitlePanel = false
                     onPortraitOverlayVisibleChange(true)
                 }
@@ -2820,6 +2954,7 @@ private fun VideoPageItem(
             onSubtitleClick = {
                 if (isCurrentPage) {
                     showSubtitlePanel = !showSubtitlePanel
+                    showAudioQualityMenu = false
                     showQualityMenu = false
                     showRatioMenu = false
                     showSpeedMenu = false
@@ -2901,6 +3036,18 @@ private fun VideoPageItem(
             )
         }
 
+        if (showAudioQualityMenu && isCurrentPage) {
+            AudioQualitySelectionMenu(
+                options = availableAudioQualities,
+                requestedAudioQuality = requestedAudioQuality,
+                onAudioQualitySelected = { audioQuality ->
+                    onAudioQualitySelected(audioQuality)
+                    showAudioQualityMenu = false
+                },
+                onDismiss = { showAudioQualityMenu = false }
+            )
+        }
+
         if (showRatioMenu && isCurrentPage) {
             Box(
                 modifier = Modifier
@@ -2926,10 +3073,7 @@ private fun VideoPageItem(
                 onSpeedSelected = { speed ->
                     val normalizedSpeed = speed.coerceAtLeast(0.1f)
                     currentPlaybackSpeed = normalizedSpeed
-                    val handledByViewModel = viewModel.applyPlaybackSpeedFromUi(normalizedSpeed)
-                    if (!handledByViewModel || exoPlayer.playbackParameters.speed != normalizedSpeed) {
-                        exoPlayer.playbackParameters = PlaybackParameters(normalizedSpeed, 1.0f)
-                    }
+                    onPlaybackSpeedSelected(normalizedSpeed)
                     scope.launch {
                         SettingsManager.setLastPlaybackSpeed(context, normalizedSpeed)
                     }

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/pager/PortraitVideoPager.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/pager/PortraitVideoPager.kt
@@ -140,10 +140,9 @@ import com.android.purebilibili.feature.video.playback.session.shouldUsePlayback
 import com.android.purebilibili.feature.video.playback.session.startPlaybackSeekInteraction
 import com.android.purebilibili.feature.video.playback.session.syncPlaybackSeekSession
 import com.android.purebilibili.feature.video.playback.session.updatePlaybackSeekInteraction
-import com.android.purebilibili.feature.video.playback.audio.AUDIO_QUALITY_DOLBY
-import com.android.purebilibili.feature.video.playback.audio.AUDIO_QUALITY_HI_RES
 import com.android.purebilibili.feature.video.playback.audio.AudioQualityOption
 import com.android.purebilibili.feature.video.playback.audio.collectAudioStreamCandidates
+import com.android.purebilibili.feature.video.playback.audio.resolveAudioQualityControlPresentation
 import com.android.purebilibili.feature.video.playback.audio.resolveRequestedAudioQuality
 import com.android.purebilibili.feature.video.playback.policy.shouldRefreshPremiumAudioForPlaybackSpeedChange
 import com.android.purebilibili.feature.video.ui.overlay.PlayerProgress
@@ -1647,16 +1646,12 @@ private fun VideoPageItem(
     var showSubtitlePanel by rememberSaveable(bvid) { mutableStateOf(false) }
     var subtitleTrackAvailable by remember(bvid) { mutableStateOf(false) }
     var subtitleOverlayEnabled by remember(bvid) { mutableStateOf(false) }
-    val selectedAudioOption = availableAudioQualities
-        .firstOrNull { it.preferenceId == selectedAudioQuality }
-    val audioQualityChipLabel = when (selectedAudioQuality) {
-        AUDIO_QUALITY_HI_RES -> "无损"
-        30250 -> "杜比"
-        else -> selectedAudioOption?.label.orEmpty()
+    val audioQualityPresentation = remember(availableAudioQualities, selectedAudioQuality) {
+        resolveAudioQualityControlPresentation(
+            options = availableAudioQualities,
+            selectedAudioQuality = selectedAudioQuality
+        )
     }
-    val showAudioQualityChip = availableAudioQualities.count {
-        it.preferenceId != -1
-    } >= 2
     val subtitleAutoPreference by SettingsManager
         .getSubtitleAutoPreference(context)
         .collectAsStateWithLifecycle(initialValue = SubtitleAutoPreference.OFF)
@@ -2843,10 +2838,9 @@ private fun VideoPageItem(
             
             currentSpeed = currentPlaybackSpeed,
             currentQualityLabel = qualityLabel,
-            currentAudioQualityLabel = audioQualityChipLabel,
-            showAudioQualityChip = showAudioQualityChip,
-            isHiResAudioSelected = selectedAudioQuality == AUDIO_QUALITY_HI_RES,
-            isDolbyAudioSelected = selectedAudioQuality == AUDIO_QUALITY_DOLBY,
+            currentAudioQualityLabel = audioQualityPresentation.label,
+            isHiResAudioSelected = audioQualityPresentation.showHiResBadge,
+            isDolbyAudioSelected = audioQualityPresentation.showDolbyBadge,
             currentRatio = aspectRatio,
             danmakuEnabled = danmakuEnabled,
             isStatusBarHidden = true,
@@ -2933,7 +2927,7 @@ private fun VideoPageItem(
                 }
             },
             onAudioQualityClick = {
-                if (isCurrentPage && showAudioQualityChip) {
+                if (isCurrentPage) {
                     showAudioQualityMenu = true
                     showQualityMenu = false
                     showSubtitlePanel = false

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/pager/PortraitVideoPager.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/pager/PortraitVideoPager.kt
@@ -112,6 +112,7 @@ import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import coil.compose.AsyncImage
 import com.android.purebilibili.core.network.NetworkModule
+import com.android.purebilibili.core.player.HiResCompatibleRenderersFactory
 import com.android.purebilibili.core.plugin.PluginManager
 import com.android.purebilibili.core.store.DanmakuSettings
 import com.android.purebilibili.core.util.NetworkUtils
@@ -561,6 +562,7 @@ fun PortraitVideoPager(
     val exoPlayer = sharedPlayer ?: remember(context) {
         val audioFocusEnabled = SettingsManager.getAudioFocusEnabledSync(context)
         ExoPlayer.Builder(context)
+            .setRenderersFactory(HiResCompatibleRenderersFactory(context))
             .setAudioAttributes(
                 androidx.media3.common.AudioAttributes.Builder()
                     .setUsage(androidx.media3.common.C.USAGE_MEDIA)

--- a/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoPlayerSection.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/ui/section/VideoPlayerSection.kt
@@ -4676,6 +4676,8 @@ fun VideoPlayerSection(
                 currentSecondCodec = currentSecondCodec,
                 onSecondCodecChange = onSecondCodecChange,
                 currentAudioQuality = currentAudioQuality,
+                selectedAudioQuality = uiState.selectedAudioQuality,
+                availableAudioQualities = uiState.availableAudioQualities,
                 onAudioQualityChange = onAudioQualityChange,
                 anime4kEnabled = anime4kPluginInfo?.enabled == true,
                 anime4kAvailable = anime4kGlesAvailable,

--- a/app/src/main/java/com/android/purebilibili/feature/video/usecase/VideoPlaybackUseCase.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/usecase/VideoPlaybackUseCase.kt
@@ -844,6 +844,8 @@ class VideoPlaybackUseCase(
         videoSecondCodecPreference: String = "avc1",
         isHevcSupported: Boolean = com.android.purebilibili.core.util.MediaUtils.isHevcSupported(),
         isAv1Supported: Boolean = com.android.purebilibili.core.util.MediaUtils.isAv1Supported(),
+        isDolbyAudioSupported: Boolean =
+            com.android.purebilibili.core.util.MediaUtils.isDolbyAtmosAudioSupported(),
         playWhenReady: Boolean = true
     ): QualitySwitchResult? {
         if (cachedVideos.isEmpty()) {
@@ -894,7 +896,8 @@ class VideoPlaybackUseCase(
         val audioSelection = resolveAudioStreamSelection(
             dash = dashCatalog,
             requestedAudioQuality = audioQualityPreference,
-            playbackSpeed = playbackSpeed
+            playbackSpeed = playbackSpeed,
+            isDolbyAudioSupported = isDolbyAudioSupported
         )
         val dashAudio = audioSelection.selected?.track
          
@@ -909,7 +912,8 @@ class VideoPlaybackUseCase(
             videoSecondCodecPreference = videoSecondCodecPreference,
             playbackQualityMode = effectivePlaybackQualityMode,
             isHevcSupported = isHevcSupported,
-            isAv1Supported = isAv1Supported
+            isAv1Supported = isAv1Supported,
+            isDolbyAudioSupported = isDolbyAudioSupported
         )
         if (videoUrl.isNotEmpty()) {
             playDashVideo(
@@ -926,7 +930,10 @@ class VideoPlaybackUseCase(
                 wasFallback = false,
                 adaptiveDashSource = adaptiveDashSource,
                 cachedDashVideos = cachedVideos,
-                cachedDashAudios = collectAudioStreamCandidates(dashCatalog).map { it.track },
+                cachedDashAudios = collectAudioStreamCandidates(
+                    dash = dashCatalog,
+                    isDolbyAudioSupported = isDolbyAudioSupported
+                ).map { it.track },
                 cachedDash = dashCatalog,
                 requestedAudioQuality = audioSelection.requestedPreferenceId,
                 selectedAudioQuality = audioSelection.selectedPreferenceId,
@@ -956,6 +963,8 @@ class VideoPlaybackUseCase(
         videoSecondCodecPreference: String = "avc1",
         isHevcSupported: Boolean = com.android.purebilibili.core.util.MediaUtils.isHevcSupported(),
         isAv1Supported: Boolean = com.android.purebilibili.core.util.MediaUtils.isAv1Supported(),
+        isDolbyAudioSupported: Boolean =
+            com.android.purebilibili.core.util.MediaUtils.isDolbyAtmosAudioSupported(),
         playWhenReady: Boolean = true
     ): QualitySwitchResult? {
         Logger.d("VideoPlaybackUseCase", " changeQualityFromApi: bvid=$bvid, cid=$cid, target=$qualityId")
@@ -988,7 +997,8 @@ class VideoPlaybackUseCase(
             videoSecondCodecPreference = videoSecondCodecPreference,
             playbackQualityMode = effectivePlaybackQualityMode,
             isHevcSupported = isHevcSupported,
-            isAv1Supported = isAv1Supported
+            isAv1Supported = isAv1Supported,
+            isDolbyAudioSupported = isDolbyAudioSupported
         ) ?: run {
             Logger.d("VideoPlaybackUseCase", " Video URL is empty")
             return null
@@ -1071,7 +1081,9 @@ class VideoPlaybackUseCase(
         videoSecondCodecPreference: String = "avc1",
         playbackQualityMode: PlaybackQualityMode = PlaybackQualityMode.AUTO,
         isHevcSupported: Boolean = com.android.purebilibili.core.util.MediaUtils.isHevcSupported(),
-        isAv1Supported: Boolean = com.android.purebilibili.core.util.MediaUtils.isAv1Supported()
+        isAv1Supported: Boolean = com.android.purebilibili.core.util.MediaUtils.isAv1Supported(),
+        isDolbyAudioSupported: Boolean =
+            com.android.purebilibili.core.util.MediaUtils.isDolbyAtmosAudioSupported()
     ): PlaybackSelectionResult? {
         val dashVideo = playUrlData.dash?.getBestVideo(
             targetQuality,
@@ -1084,7 +1096,8 @@ class VideoPlaybackUseCase(
             resolveAudioStreamSelection(
                 dash = dash,
                 requestedAudioQuality = audioQualityPreference,
-                playbackSpeed = playbackSpeed
+                playbackSpeed = playbackSpeed,
+                isDolbyAudioSupported = isDolbyAudioSupported
             )
         }
         val dashAudio = audioSelection?.selected?.track
@@ -1106,7 +1119,8 @@ class VideoPlaybackUseCase(
             videoSecondCodecPreference = videoSecondCodecPreference,
             playbackQualityMode = playbackQualityMode,
             isHevcSupported = isHevcSupported,
-            isAv1Supported = isAv1Supported
+            isAv1Supported = isAv1Supported,
+            isDolbyAudioSupported = isDolbyAudioSupported
         )
         return PlaybackSelectionResult(
             videoUrl = videoUrl,
@@ -1116,7 +1130,12 @@ class VideoPlaybackUseCase(
             adaptiveDashSource = adaptiveDashSource,
             cachedDashVideos = playUrlData.dash?.video ?: emptyList(),
             cachedDashAudios = playUrlData.dash
-                ?.let(::collectAudioStreamCandidates)
+                ?.let { dash ->
+                    collectAudioStreamCandidates(
+                        dash = dash,
+                        isDolbyAudioSupported = isDolbyAudioSupported
+                    )
+                }
                 ?.map { it.track }
                 .orEmpty(),
             cachedDash = playUrlData.dash,
@@ -1143,7 +1162,8 @@ class VideoPlaybackUseCase(
         videoSecondCodecPreference: String,
         playbackQualityMode: PlaybackQualityMode,
         isHevcSupported: Boolean,
-        isAv1Supported: Boolean
+        isAv1Supported: Boolean,
+        isDolbyAudioSupported: Boolean
     ): AdaptiveDashPlaybackSource? {
         val adaptiveTrackSet = dash?.let { sourceDash ->
             buildAdaptiveDashTrackSet(
@@ -1154,7 +1174,8 @@ class VideoPlaybackUseCase(
                 preferredVideoCodec = videoCodecPreference,
                 secondaryVideoCodec = videoSecondCodecPreference,
                 isHevcSupported = isHevcSupported,
-                isAv1Supported = isAv1Supported
+                isAv1Supported = isAv1Supported,
+                isDolbyAudioSupported = isDolbyAudioSupported
             )
         } ?: return null
 

--- a/app/src/main/java/com/android/purebilibili/feature/video/usecase/VideoPlaybackUseCase.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/usecase/VideoPlaybackUseCase.kt
@@ -20,9 +20,12 @@ import com.android.purebilibili.data.model.VideoLoadError
 import com.android.purebilibili.data.model.response.*
 import com.android.purebilibili.feature.video.playback.dash.AdaptiveDashPlaybackSource
 import com.android.purebilibili.feature.video.playback.dash.buildLocalDashManifest
+import com.android.purebilibili.feature.video.playback.audio.AudioFallbackReason
+import com.android.purebilibili.feature.video.playback.audio.AudioQualityOption
+import com.android.purebilibili.feature.video.playback.audio.collectAudioStreamCandidates
+import com.android.purebilibili.feature.video.playback.audio.resolveAudioStreamSelection
 import com.android.purebilibili.feature.video.playback.policy.PlaybackQualityMode
 import com.android.purebilibili.feature.video.playback.policy.buildAdaptiveDashTrackSet
-import com.android.purebilibili.feature.video.playback.policy.resolveSpeedCompatibleAudioQualityPreference
 import com.android.purebilibili.data.repository.ActionRepository
 import com.android.purebilibili.data.repository.VideoRepository
 import com.android.purebilibili.feature.video.controller.PlaybackProgressManager
@@ -58,6 +61,11 @@ sealed class VideoLoadResult {
         val switchableQualityIds: List<Int> = emptyList(),
         val cachedDashVideos: List<DashVideo>,
         val cachedDashAudios: List<DashAudio>,
+        val cachedDash: Dash? = null,
+        val requestedAudioQuality: Int = -1,
+        val selectedAudioQuality: Int = -1,
+        val availableAudioQualities: List<AudioQualityOption> = emptyList(),
+        val audioFallbackReason: AudioFallbackReason? = null,
         val emoteMap: Map<String, String>,
         val isLoggedIn: Boolean,
         val isVip: Boolean,
@@ -104,6 +112,11 @@ data class QualitySwitchResult(
     val adaptiveDashSource: AdaptiveDashPlaybackSource? = null,
     val cachedDashVideos: List<DashVideo>,
     val cachedDashAudios: List<DashAudio>,
+    val cachedDash: Dash? = null,
+    val requestedAudioQuality: Int = -1,
+    val selectedAudioQuality: Int = -1,
+    val availableAudioQualities: List<AudioQualityOption> = emptyList(),
+    val audioFallbackReason: AudioFallbackReason? = null,
     val switchableQualityIds: List<Int> = emptyList(),
     val qualityIds: List<Int> = emptyList(),
     val qualityLabels: List<String> = emptyList()
@@ -117,6 +130,11 @@ data class PlaybackSelectionResult(
     val adaptiveDashSource: AdaptiveDashPlaybackSource? = null,
     val cachedDashVideos: List<DashVideo>,
     val cachedDashAudios: List<DashAudio>,
+    val cachedDash: Dash? = null,
+    val requestedAudioQuality: Int = -1,
+    val selectedAudioQuality: Int = -1,
+    val availableAudioQualities: List<AudioQualityOption> = emptyList(),
+    val audioFallbackReason: AudioFallbackReason? = null,
     val switchableQualityIds: List<Int>,
     val qualityIds: List<Int>,
     val qualityLabels: List<String>,
@@ -665,6 +683,11 @@ class VideoPlaybackUseCase(
                         switchableQualityIds = selection.switchableQualityIds,
                         cachedDashVideos = selection.cachedDashVideos,
                         cachedDashAudios = selection.cachedDashAudios,
+                        cachedDash = selection.cachedDash,
+                        requestedAudioQuality = selection.requestedAudioQuality,
+                        selectedAudioQuality = selection.selectedAudioQuality,
+                        availableAudioQualities = selection.availableAudioQualities,
+                        audioFallbackReason = selection.audioFallbackReason,
                         emoteMap = emoteMap,
                         isLoggedIn = isLogin,
                         isVip = isEffectiveVip, // Pass effective VIP status (true if actual VIP or Unlocked)
@@ -811,6 +834,7 @@ class VideoPlaybackUseCase(
         qualityId: Int,
         cachedVideos: List<DashVideo>,
         cachedAudios: List<DashAudio>,
+        cachedDash: Dash? = null,
         currentPos: Long,
         durationMs: Long = 0L,
         playbackQualityMode: PlaybackQualityMode = PlaybackQualityMode.AUTO,
@@ -866,27 +890,21 @@ class VideoPlaybackUseCase(
         )
         val videoUrl = match.getValidUrl()
         
-        // [修复] 音频也应该重新选择最佳匹配，而不是盲目取第一个
-        val effectiveAudioQualityPreference = resolveSpeedCompatibleAudioQualityPreference(
+        val dashCatalog = cachedDash ?: Dash(video = cachedVideos, audio = cachedAudios)
+        val audioSelection = resolveAudioStreamSelection(
+            dash = dashCatalog,
             requestedAudioQuality = audioQualityPreference,
             playbackSpeed = playbackSpeed
         )
-
-        val dashAudio = if (effectiveAudioQualityPreference != -1) {
-            // 使用 Dash.getBestAudio 逻辑的简化版 (因为这里只有 List<DashAudio>)
-            cachedAudios.find { it.id == effectiveAudioQualityPreference }
-                ?: cachedAudios.minByOrNull { kotlin.math.abs(it.id - effectiveAudioQualityPreference) }
-        } else {
-            cachedAudios.maxByOrNull { it.bandwidth }
-        }
+        val dashAudio = audioSelection.selected?.track
          
         val audioUrl = dashAudio?.getValidUrl()
         val adaptiveDashSource = buildAdaptiveDashPlaybackSource(
             durationMs = durationMs,
             minBufferTimeMs = 1500L,
-            dash = Dash(video = cachedVideos, audio = cachedAudios),
+            dash = dashCatalog,
             targetQuality = requestedQuality,
-            audioQualityPreference = effectiveAudioQualityPreference,
+            audioQualityPreference = audioSelection.effectivePreferenceId,
             videoCodecPreference = videoCodecPreference,
             videoSecondCodecPreference = videoSecondCodecPreference,
             playbackQualityMode = effectivePlaybackQualityMode,
@@ -908,7 +926,12 @@ class VideoPlaybackUseCase(
                 wasFallback = false,
                 adaptiveDashSource = adaptiveDashSource,
                 cachedDashVideos = cachedVideos,
-                cachedDashAudios = cachedAudios,
+                cachedDashAudios = collectAudioStreamCandidates(dashCatalog).map { it.track },
+                cachedDash = dashCatalog,
+                requestedAudioQuality = audioSelection.requestedPreferenceId,
+                selectedAudioQuality = audioSelection.selectedPreferenceId,
+                availableAudioQualities = audioSelection.availableOptions,
+                audioFallbackReason = audioSelection.fallbackReason,
                 switchableQualityIds = availableIds
             )
         }
@@ -993,6 +1016,11 @@ class VideoPlaybackUseCase(
             adaptiveDashSource = selection.adaptiveDashSource,
             cachedDashVideos = selection.cachedDashVideos,
             cachedDashAudios = selection.cachedDashAudios,
+            cachedDash = selection.cachedDash,
+            requestedAudioQuality = selection.requestedAudioQuality,
+            selectedAudioQuality = selection.selectedAudioQuality,
+            availableAudioQualities = selection.availableAudioQualities,
+            audioFallbackReason = selection.audioFallbackReason,
             switchableQualityIds = selection.switchableQualityIds,
             qualityIds = selection.qualityIds,
             qualityLabels = selection.qualityLabels
@@ -1052,11 +1080,14 @@ class VideoPlaybackUseCase(
             isHevcSupported = isHevcSupported,
             isAv1Supported = isAv1Supported
         )
-        val effectiveAudioQualityPreference = resolveSpeedCompatibleAudioQualityPreference(
-            requestedAudioQuality = audioQualityPreference,
-            playbackSpeed = playbackSpeed
-        )
-        val dashAudio = playUrlData.dash?.getBestAudio(effectiveAudioQualityPreference)
+        val audioSelection = playUrlData.dash?.let { dash ->
+            resolveAudioStreamSelection(
+                dash = dash,
+                requestedAudioQuality = audioQualityPreference,
+                playbackSpeed = playbackSpeed
+            )
+        }
+        val dashAudio = audioSelection?.selected?.track
         val videoUrl = getValidVideoUrl(dashVideo, playUrlData)
         if (videoUrl.isBlank()) return null
 
@@ -1070,7 +1101,7 @@ class VideoPlaybackUseCase(
             minBufferTimeMs = playUrlData.dash?.minBufferTime?.times(1000f)?.toLong() ?: 1500L,
             dash = playUrlData.dash,
             targetQuality = targetQuality,
-            audioQualityPreference = effectiveAudioQualityPreference,
+            audioQualityPreference = audioSelection?.effectivePreferenceId ?: audioQualityPreference,
             videoCodecPreference = videoCodecPreference,
             videoSecondCodecPreference = videoSecondCodecPreference,
             playbackQualityMode = playbackQualityMode,
@@ -1084,7 +1115,15 @@ class VideoPlaybackUseCase(
             isDashPlayback = dashVideo != null,
             adaptiveDashSource = adaptiveDashSource,
             cachedDashVideos = playUrlData.dash?.video ?: emptyList(),
-            cachedDashAudios = playUrlData.dash?.audio ?: emptyList(),
+            cachedDashAudios = playUrlData.dash
+                ?.let(::collectAudioStreamCandidates)
+                ?.map { it.track }
+                .orEmpty(),
+            cachedDash = playUrlData.dash,
+            requestedAudioQuality = audioSelection?.requestedPreferenceId ?: audioQualityPreference,
+            selectedAudioQuality = audioSelection?.selectedPreferenceId ?: -1,
+            availableAudioQualities = audioSelection?.availableOptions.orEmpty(),
+            audioFallbackReason = audioSelection?.fallbackReason,
             switchableQualityIds = qualitySelectionState.switchableQualityIds,
             qualityIds = qualitySelectionState.qualityIds,
             qualityLabels = qualitySelectionState.qualityLabels,

--- a/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/VideoPlaybackViewModel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/VideoPlaybackViewModel.kt
@@ -13,6 +13,7 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.Tracks
+import androidx.media3.exoplayer.ExoPlaybackException
 import androidx.media3.exoplayer.ExoPlayer
 import com.android.purebilibili.core.cache.PlayUrlCache
 import com.android.purebilibili.core.cooldown.PlaybackCooldownManager
@@ -87,6 +88,8 @@ import com.android.purebilibili.feature.video.playback.loader.PlaybackLoader
 import com.android.purebilibili.feature.video.playback.dash.AdaptiveDashPlaybackSource
 import com.android.purebilibili.feature.video.playback.audio.AudioFallbackReason
 import com.android.purebilibili.feature.video.playback.audio.AudioQualityOption
+import com.android.purebilibili.feature.video.playback.audio.AUDIO_QUALITY_AUTO
+import com.android.purebilibili.feature.video.playback.audio.isPremiumAudioPlaybackFailure
 import com.android.purebilibili.feature.video.playback.audio.resolveRequestedAudioQuality
 import com.android.purebilibili.feature.video.playback.policy.PlaybackPostLoadTask
 import com.android.purebilibili.feature.video.playback.policy.PlaybackQualityMode
@@ -2132,6 +2135,24 @@ class VideoPlaybackViewModel : ViewModel() {
 
         override fun onPlayerError(error: PlaybackException) {
             Logger.w("PlayerVM", "Playback error: ${error.errorCodeName}, message=${error.message}")
+            val current = _uiState.value as? VideoPlaybackUiState.Success
+            val exoPlaybackError = error as? ExoPlaybackException
+            if (
+                current != null &&
+                isPremiumAudioPlaybackFailure(
+                    errorCode = error.errorCode,
+                    selectedAudioQuality = current.selectedAudioQuality,
+                    rendererName = exoPlaybackError?.rendererName,
+                    rendererSampleMimeType = exoPlaybackError?.rendererFormat?.sampleMimeType
+                )
+            ) {
+                Logger.w(
+                    "PlayerVM",
+                    "Hi-Res audio decoder failed; switching current playback to AAC"
+                )
+                fallbackFromPremiumAudioPlaybackError()
+                return
+            }
             recordCurrentCdnHealthEvent(CdnHealthEvent.PLAYER_ERROR)
             fallbackFromCdnRewrite(reason = "player_error")
         }
@@ -4666,6 +4687,7 @@ class VideoPlaybackViewModel : ViewModel() {
     
     private val _audioQualityPreference = MutableStateFlow(-1)
     val audioQualityPreference = _audioQualityPreference.asStateFlow()
+    private var premiumAudioFallbackInProgress = false
     
     fun setVideoCodec(codec: String) {
         _videoCodecPreference.value = codec // Optimistic update
@@ -4731,11 +4753,72 @@ class VideoPlaybackViewModel : ViewModel() {
                     "当前倍速暂不支持所选音质，已临时使用 $selectedLabel"
                 AudioFallbackReason.REQUESTED_UNAVAILABLE ->
                     "当前视频不支持所选音质，已使用 $selectedLabel"
+                AudioFallbackReason.DECODER_ERROR ->
+                    "当前设备无法稳定解码所选音质，已临时使用 $selectedLabel"
                 AudioFallbackReason.NO_PLAYABLE_AUDIO ->
                     "当前视频没有可用音轨"
                 null -> "✓ 已切换至 $selectedLabel"
             }
             toast(message, PlayerToastPresentation.CenteredHighlight)
+        }
+    }
+
+    internal fun fallbackFromPremiumAudioPlaybackError() {
+        if (premiumAudioFallbackInProgress) return
+
+        val current = _uiState.value as? VideoPlaybackUiState.Success ?: return
+        val player = exoPlayer ?: return
+        val hasStandardAudio = current.availableAudioQualities.any { option ->
+            option.preferenceId == AUDIO_QUALITY_AUTO
+        }
+        if (!hasStandardAudio) {
+            player.pause()
+            viewModelScope.launch {
+                toast("当前设备无法解码该 Hi-Res 音轨，且没有可回退的 AAC 音轨")
+            }
+            return
+        }
+
+        val requestedAudioQuality = current.requestedAudioQuality
+        val currentPos = player.currentPosition.coerceAtLeast(0L)
+        val playWhenReady = resolvePlaybackIntentForSourceReplacement(
+            playWhenReady = player.playWhenReady,
+            isPlaying = player.isPlaying
+        )
+        premiumAudioFallbackInProgress = true
+        playbackCdnFallbackJob?.cancel()
+        playbackCdnFallbackJob = null
+        playbackCdnFallbackState = PlaybackCdnFallbackState.Inactive
+
+        viewModelScope.launch {
+            try {
+                val switched = refreshPlaybackAudioForSpeedCompatibility(
+                    current = current,
+                    audioPreference = AUDIO_QUALITY_AUTO,
+                    currentPos = currentPos,
+                    playWhenReady = playWhenReady
+                )
+                val updated = _uiState.value as? VideoPlaybackUiState.Success
+                if (switched && updated?.selectedAudioQuality == AUDIO_QUALITY_AUTO) {
+                    _uiState.value = updated.copy(
+                        requestedAudioQuality = requestedAudioQuality,
+                        audioFallbackReason = AudioFallbackReason.DECODER_ERROR
+                    )
+                    toast(
+                        "当前设备无法稳定解码 Hi-Res，已临时切换至 AAC",
+                        PlayerToastPresentation.CenteredHighlight
+                    )
+                } else {
+                    player.pause()
+                    toast("Hi-Res 解码失败，AAC 回退也未能完成")
+                }
+            } catch (error: Exception) {
+                Logger.w("PlayerVM", "Hi-Res audio fallback failed: ${error.message}")
+                player.pause()
+                toast("Hi-Res 解码失败，AAC 回退也未能完成")
+            } finally {
+                premiumAudioFallbackInProgress = false
+            }
         }
     }
 

--- a/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/VideoPlaybackViewModel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/VideoPlaybackViewModel.kt
@@ -4722,12 +4722,9 @@ class VideoPlaybackViewModel : ViewModel() {
                 ?.firstOrNull { it.preferenceId == nextState.selectedAudioQuality }
                 ?.label
                 ?: when (nextState?.selectedAudioQuality) {
-                    30280 -> "192K"
-                    30232 -> "132K"
-                    30216 -> "64K"
                     30250 -> "杜比全景声"
                     30251 -> "Hi-Res 无损"
-                    else -> "自动"
+                    else -> "高品质 AAC"
                 }
             val message = when (nextState?.audioFallbackReason) {
                 AudioFallbackReason.SPEED_INCOMPATIBLE ->

--- a/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/VideoPlaybackViewModel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/VideoPlaybackViewModel.kt
@@ -4724,7 +4724,7 @@ class VideoPlaybackViewModel : ViewModel() {
                 ?: when (nextState?.selectedAudioQuality) {
                     30250 -> "杜比全景声"
                     30251 -> "Hi-Res 无损"
-                    else -> "高品质 AAC"
+                    else -> "AAC"
                 }
             val message = when (nextState?.audioFallbackReason) {
                 AudioFallbackReason.SPEED_INCOMPATIBLE ->

--- a/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/VideoPlaybackViewModel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/VideoPlaybackViewModel.kt
@@ -85,6 +85,9 @@ import com.android.purebilibili.feature.video.playback.loader.PlaybackLoadConfig
 import com.android.purebilibili.feature.video.playback.loader.PlaybackLoadResult
 import com.android.purebilibili.feature.video.playback.loader.PlaybackLoader
 import com.android.purebilibili.feature.video.playback.dash.AdaptiveDashPlaybackSource
+import com.android.purebilibili.feature.video.playback.audio.AudioFallbackReason
+import com.android.purebilibili.feature.video.playback.audio.AudioQualityOption
+import com.android.purebilibili.feature.video.playback.audio.resolveRequestedAudioQuality
 import com.android.purebilibili.feature.video.playback.policy.PlaybackPostLoadTask
 import com.android.purebilibili.feature.video.playback.policy.PlaybackQualityMode
 import com.android.purebilibili.feature.video.playback.policy.PlaybackHeartbeatSnapshot
@@ -461,6 +464,11 @@ sealed class VideoPlaybackUiState {
         val pendingPlaybackTransitionPositionMs: Long? = null,
         val cachedDashVideos: List<DashVideo> = emptyList(),
         val cachedDashAudios: List<DashAudio> = emptyList(),
+        val cachedDash: Dash? = null,
+        val requestedAudioQuality: Int = -1,
+        val selectedAudioQuality: Int = -1,
+        val availableAudioQualities: List<AudioQualityOption> = emptyList(),
+        val audioFallbackReason: AudioFallbackReason? = null,
         val isQualitySwitching: Boolean = false,
         val requestedQuality: Int? = null,
         val isLoggedIn: Boolean = false,
@@ -1291,9 +1299,7 @@ class VideoPlaybackViewModel : ViewModel() {
         val current = _uiState.value as? VideoPlaybackUiState.Success ?: return true
         if (current.isQualitySwitching) return true
 
-        val audioPreference = appContext?.let {
-            com.android.purebilibili.core.store.SettingsManager.getAudioQualitySync(it)
-        } ?: -1
+        val audioPreference = current.requestedAudioQuality
         if (!shouldRefreshPremiumAudioForPlaybackSpeedChange(
                 requestedAudioQuality = audioPreference,
                 previousPlaybackSpeed = previousSpeed,
@@ -1319,7 +1325,7 @@ class VideoPlaybackViewModel : ViewModel() {
         audioPreference: Int,
         currentPos: Long,
         playWhenReady: Boolean
-    ) {
+    ): Boolean {
         val sessionBlockedCodecs = playbackSessionStore.state.value.blockedVideoCodecs
         val videoCodecPreference = resolveEffectiveVideoCodecPreference(
             requestCodecOverride = null,
@@ -1336,6 +1342,7 @@ class VideoPlaybackViewModel : ViewModel() {
             qualityId = current.currentQuality,
             cachedVideos = current.cachedDashVideos,
             cachedAudios = current.cachedDashAudios,
+            cachedDash = current.cachedDash,
             currentPos = currentPos,
             durationMs = current.videoDurationMs,
             playbackQualityMode = current.playbackQualityMode,
@@ -1357,10 +1364,11 @@ class VideoPlaybackViewModel : ViewModel() {
             isHevcSupported = isHevcSupported,
             isAv1Supported = isAv1Supported,
             playWhenReady = playWhenReady
-        ) ?: return
+        ) ?: return false
 
         val nextCachedDashVideos = result.cachedDashVideos.ifEmpty { current.cachedDashVideos }
         val nextCachedDashAudios = result.cachedDashAudios.ifEmpty { current.cachedDashAudios }
+        val nextCachedDash = result.cachedDash ?: current.cachedDash
         val cdnSelection = resolvePlaybackCdnCandidateSelection(
             videoUrl = result.videoUrl,
             audioUrl = result.audioUrl,
@@ -1388,6 +1396,12 @@ class VideoPlaybackViewModel : ViewModel() {
             adaptiveDashSource = cdnSelection.adaptiveDashSource,
             cachedDashVideos = nextCachedDashVideos,
             cachedDashAudios = nextCachedDashAudios,
+            cachedDash = nextCachedDash,
+            requestedAudioQuality = result.requestedAudioQuality,
+            selectedAudioQuality = result.selectedAudioQuality,
+            availableAudioQualities = result.availableAudioQualities
+                .ifEmpty { current.availableAudioQualities },
+            audioFallbackReason = result.audioFallbackReason,
             allVideoUrls = cdnSelection.allVideoUrls,
             allAudioUrls = cdnSelection.allAudioUrls,
             cdnCandidateSources = cdnSelection.candidateSources,
@@ -1397,6 +1411,7 @@ class VideoPlaybackViewModel : ViewModel() {
             qualityLabels = result.qualityLabels.ifEmpty { current.qualityLabels },
             switchableQualityIds = result.switchableQualityIds.ifEmpty { current.switchableQualityIds }
         )
+        return true
     }
     
     //  SponsorBlock (via Plugin)
@@ -2889,8 +2904,13 @@ class VideoPlaybackViewModel : ViewModel() {
                     )
                 } ?: 64
                 //  [新增] 获取音频/视频偏好
-                val audioQualityPreference = appContext?.let { 
-                    com.android.purebilibili.core.store.SettingsManager.getAudioQualitySync(it) 
+                val audioQualityPreference = appContext?.let { context ->
+                    resolveRequestedAudioQuality(
+                        defaultAudioQuality = com.android.purebilibili.core.store.SettingsManager
+                            .getDefaultAudioQualitySync(context),
+                        rememberedAudioQuality = com.android.purebilibili.core.store.SettingsManager
+                            .getAudioQualitySync(context)
+                    )
                 } ?: -1
                 val settingsCodecPreference = appContext?.let {
                     com.android.purebilibili.core.store.SettingsManager.getVideoCodecSync(it)
@@ -3050,6 +3070,11 @@ class VideoPlaybackViewModel : ViewModel() {
                             switchableQualityIds = result.switchableQualityIds,
                             cachedDashVideos = result.cachedDashVideos,
                             cachedDashAudios = result.cachedDashAudios,
+                            cachedDash = result.cachedDash,
+                            requestedAudioQuality = result.requestedAudioQuality,
+                            selectedAudioQuality = result.selectedAudioQuality,
+                            availableAudioQualities = result.availableAudioQualities,
+                            audioFallbackReason = result.audioFallbackReason,
                             emoteMap = result.emoteMap,
                             isLoggedIn = result.isLoggedIn,
                             isVip = result.isVip,
@@ -3365,9 +3390,7 @@ class VideoPlaybackViewModel : ViewModel() {
         val videoSecondCodecPreference = _videoSecondCodecPreference.value
         val isHevcSupported = com.android.purebilibili.core.util.MediaUtils.isHevcSupported()
         val isAv1Supported = com.android.purebilibili.core.util.MediaUtils.isAv1Supported()
-        val audioQualityPreference = appContext?.let {
-            com.android.purebilibili.core.store.SettingsManager.getAudioQualitySync(it)
-        } ?: -1
+        val audioQualityPreference = current.requestedAudioQuality
         val hdrPlaybackQualityMode = PlaybackQualityMode.LOCKED(125)
 
         val selection = playbackUseCase.resolvePlaybackSelection(
@@ -3422,6 +3445,11 @@ class VideoPlaybackViewModel : ViewModel() {
                 adaptiveDashSource = selection.adaptiveDashSource,
                 cachedDashVideos = selection.cachedDashVideos,
                 cachedDashAudios = selection.cachedDashAudios,
+                cachedDash = selection.cachedDash,
+                requestedAudioQuality = selection.requestedAudioQuality,
+                selectedAudioQuality = selection.selectedAudioQuality,
+                availableAudioQualities = selection.availableAudioQualities,
+                audioFallbackReason = selection.audioFallbackReason,
                 qualityIds = selection.qualityIds,
                 qualityLabels = selection.qualityLabels,
                 switchableQualityIds = selection.switchableQualityIds,
@@ -4661,23 +4689,56 @@ class VideoPlaybackViewModel : ViewModel() {
     }
 
     fun setAudioQuality(audioQuality: Int) {
-        _audioQualityPreference.value = audioQuality // Optimistic update
-        com.android.purebilibili.core.util.Logger.d("VideoPlaybackViewModel", "🎵 setAudioQuality called with: $audioQuality")
-        //  [调试] 显示 Toast 提示
-        val label = when(audioQuality) {
-            -1 -> "自动"
-            30280 -> "192K"
-            30250 -> "杜比全景声"
-            30251 -> "Hi-Res无损"
-            else -> "未知($audioQuality)"
-        }
-        toast("切换音质为: $label")
-
+        val previousAudioQuality = _audioQualityPreference.value
+        _audioQualityPreference.value = audioQuality
+        Logger.d("VideoPlaybackViewModel", "🎵 setAudioQuality called with: $audioQuality")
         viewModelScope.launch {
-            appContext?.let { 
-                com.android.purebilibili.core.store.SettingsManager.setAudioQuality(it, audioQuality)
-                reloadVideo() // Reload to apply new audio quality
+            val current = _uiState.value as? VideoPlaybackUiState.Success
+            val player = exoPlayer
+            if (current == null || player == null) {
+                appContext?.let {
+                    com.android.purebilibili.core.store.SettingsManager.setAudioQuality(it, audioQuality)
+                }
+                return@launch
             }
+
+            val switched = refreshPlaybackAudioForSpeedCompatibility(
+                current = current,
+                audioPreference = audioQuality,
+                currentPos = player.currentPosition.coerceAtLeast(0L),
+                playWhenReady = player.playWhenReady
+            )
+            if (!switched) {
+                _audioQualityPreference.value = previousAudioQuality
+                toast("音质切换失败，请稍后重试")
+                return@launch
+            }
+
+            appContext?.let {
+                com.android.purebilibili.core.store.SettingsManager.setAudioQuality(it, audioQuality)
+            }
+            val nextState = _uiState.value as? VideoPlaybackUiState.Success
+            val selectedLabel = nextState?.availableAudioQualities
+                ?.firstOrNull { it.preferenceId == nextState.selectedAudioQuality }
+                ?.label
+                ?: when (nextState?.selectedAudioQuality) {
+                    30280 -> "192K"
+                    30232 -> "132K"
+                    30216 -> "64K"
+                    30250 -> "杜比全景声"
+                    30251 -> "Hi-Res 无损"
+                    else -> "自动"
+                }
+            val message = when (nextState?.audioFallbackReason) {
+                AudioFallbackReason.SPEED_INCOMPATIBLE ->
+                    "当前倍速暂不支持所选音质，已临时使用 $selectedLabel"
+                AudioFallbackReason.REQUESTED_UNAVAILABLE ->
+                    "当前视频不支持所选音质，已使用 $selectedLabel"
+                AudioFallbackReason.NO_PLAYABLE_AUDIO ->
+                    "当前视频没有可用音轨"
+                null -> "✓ 已切换至 $selectedLabel"
+            }
+            toast(message, PlayerToastPresentation.CenteredHighlight)
         }
     }
 
@@ -6694,10 +6755,7 @@ class VideoPlaybackViewModel : ViewModel() {
         
         viewModelScope.launch {
             try {
-                // [新增] 获取当前音频偏好
-                val audioPref = appContext?.let { 
-                    com.android.purebilibili.core.store.SettingsManager.getAudioQualitySync(it) 
-                } ?: -1
+                val audioPref = current.requestedAudioQuality
                 val sessionBlockedCodecs = playbackSessionStore.state.value.blockedVideoCodecs
                 val videoCodecPreference = resolveEffectiveVideoCodecPreference(
                     requestCodecOverride = null,
@@ -6715,6 +6773,7 @@ class VideoPlaybackViewModel : ViewModel() {
                     qualityId = qualityId,
                     cachedVideos = current.cachedDashVideos,
                     cachedAudios = current.cachedDashAudios,
+                    cachedDash = current.cachedDash,
                     currentPos = currentPos,
                     durationMs = current.videoDurationMs,
                     playbackQualityMode = playbackQualityMode,
@@ -6741,6 +6800,7 @@ class VideoPlaybackViewModel : ViewModel() {
                 if (result != null) {
                     val nextCachedDashVideos = result.cachedDashVideos.ifEmpty { current.cachedDashVideos }
                     val nextCachedDashAudios = result.cachedDashAudios.ifEmpty { current.cachedDashAudios }
+                    val nextCachedDash = result.cachedDash ?: current.cachedDash
                     val cdnSelection = resolvePlaybackCdnCandidateSelection(
                         videoUrl = result.videoUrl,
                         audioUrl = result.audioUrl,
@@ -6757,6 +6817,11 @@ class VideoPlaybackViewModel : ViewModel() {
                             adaptiveDashSource = result.adaptiveDashSource,
                             cachedDashVideos = nextCachedDashVideos,
                             cachedDashAudios = nextCachedDashAudios,
+                            cachedDash = nextCachedDash,
+                            requestedAudioQuality = result.requestedAudioQuality,
+                            selectedAudioQuality = result.selectedAudioQuality,
+                            availableAudioQualities = result.availableAudioQualities,
+                            audioFallbackReason = result.audioFallbackReason,
                             qualityIds = result.qualityIds,
                             qualityLabels = result.qualityLabels,
                             switchableQualityIds = result.switchableQualityIds,
@@ -6831,8 +6896,13 @@ class VideoPlaybackViewModel : ViewModel() {
                     val videoSecondCodecPreference = appContext?.let {
                         com.android.purebilibili.core.store.SettingsManager.getVideoSecondCodecSync(it)
                     } ?: AVC_CODEC_KEY
-                    val audioQualityPreference = appContext?.let { 
-                        com.android.purebilibili.core.store.SettingsManager.getAudioQualitySync(it) 
+                    val audioQualityPreference = appContext?.let { context ->
+                        resolveRequestedAudioQuality(
+                            defaultAudioQuality = com.android.purebilibili.core.store.SettingsManager
+                                .getDefaultAudioQualitySync(context),
+                            rememberedAudioQuality = com.android.purebilibili.core.store.SettingsManager
+                                .getAudioQualitySync(context)
+                        )
                     } ?: -1
                     
                     val isHevcSupported = com.android.purebilibili.core.util.MediaUtils.isHevcSupported()
@@ -6884,6 +6954,11 @@ class VideoPlaybackViewModel : ViewModel() {
                             switchableQualityIds = selection.switchableQualityIds,
                             cachedDashVideos = selection.cachedDashVideos,
                             cachedDashAudios = selection.cachedDashAudios,
+                            cachedDash = selection.cachedDash,
+                            requestedAudioQuality = selection.requestedAudioQuality,
+                            selectedAudioQuality = selection.selectedAudioQuality,
+                            availableAudioQualities = selection.availableAudioQualities,
+                            audioFallbackReason = selection.audioFallbackReason,
                             currentCdnIndex = 0,
                             allVideoUrls = cdnSelection.allVideoUrls,
                             allAudioUrls = cdnSelection.allAudioUrls,
@@ -7023,9 +7098,7 @@ class VideoPlaybackViewModel : ViewModel() {
             val videoSecondCodecPreference = appContext?.let {
                 com.android.purebilibili.core.store.SettingsManager.getVideoSecondCodecSync(it)
             } ?: AVC_CODEC_KEY
-            val audioQualityPreference = appContext?.let {
-                com.android.purebilibili.core.store.SettingsManager.getAudioQualitySync(it)
-            } ?: -1
+            val audioQualityPreference = current.requestedAudioQuality
 
             val isHevcSupported = com.android.purebilibili.core.util.MediaUtils.isHevcSupported()
             val isAv1Supported = resolveEffectiveAv1Support(
@@ -7074,6 +7147,11 @@ class VideoPlaybackViewModel : ViewModel() {
                 switchableQualityIds = selection.switchableQualityIds,
                 cachedDashVideos = selection.cachedDashVideos,
                 cachedDashAudios = selection.cachedDashAudios,
+                cachedDash = selection.cachedDash,
+                requestedAudioQuality = selection.requestedAudioQuality,
+                selectedAudioQuality = selection.selectedAudioQuality,
+                availableAudioQualities = selection.availableAudioQualities,
+                audioFallbackReason = selection.audioFallbackReason,
                 currentCdnIndex = 0,
                 allVideoUrls = cdnSelection.allVideoUrls,
                 allAudioUrls = cdnSelection.allAudioUrls,
@@ -7491,6 +7569,11 @@ class VideoPlaybackViewModel : ViewModel() {
         val adaptiveDashSource: AdaptiveDashPlaybackSource?,
         val cachedDashVideos: List<DashVideo>,
         val cachedDashAudios: List<DashAudio>,
+        val cachedDash: Dash? = null,
+        val requestedAudioQuality: Int = -1,
+        val selectedAudioQuality: Int = -1,
+        val availableAudioQualities: List<AudioQualityOption> = emptyList(),
+        val audioFallbackReason: AudioFallbackReason? = null,
         val qualityIds: List<Int>,
         val qualityLabels: List<String>,
         val switchableQualityIds: List<Int>,
@@ -7976,6 +8059,12 @@ class VideoPlaybackViewModel : ViewModel() {
                 .ifEmpty { current.switchableQualityIds },
             cachedDashVideos = payload.cachedDashVideos,
             cachedDashAudios = payload.cachedDashAudios,
+            cachedDash = payload.cachedDash ?: current.cachedDash,
+            requestedAudioQuality = payload.requestedAudioQuality,
+            selectedAudioQuality = payload.selectedAudioQuality,
+            availableAudioQualities = payload.availableAudioQualities
+                .ifEmpty { current.availableAudioQualities },
+            audioFallbackReason = payload.audioFallbackReason,
             currentCdnIndex = 0,
             allVideoUrls = cdnSelection.allVideoUrls,
             allAudioUrls = cdnSelection.allAudioUrls,

--- a/app/src/test/java/com/android/purebilibili/core/player/HiResCompatibleRenderersFactoryTest.kt
+++ b/app/src/test/java/com/android/purebilibili/core/player/HiResCompatibleRenderersFactoryTest.kt
@@ -1,0 +1,43 @@
+package com.android.purebilibili.core.player
+
+import androidx.media3.common.MimeTypes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HiResCompatibleRenderersFactoryTest {
+
+    @Test
+    fun `FLAC codec input buffer is raised above undersized platform default`() {
+        assertEquals(
+            HI_RES_FLAC_MIN_CODEC_INPUT_SIZE_BYTES,
+            resolveHiResCodecMaxInputSize(
+                defaultMaxInputSize = 32 * 1024,
+                sampleMimeTypes = listOf(MimeTypes.AUDIO_FLAC)
+            )
+        )
+    }
+
+    @Test
+    fun `larger FLAC codec input buffer is preserved`() {
+        val existingSize = HI_RES_FLAC_MIN_CODEC_INPUT_SIZE_BYTES * 2
+
+        assertEquals(
+            existingSize,
+            resolveHiResCodecMaxInputSize(
+                defaultMaxInputSize = existingSize,
+                sampleMimeTypes = listOf(MimeTypes.AUDIO_FLAC)
+            )
+        )
+    }
+
+    @Test
+    fun `AAC codec input buffer remains unchanged`() {
+        assertEquals(
+            32 * 1024,
+            resolveHiResCodecMaxInputSize(
+                defaultMaxInputSize = 32 * 1024,
+                sampleMimeTypes = listOf(MimeTypes.AUDIO_AAC)
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/android/purebilibili/feature/audio/screen/MusicPlayerContentStructureTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/audio/screen/MusicPlayerContentStructureTest.kt
@@ -41,14 +41,14 @@ class MusicPlayerContentStructureTest {
     }
 
     @Test
-    fun `player uses three mode liquid dock and moves secondary actions to sheet`() {
+    fun `player uses four mode liquid dock and moves secondary actions to sheet`() {
         val source = loadSource()
         val playerPage = source
             .substringAfter("private fun PlayerPage(")
             .substringBefore("private fun MusicArtwork(")
 
         assertTrue(playerPage.contains("MusicPlayModeDock("))
-        assertTrue(source.contains("listOf(\"顺序播放\", \"随机播放\", \"单曲循环\")"))
+        assertTrue(source.contains("listOf(\"顺序播放\", \"随机播放\", \"单曲循环\", \"列表循环\")"))
         assertTrue(source.contains("showActions"))
         assertTrue(source.contains("播放器操作"))
         assertTrue(source.contains("onCollectionClick"))

--- a/app/src/test/java/com/android/purebilibili/feature/settings/PlaybackSettingsSelectionPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/settings/PlaybackSettingsSelectionPolicyTest.kt
@@ -18,13 +18,23 @@ class PlaybackSettingsSelectionPolicyTest {
         assertEquals(
             listOf(
                 DEFAULT_AUDIO_QUALITY_FOLLOW_LAST,
-                -1,
-                30280,
+                30251,
                 30250,
-                30251
+                -1
             ),
             resolveDefaultAudioQualityOptions().map { it.value }
         )
+        assertEquals(
+            listOf("跟随上次", "Hi-Res 无损", "杜比全景声", "高品质 AAC"),
+            resolveDefaultAudioQualityOptions().map { it.label }
+        )
+    }
+
+    @Test
+    fun `legacy concrete AAC preference is normalized to high quality AAC`() {
+        assertEquals(-1, normalizeDefaultAudioQualityOption(30280))
+        assertEquals(-1, normalizeDefaultAudioQualityOption(30232))
+        assertEquals(-1, normalizeDefaultAudioQualityOption(30216))
     }
 
     @Test

--- a/app/src/test/java/com/android/purebilibili/feature/settings/PlaybackSettingsSelectionPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/settings/PlaybackSettingsSelectionPolicyTest.kt
@@ -25,7 +25,7 @@ class PlaybackSettingsSelectionPolicyTest {
             resolveDefaultAudioQualityOptions().map { it.value }
         )
         assertEquals(
-            listOf("跟随上次", "Hi-Res 无损", "杜比全景声", "高品质 AAC"),
+            listOf("跟随上次", "Hi-Res 无损", "杜比全景声", "AAC"),
             resolveDefaultAudioQualityOptions().map { it.label }
         )
     }

--- a/app/src/test/java/com/android/purebilibili/feature/settings/PlaybackSettingsSelectionPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/settings/PlaybackSettingsSelectionPolicyTest.kt
@@ -414,6 +414,8 @@ class PlaybackSettingsSelectionPolicyTest {
             File(path.removePrefix("app/")),
             File("..", path)
         )
-        return candidates.first { it.exists() }.readText()
+        return candidates.first { it.exists() }
+            .readText()
+            .replace("\r\n", "\n")
     }
 }

--- a/app/src/test/java/com/android/purebilibili/feature/settings/PlaybackSettingsSelectionPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/settings/PlaybackSettingsSelectionPolicyTest.kt
@@ -2,6 +2,7 @@ package com.android.purebilibili.feature.settings
 
 import com.android.purebilibili.core.store.FullscreenAspectRatio
 import com.android.purebilibili.core.store.FullscreenMode
+import com.android.purebilibili.core.store.DEFAULT_AUDIO_QUALITY_FOLLOW_LAST
 import com.android.purebilibili.core.store.PortraitPlayerCollapseMode
 import com.android.purebilibili.core.theme.UiPreset
 import java.io.File
@@ -11,6 +12,20 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class PlaybackSettingsSelectionPolicyTest {
+
+    @Test
+    fun `default audio quality options expose follow last and supported preferences`() {
+        assertEquals(
+            listOf(
+                DEFAULT_AUDIO_QUALITY_FOLLOW_LAST,
+                -1,
+                30280,
+                30250,
+                30251
+            ),
+            resolveDefaultAudioQualityOptions().map { it.value }
+        )
+    }
 
     @Test
     fun `playback interaction and fullscreen blocks should be split into scene composables`() {

--- a/app/src/test/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicyTest.kt
@@ -130,6 +130,22 @@ class AudioStreamSelectionPolicyTest {
 
         assertEquals(listOf(AUDIO_QUALITY_AUTO, 30280), options.map { it.preferenceId })
         assertTrue(options.none { it.isHiRes })
+        assertTrue(options.none { it.isDolby })
+    }
+
+    @Test
+    fun `premium options expose matching audio badges`() {
+        val options = buildAvailableAudioQualityOptions(
+            collectAudioStreamCandidates(fullDash())
+        )
+
+        val hiResOption = options.first { it.preferenceId == AUDIO_QUALITY_HI_RES }
+        val dolbyOption = options.first { it.preferenceId == AUDIO_QUALITY_DOLBY }
+
+        assertTrue(hiResOption.isHiRes)
+        assertTrue(!hiResOption.isDolby)
+        assertTrue(dolbyOption.isDolby)
+        assertTrue(!dolbyOption.isHiRes)
     }
 
     private fun fullDash(): Dash {

--- a/app/src/test/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicyTest.kt
@@ -1,0 +1,142 @@
+package com.android.purebilibili.feature.video.playback.audio
+
+import com.android.purebilibili.data.model.response.Dash
+import com.android.purebilibili.data.model.response.DashAudio
+import com.android.purebilibili.data.model.response.Dolby
+import com.android.purebilibili.data.model.response.Flac
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AudioStreamSelectionPolicyTest {
+
+    private val standard192 = DashAudio(
+        id = 30280,
+        baseUrl = "https://example.com/audio-192.m4s",
+        bandwidth = 192_000
+    )
+    private val standard64 = DashAudio(
+        id = 30216,
+        baseUrl = "https://example.com/audio-64.m4s",
+        bandwidth = 64_000
+    )
+    private val dolby = DashAudio(
+        id = AUDIO_QUALITY_DOLBY,
+        baseUrl = "https://example.com/audio-dolby.m4s",
+        bandwidth = 448_000
+    )
+    private val hiRes = DashAudio(
+        id = AUDIO_QUALITY_HI_RES,
+        baseUrl = "https://example.com/audio-hires.m4s",
+        bandwidth = 1_800_000,
+        mimeType = "audio/mp4",
+        codecs = "fLaC"
+    )
+
+    @Test
+    fun `collect candidates includes standard dolby and hi res streams`() {
+        val candidates = collectAudioStreamCandidates(fullDash())
+
+        assertEquals(
+            listOf(AudioStreamKind.HI_RES, AudioStreamKind.DOLBY, AudioStreamKind.STANDARD, AudioStreamKind.STANDARD),
+            candidates.map { it.kind }
+        )
+        assertEquals(
+            listOf(AUDIO_QUALITY_HI_RES, AUDIO_QUALITY_DOLBY, 30280, 30216),
+            candidates.map { it.preferenceId }
+        )
+    }
+
+    @Test
+    fun `auto selects best standard audio without enabling premium audio`() {
+        val decision = resolveAudioStreamSelection(
+            dash = fullDash(),
+            requestedAudioQuality = AUDIO_QUALITY_AUTO
+        )
+
+        assertEquals(30280, decision.selectedPreferenceId)
+        assertEquals(AudioStreamKind.STANDARD, decision.selected?.kind)
+        assertNull(decision.fallbackReason)
+    }
+
+    @Test
+    fun `explicit hi res selection returns flac candidate`() {
+        val decision = resolveAudioStreamSelection(
+            dash = fullDash(),
+            requestedAudioQuality = AUDIO_QUALITY_HI_RES
+        )
+
+        assertEquals(AUDIO_QUALITY_HI_RES, decision.selectedPreferenceId)
+        assertEquals("https://example.com/audio-hires.m4s", decision.selected?.track?.getValidUrl())
+        assertNull(decision.fallbackReason)
+    }
+
+    @Test
+    fun `missing hi res falls back to best standard without changing request`() {
+        val decision = resolveAudioStreamSelection(
+            dash = Dash(audio = listOf(standard64, standard192)),
+            requestedAudioQuality = AUDIO_QUALITY_HI_RES
+        )
+
+        assertEquals(AUDIO_QUALITY_HI_RES, decision.requestedPreferenceId)
+        assertEquals(30280, decision.selectedPreferenceId)
+        assertEquals(AudioFallbackReason.REQUESTED_UNAVAILABLE, decision.fallbackReason)
+    }
+
+    @Test
+    fun `high speed temporarily falls back from hi res to standard`() {
+        val decision = resolveAudioStreamSelection(
+            dash = fullDash(),
+            requestedAudioQuality = AUDIO_QUALITY_HI_RES,
+            playbackSpeed = 2.0f
+        )
+
+        assertEquals(AUDIO_QUALITY_HI_RES, decision.requestedPreferenceId)
+        assertEquals(AUDIO_QUALITY_AUTO, decision.effectivePreferenceId)
+        assertEquals(30280, decision.selectedPreferenceId)
+        assertEquals(AudioFallbackReason.SPEED_INCOMPATIBLE, decision.fallbackReason)
+    }
+
+    @Test
+    fun `concrete default overrides remembered manual selection`() {
+        assertEquals(
+            30280,
+            resolveRequestedAudioQuality(
+                defaultAudioQuality = 30280,
+                rememberedAudioQuality = AUDIO_QUALITY_HI_RES
+            )
+        )
+    }
+
+    @Test
+    fun `follow last default uses remembered manual selection`() {
+        assertEquals(
+            AUDIO_QUALITY_HI_RES,
+            resolveRequestedAudioQuality(
+                defaultAudioQuality = AUDIO_QUALITY_FOLLOW_LAST_SELECTED,
+                rememberedAudioQuality = AUDIO_QUALITY_HI_RES
+            )
+        )
+    }
+
+    @Test
+    fun `available options only expose tracks returned by current response`() {
+        val options = buildAvailableAudioQualityOptions(
+            collectAudioStreamCandidates(
+                Dash(audio = listOf(standard192))
+            )
+        )
+
+        assertEquals(listOf(AUDIO_QUALITY_AUTO, 30280), options.map { it.preferenceId })
+        assertTrue(options.none { it.isHiRes })
+    }
+
+    private fun fullDash(): Dash {
+        return Dash(
+            audio = listOf(standard192, standard64),
+            dolby = Dolby(audio = listOf(dolby)),
+            flac = Flac(display = true, audio = hiRes)
+        )
+    }
+}

--- a/app/src/test/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicyTest.kt
@@ -243,6 +243,21 @@ class AudioStreamSelectionPolicyTest {
         assertEquals("AAC", presentation.label)
     }
 
+    @Test
+    fun `Hi Res control shows explicit text next to badge`() {
+        val options = buildAvailableAudioQualityOptions(
+            collectAudioStreamCandidates(fullDash())
+        )
+
+        val presentation = resolveAudioQualityControlPresentation(
+            options = options,
+            selectedAudioQuality = AUDIO_QUALITY_HI_RES
+        )
+
+        assertEquals("Hi-Res", presentation.label)
+        assertTrue(presentation.showHiResBadge)
+    }
+
     private fun fullDash(): Dash {
         return Dash(
             audio = listOf(standard192, standard64),

--- a/app/src/test/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicyTest.kt
@@ -24,7 +24,9 @@ class AudioStreamSelectionPolicyTest {
     private val dolby = DashAudio(
         id = AUDIO_QUALITY_DOLBY,
         baseUrl = "https://example.com/audio-dolby.m4s",
-        bandwidth = 448_000
+        bandwidth = 448_000,
+        mimeType = "audio/mp4",
+        codecs = "ec-3"
     )
     private val hiRes = DashAudio(
         id = AUDIO_QUALITY_HI_RES,
@@ -136,6 +138,51 @@ class AudioStreamSelectionPolicyTest {
     }
 
     @Test
+    fun `dolby container does not promote AAC track to dolby`() {
+        val aacInDolbyContainer = standard192.copy(
+            baseUrl = "https://example.com/audio-aac-in-dolby-container.m4s",
+            codecs = "mp4a.40.2"
+        )
+
+        val candidates = collectAudioStreamCandidates(
+            Dash(
+                audio = listOf(standard192),
+                dolby = Dolby(type = 1, audio = listOf(aacInDolbyContainer))
+            )
+        )
+
+        assertTrue(candidates.none { it.kind == AudioStreamKind.DOLBY })
+    }
+
+    @Test
+    fun `dolby track requires both dolby id and E AC 3 codec`() {
+        val dolbyIdWithAacCodec = dolby.copy(codecs = "mp4a.40.2")
+        val wrongIdWithDolbyCodec = dolby.copy(id = 30280)
+
+        val candidates = collectAudioStreamCandidates(
+            Dash(
+                dolby = Dolby(
+                    type = 1,
+                    audio = listOf(dolbyIdWithAacCodec, wrongIdWithDolbyCodec)
+                )
+            )
+        )
+
+        assertTrue(candidates.none { it.kind == AudioStreamKind.DOLBY })
+    }
+
+    @Test
+    fun `disabled dolby container does not expose dolby track`() {
+        val candidates = collectAudioStreamCandidates(
+            Dash(
+                dolby = Dolby(type = 0, audio = listOf(dolby))
+            )
+        )
+
+        assertTrue(candidates.none { it.kind == AudioStreamKind.DOLBY })
+    }
+
+    @Test
     fun `premium options expose matching audio badges`() {
         val options = buildAvailableAudioQualityOptions(
             collectAudioStreamCandidates(fullDash())
@@ -156,10 +203,36 @@ class AudioStreamSelectionPolicyTest {
         assertEquals(AudioStreamKind.STANDARD, aacOption.kind)
     }
 
+    @Test
+    fun `audio quality control keeps a visible fallback when options are empty`() {
+        val presentation = resolveAudioQualityControlPresentation(
+            options = emptyList(),
+            selectedAudioQuality = AUDIO_QUALITY_AUTO
+        )
+
+        assertEquals("音质", presentation.label)
+        assertTrue(!presentation.showHiResBadge)
+        assertTrue(!presentation.showDolbyBadge)
+    }
+
+    @Test
+    fun `single AAC option remains visible in audio quality control`() {
+        val options = buildAvailableAudioQualityOptions(
+            collectAudioStreamCandidates(Dash(audio = listOf(standard192)))
+        )
+
+        val presentation = resolveAudioQualityControlPresentation(
+            options = options,
+            selectedAudioQuality = AUDIO_QUALITY_AUTO
+        )
+
+        assertEquals("高品质 AAC", presentation.label)
+    }
+
     private fun fullDash(): Dash {
         return Dash(
             audio = listOf(standard192, standard64),
-            dolby = Dolby(audio = listOf(dolby)),
+            dolby = Dolby(type = 1, audio = listOf(dolby)),
             flac = Flac(display = true, audio = hiRes)
         )
     }

--- a/app/src/test/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicyTest.kt
@@ -55,8 +55,9 @@ class AudioStreamSelectionPolicyTest {
             requestedAudioQuality = AUDIO_QUALITY_AUTO
         )
 
-        assertEquals(30280, decision.selectedPreferenceId)
+        assertEquals(AUDIO_QUALITY_AUTO, decision.selectedPreferenceId)
         assertEquals(AudioStreamKind.STANDARD, decision.selected?.kind)
+        assertEquals(30280, decision.selected?.track?.id)
         assertNull(decision.fallbackReason)
     }
 
@@ -80,7 +81,7 @@ class AudioStreamSelectionPolicyTest {
         )
 
         assertEquals(AUDIO_QUALITY_HI_RES, decision.requestedPreferenceId)
-        assertEquals(30280, decision.selectedPreferenceId)
+        assertEquals(AUDIO_QUALITY_AUTO, decision.selectedPreferenceId)
         assertEquals(AudioFallbackReason.REQUESTED_UNAVAILABLE, decision.fallbackReason)
     }
 
@@ -94,14 +95,14 @@ class AudioStreamSelectionPolicyTest {
 
         assertEquals(AUDIO_QUALITY_HI_RES, decision.requestedPreferenceId)
         assertEquals(AUDIO_QUALITY_AUTO, decision.effectivePreferenceId)
-        assertEquals(30280, decision.selectedPreferenceId)
+        assertEquals(AUDIO_QUALITY_AUTO, decision.selectedPreferenceId)
         assertEquals(AudioFallbackReason.SPEED_INCOMPATIBLE, decision.fallbackReason)
     }
 
     @Test
-    fun `concrete default overrides remembered manual selection`() {
+    fun `legacy concrete AAC default maps to high quality AAC`() {
         assertEquals(
-            30280,
+            AUDIO_QUALITY_AUTO,
             resolveRequestedAudioQuality(
                 defaultAudioQuality = 30280,
                 rememberedAudioQuality = AUDIO_QUALITY_HI_RES
@@ -128,7 +129,8 @@ class AudioStreamSelectionPolicyTest {
             )
         )
 
-        assertEquals(listOf(AUDIO_QUALITY_AUTO, 30280), options.map { it.preferenceId })
+        assertEquals(listOf(AUDIO_QUALITY_AUTO), options.map { it.preferenceId })
+        assertEquals("高品质 AAC", options.single().label)
         assertTrue(options.none { it.isHiRes })
         assertTrue(options.none { it.isDolby })
     }
@@ -141,11 +143,17 @@ class AudioStreamSelectionPolicyTest {
 
         val hiResOption = options.first { it.preferenceId == AUDIO_QUALITY_HI_RES }
         val dolbyOption = options.first { it.preferenceId == AUDIO_QUALITY_DOLBY }
+        val aacOption = options.first { it.preferenceId == AUDIO_QUALITY_AUTO }
 
+        assertEquals(
+            listOf(AUDIO_QUALITY_HI_RES, AUDIO_QUALITY_DOLBY, AUDIO_QUALITY_AUTO),
+            options.map { it.preferenceId }
+        )
         assertTrue(hiResOption.isHiRes)
         assertTrue(!hiResOption.isDolby)
         assertTrue(dolbyOption.isDolby)
         assertTrue(!dolbyOption.isHiRes)
+        assertEquals(AudioStreamKind.STANDARD, aacOption.kind)
     }
 
     private fun fullDash(): Dash {

--- a/app/src/test/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/playback/audio/AudioStreamSelectionPolicyTest.kt
@@ -132,7 +132,7 @@ class AudioStreamSelectionPolicyTest {
         )
 
         assertEquals(listOf(AUDIO_QUALITY_AUTO), options.map { it.preferenceId })
-        assertEquals("高品质 AAC", options.single().label)
+        assertEquals("AAC", options.single().label)
         assertTrue(options.none { it.isHiRes })
         assertTrue(options.none { it.isDolby })
     }
@@ -183,6 +183,20 @@ class AudioStreamSelectionPolicyTest {
     }
 
     @Test
+    fun `unsupported dolby decoder hides dolby and falls back to AAC`() {
+        val decision = resolveAudioStreamSelection(
+            dash = fullDash(),
+            requestedAudioQuality = AUDIO_QUALITY_DOLBY,
+            isDolbyAudioSupported = false
+        )
+
+        assertEquals(AUDIO_QUALITY_AUTO, decision.selectedPreferenceId)
+        assertEquals(AudioStreamKind.STANDARD, decision.selected?.kind)
+        assertEquals(AudioFallbackReason.REQUESTED_UNAVAILABLE, decision.fallbackReason)
+        assertTrue(decision.availableOptions.none { it.isDolby })
+    }
+
+    @Test
     fun `premium options expose matching audio badges`() {
         val options = buildAvailableAudioQualityOptions(
             collectAudioStreamCandidates(fullDash())
@@ -226,7 +240,7 @@ class AudioStreamSelectionPolicyTest {
             selectedAudioQuality = AUDIO_QUALITY_AUTO
         )
 
-        assertEquals("高品质 AAC", presentation.label)
+        assertEquals("AAC", presentation.label)
     }
 
     private fun fullDash(): Dash {

--- a/app/src/test/java/com/android/purebilibili/feature/video/playback/audio/PremiumAudioPlaybackFailurePolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/playback/audio/PremiumAudioPlaybackFailurePolicyTest.kt
@@ -1,0 +1,45 @@
+package com.android.purebilibili.feature.video.playback.audio
+
+import androidx.media3.common.PlaybackException
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PremiumAudioPlaybackFailurePolicyTest {
+
+    @Test
+    fun `Hi Res runtime failure from audio renderer triggers AAC fallback`() {
+        assertTrue(
+            isPremiumAudioPlaybackFailure(
+                errorCode = PlaybackException.ERROR_CODE_FAILED_RUNTIME_CHECK,
+                selectedAudioQuality = AUDIO_QUALITY_HI_RES,
+                rendererName = "MediaCodecAudioRenderer",
+                rendererSampleMimeType = "audio/flac"
+            )
+        )
+    }
+
+    @Test
+    fun `video renderer runtime failure is not treated as Hi Res audio failure`() {
+        assertFalse(
+            isPremiumAudioPlaybackFailure(
+                errorCode = PlaybackException.ERROR_CODE_FAILED_RUNTIME_CHECK,
+                selectedAudioQuality = AUDIO_QUALITY_HI_RES,
+                rendererName = "MediaCodecVideoRenderer",
+                rendererSampleMimeType = "video/hevc"
+            )
+        )
+    }
+
+    @Test
+    fun `AAC failure does not trigger premium audio fallback`() {
+        assertFalse(
+            isPremiumAudioPlaybackFailure(
+                errorCode = PlaybackException.ERROR_CODE_FAILED_RUNTIME_CHECK,
+                selectedAudioQuality = AUDIO_QUALITY_AUTO,
+                rendererName = "MediaCodecAudioRenderer",
+                rendererSampleMimeType = "audio/mp4a-latm"
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/android/purebilibili/feature/video/playback/policy/AdaptiveDashTrackPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/playback/policy/AdaptiveDashTrackPolicyTest.kt
@@ -3,6 +3,10 @@ package com.android.purebilibili.feature.video.playback.policy
 import com.android.purebilibili.data.model.response.Dash
 import com.android.purebilibili.data.model.response.DashAudio
 import com.android.purebilibili.data.model.response.DashVideo
+import com.android.purebilibili.data.model.response.Dolby
+import com.android.purebilibili.data.model.response.Flac
+import com.android.purebilibili.feature.video.playback.audio.AUDIO_QUALITY_DOLBY
+import com.android.purebilibili.feature.video.playback.audio.AUDIO_QUALITY_HI_RES
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -120,5 +124,64 @@ class AdaptiveDashTrackPolicyTest {
         )
 
         assertEquals(false, shouldRefresh)
+    }
+
+    @Test
+    fun `explicit hi res keeps only flac representation`() {
+        val hiRes = DashAudio(
+            id = AUDIO_QUALITY_HI_RES,
+            baseUrl = "https://example.com/audio-hires.m4s",
+            codecs = "fLaC",
+            bandwidth = 1_800_000
+        )
+        val result = buildAdaptiveDashTrackSet(
+            dash = dash.copy(flac = Flac(display = true, audio = hiRes)),
+            mode = PlaybackQualityMode.AUTO,
+            autoQualityCap = 80,
+            preferredAudioQuality = AUDIO_QUALITY_HI_RES,
+            preferredVideoCodec = "hev1",
+            secondaryVideoCodec = "avc1",
+            isHevcSupported = true,
+            isAv1Supported = false
+        )
+
+        assertEquals(listOf("https://example.com/audio-hires.m4s"), result.audioTracks.map { it.getValidUrl() })
+    }
+
+    @Test
+    fun `explicit dolby keeps only dolby representation`() {
+        val dolby = DashAudio(
+            id = AUDIO_QUALITY_DOLBY,
+            baseUrl = "https://example.com/audio-dolby.m4s",
+            bandwidth = 448_000
+        )
+        val result = buildAdaptiveDashTrackSet(
+            dash = dash.copy(dolby = Dolby(audio = listOf(dolby))),
+            mode = PlaybackQualityMode.AUTO,
+            autoQualityCap = 80,
+            preferredAudioQuality = AUDIO_QUALITY_DOLBY,
+            preferredVideoCodec = "hev1",
+            secondaryVideoCodec = "avc1",
+            isHevcSupported = true,
+            isAv1Supported = false
+        )
+
+        assertEquals(listOf("https://example.com/audio-dolby.m4s"), result.audioTracks.map { it.getValidUrl() })
+    }
+
+    @Test
+    fun `explicit unavailable premium audio falls back to one best standard representation`() {
+        val result = buildAdaptiveDashTrackSet(
+            dash = dash,
+            mode = PlaybackQualityMode.AUTO,
+            autoQualityCap = 80,
+            preferredAudioQuality = AUDIO_QUALITY_HI_RES,
+            preferredVideoCodec = "hev1",
+            secondaryVideoCodec = "avc1",
+            isHevcSupported = true,
+            isAv1Supported = false
+        )
+
+        assertEquals(listOf(30280), result.audioTracks.map { it.id })
     }
 }

--- a/app/src/test/java/com/android/purebilibili/feature/video/playback/policy/AdaptiveDashTrackPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/playback/policy/AdaptiveDashTrackPolicyTest.kt
@@ -153,10 +153,11 @@ class AdaptiveDashTrackPolicyTest {
         val dolby = DashAudio(
             id = AUDIO_QUALITY_DOLBY,
             baseUrl = "https://example.com/audio-dolby.m4s",
-            bandwidth = 448_000
+            bandwidth = 448_000,
+            codecs = "ec-3"
         )
         val result = buildAdaptiveDashTrackSet(
-            dash = dash.copy(dolby = Dolby(audio = listOf(dolby))),
+            dash = dash.copy(dolby = Dolby(type = 1, audio = listOf(dolby))),
             mode = PlaybackQualityMode.AUTO,
             autoQualityCap = 80,
             preferredAudioQuality = AUDIO_QUALITY_DOLBY,
@@ -167,6 +168,29 @@ class AdaptiveDashTrackPolicyTest {
         )
 
         assertEquals(listOf("https://example.com/audio-dolby.m4s"), result.audioTracks.map { it.getValidUrl() })
+    }
+
+    @Test
+    fun `unsupported dolby decoder falls back to standard representation`() {
+        val dolby = DashAudio(
+            id = AUDIO_QUALITY_DOLBY,
+            baseUrl = "https://example.com/audio-dolby.m4s",
+            bandwidth = 448_000,
+            codecs = "ec-3"
+        )
+        val result = buildAdaptiveDashTrackSet(
+            dash = dash.copy(dolby = Dolby(type = 1, audio = listOf(dolby))),
+            mode = PlaybackQualityMode.AUTO,
+            autoQualityCap = 80,
+            preferredAudioQuality = AUDIO_QUALITY_DOLBY,
+            preferredVideoCodec = "hev1",
+            secondaryVideoCodec = "avc1",
+            isHevcSupported = true,
+            isAv1Supported = false,
+            isDolbyAudioSupported = false
+        )
+
+        assertEquals(listOf(30280), result.audioTracks.map { it.id })
     }
 
     @Test

--- a/app/src/test/java/com/android/purebilibili/feature/video/screen/AudioModeAudioQualityStructureTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/screen/AudioModeAudioQualityStructureTest.kt
@@ -1,0 +1,45 @@
+package com.android.purebilibili.feature.video.screen
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class AudioModeAudioQualityStructureTest {
+
+    @Test
+    fun `audio mode forwards current audio quality state and switch action`() {
+        val source = loadSource(
+            "src/main/java/com/android/purebilibili/feature/video/screen/AudioModeMusicPlayer.kt",
+            "app/src/main/java/com/android/purebilibili/feature/video/screen/AudioModeMusicPlayer.kt"
+        )
+
+        assertTrue(source.contains("resolveAudioQualityControlPresentation("))
+        assertTrue(source.contains("audioQualityOptions = successState.availableAudioQualities"))
+        assertTrue(source.contains("requestedAudioQuality = successState.requestedAudioQuality"))
+        assertTrue(source.contains("onAudioQualitySelected = viewModel::setAudioQuality"))
+    }
+
+    @Test
+    fun `music player page exposes direct audio quality control and shared menu`() {
+        val source = loadSource(
+            "src/main/java/com/android/purebilibili/feature/audio/screen/MusicPlayerContent.kt",
+            "app/src/main/java/com/android/purebilibili/feature/audio/screen/MusicPlayerContent.kt"
+        )
+
+        assertTrue(source.contains("MusicAudioQualityControl("))
+        assertTrue(source.contains(".heightIn(min = 48.dp)"))
+        assertTrue(source.contains("HiResBadge()"))
+        assertTrue(source.contains("DolbyBadge()"))
+        assertTrue(source.contains("AudioQualitySelectionMenu("))
+        assertTrue(source.contains("options = audioQualityOptions"))
+        assertTrue(source.contains("requestedAudioQuality = requestedAudioQuality"))
+        assertTrue(source.contains("onAudioQualitySelected(quality)"))
+        assertTrue(source.contains("showAudioQuality = false"))
+    }
+
+    private fun loadSource(vararg paths: String): String {
+        val sourceFile = paths.map(::File).firstOrNull { it.exists() }
+            ?: error("Cannot locate source from ${File(".").absolutePath}")
+        return sourceFile.readText()
+    }
+}

--- a/app/src/test/java/com/android/purebilibili/feature/video/state/PlayerErrorRecoveryPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/state/PlayerErrorRecoveryPolicyTest.kt
@@ -52,6 +52,22 @@ class PlayerErrorRecoveryPolicyTest {
     }
 
     @Test
+    fun premiumAudioFailureBypassesGenericRetryLoop() {
+        val action = decidePlayerErrorRecovery(
+            errorCode = PlaybackException.ERROR_CODE_FAILED_RUNTIME_CHECK,
+            hasCdnAlternatives = true,
+            retryCount = 0,
+            maxRetries = 3,
+            cdnSwitchCount = 0,
+            maxCdnSwitches = 2,
+            isDecoderLikeFailure = false,
+            isPremiumAudioFailure = true
+        )
+
+        assertEquals(PlayerErrorRecoveryAction.FALLBACK_PREMIUM_AUDIO, action)
+    }
+
+    @Test
     fun decoderLikeFailureAllowsSecondaryThenAvcFallback() {
         val secondFallback = decidePlayerErrorRecovery(
             errorCode = PlaybackException.ERROR_CODE_FAILED_RUNTIME_CHECK,

--- a/app/src/test/java/com/android/purebilibili/feature/video/ui/components/AudioQualityVisibilityStructureTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/ui/components/AudioQualityVisibilityStructureTest.kt
@@ -42,6 +42,22 @@ class AudioQualityVisibilityStructureTest {
         assertTrue(source.contains("text = \"音频音质\""))
     }
 
+    @Test
+    fun `portrait video player opens audio quality menu in a full screen dialog`() {
+        val overlaySource = loadSource(
+            "src/main/java/com/android/purebilibili/feature/video/ui/overlay/VideoPlayerOverlay.kt"
+        )
+        val menuSource = loadSource(
+            "src/main/java/com/android/purebilibili/feature/video/ui/components/AudioQualitySelectionMenu.kt"
+        )
+        val audioMenuHost = overlaySource
+            .substringAfter("if (showAudioQualityMenu)")
+            .substringBefore("// --- 7.")
+
+        assertTrue(audioMenuHost.contains("AudioQualitySelectionMenuDialog("))
+        assertTrue(menuSource.contains("DialogProperties(usePlatformDefaultWidth = false)"))
+    }
+
     private fun loadSource(relativePath: String): String {
         val moduleRelative = File(relativePath)
         val repositoryRelative = File("app/$relativePath")

--- a/app/src/test/java/com/android/purebilibili/feature/video/ui/components/AudioQualityVisibilityStructureTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/ui/components/AudioQualityVisibilityStructureTest.kt
@@ -1,0 +1,52 @@
+package com.android.purebilibili.feature.video.ui.components
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AudioQualityVisibilityStructureTest {
+
+    @Test
+    fun `landscape audio quality control is not gated by available option count`() {
+        val source = loadSource(
+            "src/main/java/com/android/purebilibili/feature/video/ui/overlay/VideoPlayerOverlay.kt"
+        )
+        val controlBarSource = loadSource(
+            "src/main/java/com/android/purebilibili/feature/video/ui/overlay/BottomControlBar.kt"
+        )
+
+        assertFalse(source.contains("availableAudioQualities.count { option ->"))
+        assertTrue(source.contains("resolveAudioQualityControlPresentation("))
+        assertFalse(controlBarSource.contains("if (currentAudioQualityLabel.isNotEmpty())"))
+        assertTrue(controlBarSource.contains("currentAudioQualityLabel.ifBlank { \"音质\" }"))
+    }
+
+    @Test
+    fun `portrait audio quality control is always rendered`() {
+        val source = loadSource(
+            "src/main/java/com/android/purebilibili/feature/video/ui/overlay/PortraitFullscreenOverlay.kt"
+        )
+
+        assertFalse(source.contains("showAudioQualityChip"))
+        assertTrue(source.contains("label = currentAudioQualityLabel"))
+    }
+
+    @Test
+    fun `advanced settings always contains audio quality section`() {
+        val source = loadSource(
+            "src/main/java/com/android/purebilibili/feature/video/ui/components/VideoSettingsPanel.kt"
+        )
+
+        assertFalse(source.contains("availableAudioQualities.count { it.preferenceId != -1 }"))
+        assertTrue(source.contains("text = \"音频音质\""))
+    }
+
+    private fun loadSource(relativePath: String): String {
+        val moduleRelative = File(relativePath)
+        val repositoryRelative = File("app/$relativePath")
+        return listOf(moduleRelative, repositoryRelative)
+            .first { it.exists() }
+            .readText()
+    }
+}

--- a/app/src/test/java/com/android/purebilibili/feature/video/ui/pager/PortraitVideoLoadPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/ui/pager/PortraitVideoLoadPolicyTest.kt
@@ -4,6 +4,7 @@ import com.android.purebilibili.data.model.response.Dash
 import com.android.purebilibili.data.model.response.DashAudio
 import com.android.purebilibili.data.model.response.DashVideo
 import com.android.purebilibili.data.model.response.Durl
+import com.android.purebilibili.data.model.response.Flac
 import com.android.purebilibili.data.model.response.Owner
 import com.android.purebilibili.data.model.response.PlayUrlData
 import com.android.purebilibili.data.model.response.RelatedVideo
@@ -225,6 +226,43 @@ class PortraitVideoLoadPolicyTest {
         )
 
         assertEquals("https://cdn.example/80.m4s", urls?.videoUrl)
+    }
+
+    @Test
+    fun playbackStreamUrls_selectsRequestedHiResTrack() {
+        val playData = PlayUrlData(
+            dash = Dash(
+                video = listOf(
+                    DashVideo(
+                        id = 80,
+                        baseUrl = "https://cdn.example/video.m4s",
+                        codecs = "avc1.64001E"
+                    )
+                ),
+                audio = listOf(
+                    DashAudio(
+                        id = 30232,
+                        baseUrl = "https://cdn.example/standard.m4s"
+                    )
+                ),
+                flac = Flac(
+                    display = true,
+                    audio = DashAudio(
+                        id = 30251,
+                        baseUrl = "https://cdn.example/hires.m4s"
+                    )
+                )
+            )
+        )
+
+        val urls = resolvePortraitPlaybackStreamUrls(
+            playData = playData,
+            requestedAudioQuality = 30251
+        )
+
+        assertEquals("https://cdn.example/hires.m4s", urls?.audioUrl)
+        assertEquals(30251, urls?.audioSelection?.selectedPreferenceId)
+        assertTrue(urls?.audioSelection?.availableOptions?.any { it.isHiRes } == true)
     }
 
     @Test

--- a/app/src/test/java/com/android/purebilibili/feature/video/usecase/VideoPlaybackUseCaseQualitySwitchTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/usecase/VideoPlaybackUseCaseQualitySwitchTest.kt
@@ -6,6 +6,7 @@ import com.android.purebilibili.data.model.response.Dash
 import com.android.purebilibili.data.model.response.Durl
 import com.android.purebilibili.data.model.response.Flac
 import com.android.purebilibili.data.model.response.PlayUrlData
+import com.android.purebilibili.feature.video.playback.audio.AUDIO_QUALITY_AUTO
 import com.android.purebilibili.feature.video.playback.audio.AUDIO_QUALITY_HI_RES
 import com.android.purebilibili.feature.video.playback.audio.AudioFallbackReason
 import com.android.purebilibili.feature.video.playback.policy.PlaybackQualityMode
@@ -422,7 +423,7 @@ class VideoPlaybackUseCaseQualitySwitchTest {
         assertEquals("https://example.com/audio-192.m4s", result?.audioUrl)
         assertEquals(listOf(30280, 30216), result?.adaptiveDashSource?.audioTracks?.map { it.id })
         assertEquals(AUDIO_QUALITY_HI_RES, result?.requestedAudioQuality)
-        assertEquals(30280, result?.selectedAudioQuality)
+        assertEquals(AUDIO_QUALITY_AUTO, result?.selectedAudioQuality)
         assertEquals(AudioFallbackReason.SPEED_INCOMPATIBLE, result?.audioFallbackReason)
     }
 
@@ -462,7 +463,7 @@ class VideoPlaybackUseCaseQualitySwitchTest {
         assertEquals(listOf(AUDIO_QUALITY_HI_RES), result?.adaptiveDashSource?.audioTracks?.map { it.id })
         assertEquals(AUDIO_QUALITY_HI_RES, result?.selectedAudioQuality)
         assertEquals(
-            listOf(-1, AUDIO_QUALITY_HI_RES, 30280),
+            listOf(AUDIO_QUALITY_HI_RES, AUDIO_QUALITY_AUTO),
             result?.availableAudioQualities?.map { it.preferenceId }
         )
         assertEquals(hiResAudio, result?.cachedDash?.flac?.audio)

--- a/app/src/test/java/com/android/purebilibili/feature/video/usecase/VideoPlaybackUseCaseQualitySwitchTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/usecase/VideoPlaybackUseCaseQualitySwitchTest.kt
@@ -4,7 +4,10 @@ import com.android.purebilibili.data.model.response.DashAudio
 import com.android.purebilibili.data.model.response.DashVideo
 import com.android.purebilibili.data.model.response.Dash
 import com.android.purebilibili.data.model.response.Durl
+import com.android.purebilibili.data.model.response.Flac
 import com.android.purebilibili.data.model.response.PlayUrlData
+import com.android.purebilibili.feature.video.playback.audio.AUDIO_QUALITY_HI_RES
+import com.android.purebilibili.feature.video.playback.audio.AudioFallbackReason
 import com.android.purebilibili.feature.video.playback.policy.PlaybackQualityMode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -418,6 +421,51 @@ class VideoPlaybackUseCaseQualitySwitchTest {
 
         assertEquals("https://example.com/audio-192.m4s", result?.audioUrl)
         assertEquals(listOf(30280, 30216), result?.adaptiveDashSource?.audioTracks?.map { it.id })
+        assertEquals(AUDIO_QUALITY_HI_RES, result?.requestedAudioQuality)
+        assertEquals(30280, result?.selectedAudioQuality)
+        assertEquals(AudioFallbackReason.SPEED_INCOMPATIBLE, result?.audioFallbackReason)
+    }
+
+    @Test
+    fun `resolvePlaybackSelection selects flac and exposes real audio options`() {
+        val useCase = VideoPlaybackUseCase()
+        val hiResAudio = DashAudio(
+            id = AUDIO_QUALITY_HI_RES,
+            baseUrl = "https://example.com/audio-hires.m4s",
+            bandwidth = 1_800_000,
+            codecs = "fLaC"
+        )
+
+        val result = useCase.resolvePlaybackSelection(
+            playUrlData = PlayUrlData(
+                quality = 80,
+                acceptQuality = listOf(80),
+                dash = Dash(
+                    video = listOf(
+                        DashVideo(id = 80, baseUrl = "https://example.com/1080-hevc.m4s", codecs = "hev1")
+                    ),
+                    audio = listOf(
+                        DashAudio(id = 30280, baseUrl = "https://example.com/audio-192.m4s", bandwidth = 192_000)
+                    ),
+                    flac = Flac(display = true, audio = hiResAudio)
+                )
+            ),
+            targetQuality = 80,
+            audioQualityPreference = AUDIO_QUALITY_HI_RES,
+            videoCodecPreference = "hev1",
+            videoSecondCodecPreference = "avc1",
+            isHevcSupported = true,
+            isAv1Supported = false
+        )
+
+        assertEquals("https://example.com/audio-hires.m4s", result?.audioUrl)
+        assertEquals(listOf(AUDIO_QUALITY_HI_RES), result?.adaptiveDashSource?.audioTracks?.map { it.id })
+        assertEquals(AUDIO_QUALITY_HI_RES, result?.selectedAudioQuality)
+        assertEquals(
+            listOf(-1, AUDIO_QUALITY_HI_RES, 30280),
+            result?.availableAudioQualities?.map { it.preferenceId }
+        )
+        assertEquals(hiResAudio, result?.cachedDash?.flac?.audio)
     }
 
     @Test

--- a/app/src/test/java/com/android/purebilibili/feature/video/usecase/VideoPlaybackUseCaseQualitySwitchTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/usecase/VideoPlaybackUseCaseQualitySwitchTest.kt
@@ -4,9 +4,11 @@ import com.android.purebilibili.data.model.response.DashAudio
 import com.android.purebilibili.data.model.response.DashVideo
 import com.android.purebilibili.data.model.response.Dash
 import com.android.purebilibili.data.model.response.Durl
+import com.android.purebilibili.data.model.response.Dolby
 import com.android.purebilibili.data.model.response.Flac
 import com.android.purebilibili.data.model.response.PlayUrlData
 import com.android.purebilibili.feature.video.playback.audio.AUDIO_QUALITY_AUTO
+import com.android.purebilibili.feature.video.playback.audio.AUDIO_QUALITY_DOLBY
 import com.android.purebilibili.feature.video.playback.audio.AUDIO_QUALITY_HI_RES
 import com.android.purebilibili.feature.video.playback.audio.AudioFallbackReason
 import com.android.purebilibili.feature.video.playback.policy.PlaybackQualityMode
@@ -467,6 +469,54 @@ class VideoPlaybackUseCaseQualitySwitchTest {
             result?.availableAudioQualities?.map { it.preferenceId }
         )
         assertEquals(hiResAudio, result?.cachedDash?.flac?.audio)
+    }
+
+    @Test
+    fun `resolvePlaybackSelection excludes dolby when device decoder is unavailable`() {
+        val useCase = VideoPlaybackUseCase()
+        val standardAudio = DashAudio(
+            id = 30280,
+            baseUrl = "https://example.com/audio-aac.m4s",
+            bandwidth = 192_000,
+            codecs = "mp4a.40.2"
+        )
+        val dolbyAudio = DashAudio(
+            id = AUDIO_QUALITY_DOLBY,
+            baseUrl = "https://example.com/audio-dolby.m4s",
+            bandwidth = 448_000,
+            codecs = "ec-3"
+        )
+
+        val result = useCase.resolvePlaybackSelection(
+            playUrlData = PlayUrlData(
+                quality = 80,
+                acceptQuality = listOf(80),
+                dash = Dash(
+                    video = listOf(
+                        DashVideo(
+                            id = 80,
+                            baseUrl = "https://example.com/1080-hevc.m4s",
+                            codecs = "hev1"
+                        )
+                    ),
+                    audio = listOf(standardAudio),
+                    dolby = Dolby(type = 1, audio = listOf(dolbyAudio))
+                )
+            ),
+            targetQuality = 80,
+            audioQualityPreference = AUDIO_QUALITY_DOLBY,
+            videoCodecPreference = "hev1",
+            videoSecondCodecPreference = "avc1",
+            isHevcSupported = true,
+            isAv1Supported = false,
+            isDolbyAudioSupported = false
+        )
+
+        assertEquals(standardAudio.getValidUrl(), result?.audioUrl)
+        assertEquals(listOf(30280), result?.adaptiveDashSource?.audioTracks?.map { it.id })
+        assertEquals(AUDIO_QUALITY_AUTO, result?.selectedAudioQuality)
+        assertEquals(AudioFallbackReason.REQUESTED_UNAVAILABLE, result?.audioFallbackReason)
+        assertTrue(result?.availableAudioQualities?.none { it.preferenceId == AUDIO_QUALITY_DOLBY } == true)
     }
 
     @Test


### PR DESCRIPTION
# feat(player): 增加 Hi-Res、杜比全景声与 AAC 音质选择

## 修改内容

### 统一音频流选择策略

- 将用户可见音质归并为三类：
  - `Hi-Res 无损`，with帅气小金标💗
  - `杜比全景声`
  - `AAC`
- AAC 内部自动选择当前响应中码率最高的标准音轨。
- 可选项只来自当前播放响应中真实存在且 URL 有效的音轨。
- 将“用户请求的音质”和“当前实际播放的音轨”分开保存，发生回退时不会覆盖用户长期偏好。
- 自适应 DASH 本地 MPD 会按选择写入 Hi-Res、Dolby 或标准 AAC 音轨；高级音质只保留对应单轨，AAC 模式保留标准音轨集合供播放器自适应选择。

### 播放器入口

- 在现有画质入口左侧增加音质入口。
- 普通视频、番剧、竖屏视频和高级播放设置均接入音质选择。
- “听视频”的纯音乐播放页在歌曲信息下方增加音质入口，显示 `AAC`、`Hi-Res` 或 `Dolby`，高级音质保留对应小型标签。
- 音质入口始终显示；音轨信息尚未加载时显示“音质”占位。
- 切换音轨时保留当前播放进度和播放/暂停状态。

### 长期记忆与默认音质

- 播放设置新增“默认音质”：
  - `跟随上次`
  - `Hi-Res 无损`
  - `杜比全景声`
  - `AAC`
- 默认使用“跟随上次”。
- 选择具体默认音质后，新视频优先采用默认设置；播放器中的手动选择仍可临时覆盖当前视频，但不会改写具体默认设置。
- 默认音质纳入设置导入、导出和搜索范围。

### 倍速兼容回退

- 播放速度超过 `1.5x` 时，Hi-Res 和 Dolby 临时回退到 AAC。
- 回到兼容倍速后重新应用用户请求的高级音质。
- 临时回退只改变实际播放音轨，不覆盖长期记忆。

### Dolby 识别与设备能力保护

- Dolby 候选必须同时满足：
  - 接口标记 Dolby 容器已启用；
  - 音轨 ID 为 `30250`；
  - 编码为 E-AC-3；
  - URL 有效。
- 普通 AAC 即使出现在 Dolby 容器中，也不会被误报为“杜比全景声”。
- 播放前检查设备是否提供 `audio/eac3` 或 `audio/eac3-joc` 解码器。
- 设备不支持 Dolby 解码时：
  - 当前视频的音质菜单不展示 Dolby；
  - 已保存的 Dolby 偏好安全回退到 AAC；
  - 本地 DASH MPD 不写入无法解码的 Dolby 音轨。

默认音质设置保留 Dolby 选项，实际播放选项以当前设备能力和当前视频返回的音轨为准。

### Hi-Res 播放兼容

- “听视频”当前使用 Hi-Res 音轨时显示 `Hi-Res` 文案和小型 Hi-Res 标签。
- 普通视频、番剧、竖屏视频和迷你播放器统一使用 Hi-Res 兼容音频渲染器。
- FLAC 音轨的 codec 输入缓冲区下限设置为 1 MiB。
- Hi-Res 音频解码失败时，当前视频临时切换至 AAC。
- 临时回退保留用户选择的 Hi-Res 长期偏好，不修改默认音质设置。
- Hi-Res 解码失败不再进入 CDN 或普通播放源的重复重试流程。

![Screenshot_20260728_011956_com_android_purebilibili_dev_MainActivitySplashBlueSnow.jpg](https://github.com/user-attachments/assets/27d0225e-07ff-476e-8184-7da6bcad1c90)

![Screenshot_20260728_012013_com_android_purebilibili_dev_MainActivitySplashBlueSnow.jpg](https://github.com/user-attachments/assets/ab845e48-16c6-464c-a039-2fff98541380)

![Screenshot_20260728_012023_com_android_purebilibili_dev_MainActivitySplashBlueSnow.jpg](https://github.com/user-attachments/assets/6f97c7a4-1629-4cca-aa9f-194bf5344119)



