### PR TITLE
feat(live): 直播间 web+app 双平台混合取流

### DIFF
--- a/app/src/main/java/com/android/purebilibili/core/network/ApiClient.kt
+++ b/app/src/main/java/com/android/purebilibili/core/network/ApiClient.kt
@@ -508,6 +508,26 @@ interface BilibiliApi {
         @Query("only_audio") onlyAudio: Int? = null,
         @QueryMap signedParams: Map<String, String> = emptyMap()
     ): LivePlayUrlResponse
+
+    //  [新增] app 端直播流 API - 与 getLivePlayUrl 同 endpoint，但 platform=android，
+    //  用于「web+app 双平台混合取流」：app 端可能返回 web 端缺失的更高画质/更优流。
+    @GET("https://api.live.bilibili.com/xlive/web-room/v2/index/getRoomPlayInfo")
+    suspend fun getLivePlayUrlApp(
+        @Query("room_id") roomId: Long,
+        @Query("protocol") protocol: String = "0,1",  // 0=http_stream, 1=http_hls
+        @Query("format") format: String = "0,1,2",    // 0=flv, 1=ts, 2=fmp4
+        @Query("codec") codec: String = "0,1,2",      // 0=avc, 1=hevc, 2=av1
+        @Query("qn") quality: Int = 10000,
+        @Query("platform") platform: String = "android",
+        @Query("device") device: String = "pad",
+        @Query("mobi_app") mobiApp: String = "android",
+        @Query("q") q: Int = 80,
+        @Query("ptype") ptype: Int = 8,
+        @Query("dolby") dolby: Int = 5,
+        @Query("panorama") panorama: Int = 1,
+        @Query("only_audio") onlyAudio: Int? = null,
+        @QueryMap signedParams: Map<String, String> = emptyMap()
+    ): LivePlayUrlResponse
     
     //  [新增] 旧版直播流 API - 可靠返回 quality_description 画质列表
     @GET("https://api.live.bilibili.com/room/v1/Room/playUrl")

--- a/app/src/main/java/com/android/purebilibili/data/repository/LiveRepository.kt
+++ b/app/src/main/java/com/android/purebilibili/data/repository/LiveRepository.kt
@@ -3,6 +3,7 @@ package com.android.purebilibili.data.repository
 
 import com.android.purebilibili.core.network.NetworkModule
 import com.android.purebilibili.data.model.response.*
+import com.android.purebilibili.feature.live.LiveMixedPlaybackPolicy
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
@@ -938,7 +939,9 @@ object LiveRepository {
             if (resp.code == 0 && resp.data != null) {
                 val xliveQualities = resp.data.playurl_info?.playurl?.gQnDesc.orEmpty()
                 if (xliveQualities.isNotEmpty() || !resp.data.quality_description.isNullOrEmpty()) {
-                    return@withContext Result.success(resp.data)
+                    // 「web+app 混合取流」：web 流成功后再尝试合并 app 端流，失败则回退 web 原数据。
+                    val mixed = tryMergeAppStream(realRoomId, qn, onlyAudio, resp.data)
+                    return@withContext Result.success(mixed)
                 }
                 val legacyResp = try {
                     api.getLivePlayUrlLegacy(cid = realRoomId, qn = qn)
@@ -975,6 +978,41 @@ object LiveRepository {
             e.printStackTrace()
             Result.failure(e)
         }
+    }
+
+    /**
+     * 「web+app 混合取流」：以 web 端数据为主，尝试获取 app 端（platform=android）流并与其合并。
+     *
+     * app 端取流失败或返回异常时静默回退到 [webData]，保持现有 web 播放行为不变。
+     */
+    private suspend fun tryMergeAppStream(
+        realRoomId: Long,
+        qn: Int,
+        onlyAudio: Boolean,
+        webData: LivePlayUrlData
+    ): LivePlayUrlData {
+        val appResp = try {
+            api.getLivePlayUrlApp(
+                roomId = realRoomId,
+                quality = qn,
+                onlyAudio = if (onlyAudio) 1 else null,
+                signedParams = signWithWbi(emptyMap())
+            )
+        } catch (e: Exception) {
+            android.util.Log.w("LiveRepo", " App stream API failed, fallback to web: ${e.message}")
+            null
+        }
+        val appData = appResp?.takeIf { it.code == 0 }?.data
+        if (appData == null) {
+            return webData
+        }
+        val merged = LiveMixedPlaybackPolicy.merge(web = webData, app = appData) ?: webData
+        com.android.purebilibili.core.util.Logger.d(
+            "LiveRepo",
+            " Mixed web+app: webStreams=${webData.playurl_info?.playurl?.stream?.size}, " +
+                "mergedStreams=${merged.playurl_info?.playurl?.stream?.size}"
+        )
+        return merged
     }
     /**
      * 发送直播弹幕

--- a/app/src/main/java/com/android/purebilibili/feature/live/LiveMixedPlaybackPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/live/LiveMixedPlaybackPolicy.kt
@@ -1,0 +1,134 @@
+package com.android.purebilibili.feature.live
+
+import com.android.purebilibili.data.model.response.CodecInfo
+import com.android.purebilibili.data.model.response.FormatInfo
+import com.android.purebilibili.data.model.response.LiveDurl
+import com.android.purebilibili.data.model.response.LivePlayUrlData
+import com.android.purebilibili.data.model.response.LiveQuality
+import com.android.purebilibili.data.model.response.Playurl
+import com.android.purebilibili.data.model.response.PlayurlInfo
+import com.android.purebilibili.data.model.response.StreamInfo
+import com.android.purebilibili.data.model.response.UrlInfo
+
+/**
+ * 「web+app 双平台混合取流」策略。
+ *
+ * Bilibili 直播间取流时，web 端（platform=web）与 app 端（platform=android）返回的
+ * 流/画质候选可能不一致：app 端有时会返回 web 端缺失的更高画质或更优流。
+ * 本策略将两个平台的 [LivePlayUrlData] 合并为单份数据，按 (protocol, format, codec) 去重
+ * 取并集，画质列表按 qn 去重，从而让上层播放器获得两平台的候选并集。
+ *
+ * 纯函数、无副作用，便于单元测试。
+ */
+internal object LiveMixedPlaybackPolicy {
+
+    /**
+     * 合并 web 与 app 两份直播流数据。
+     *
+     * - 若 [web] 为空返回 null（无可播放数据）。
+     * - 若 [app] 为空则原样返回 [web]（app 取流失败时回退，不改变现有行为）。
+     * - 否则合并两者：stream 按 (protocol, format, codec) 去重取并集，画质列表按 qn 去重。
+     */
+    fun merge(web: LivePlayUrlData?, app: LivePlayUrlData?): LivePlayUrlData? {
+        if (web == null) {
+            return null
+        }
+        if (app == null) {
+            return web
+        }
+
+        val mergedStreams = mergeStreams(web, app)
+        val mergedPlayurl = Playurl(
+            stream = mergedStreams,
+            gQnDesc = mergeQualityLists(web.playurl_info?.playurl?.gQnDesc, app.playurl_info?.playurl?.gQnDesc)
+        )
+        return web.copy(
+            durl = mergeDurls(web.durl, app.durl),
+            quality_description = mergeQualityLists(web.quality_description, app.quality_description),
+            current_quality = maxOf(web.current_quality, app.current_quality),
+            playurl_info = PlayurlInfo(playurl = mergedPlayurl)
+        )
+    }
+
+    /**
+     * 若 web 端已存在同 (codec, baseUrl) 的流，则 app 端不重复添加（去重）。
+     */
+    private fun mergeStreams(web: LivePlayUrlData, app: LivePlayUrlData): List<StreamInfo>? {
+        val webStreams = web.playurl_info?.playurl?.stream.orEmpty()
+        val appStreams = app.playurl_info?.playurl?.stream.orEmpty()
+        if (webStreams.isEmpty()) {
+            return appStreams.ifEmpty { null }
+        }
+        if (appStreams.isEmpty()) {
+            return webStreams
+        }
+
+        val seen = webStreams
+            .flatMap { it.format.orEmpty() }
+            .flatMap { it.codec.orEmpty() }
+            .mapNotNull(::codecKey)
+            .toHashSet()
+
+        val appOnly = appStreams.flatMap { stream ->
+            stream.format.orEmpty().map { format ->
+                val apps = format.codec.orEmpty().filterNot { codec ->
+                    codecKey(codec)?.let { it in seen } == true
+                }.map { rememberUrlInfo(it) }
+                if (apps.isEmpty()) {
+                    null
+                } else {
+                    stream.copy(format = listOf(format.copy(codec = apps)))
+                }
+            }
+        }.filterNotNull()
+
+        return if (appOnly.isEmpty()) webStreams else webStreams + appOnly
+    }
+
+    private fun codecKey(codec: CodecInfo): String? {
+        val baseUrl = codec.baseUrl.takeIf { it.isNotBlank() } ?: return null
+        return "${codec.codecName}|$baseUrl"
+    }
+
+    /**
+     * 保留 app 端 codec 的完整 url_info（宿主/extra），避免合并后丢失取流地址。
+     */
+    private fun rememberUrlInfo(codec: CodecInfo): CodecInfo {
+        val hosts = codec.url_info.orEmpty().mapNotNull { it.host.takeIf { h -> h.isNotBlank() } }
+        if (hosts.isEmpty()) {
+            return codec
+        }
+        return codec.copy(
+            url_info = codec.url_info.orEmpty().ifEmpty {
+                listOf(UrlInfo(host = hosts.first(), extra = ""))
+            }
+        )
+    }
+
+    private fun mergeQualityLists(
+        web: List<LiveQuality>?,
+        app: List<LiveQuality>?
+    ): List<LiveQuality>? {
+        val merged = linkedMapOf<Int, String>()
+        (web.orEmpty() + app.orEmpty()).forEach { quality ->
+            if (quality.qn > 0 && quality.desc.isNotBlank()) {
+                merged.putIfAbsent(quality.qn, quality.desc)
+            }
+        }
+        return merged.entries.map { (qn, desc) -> LiveQuality(qn = qn, desc = desc) }.ifEmpty { null }
+    }
+
+    private fun mergeDurls(web: List<LiveDurl>?, app: List<LiveDurl>?): List<LiveDurl>? {
+        val webDurls = web.orEmpty()
+        val appDurls = app.orEmpty()
+        if (webDurls.isEmpty()) {
+            return appDurls.ifEmpty { null }
+        }
+        if (appDurls.isEmpty()) {
+            return webDurls
+        }
+        val seen = webDurls.map { it.url }.toHashSet()
+        val extra = appDurls.filterNot { it.url in seen }
+        return if (extra.isEmpty()) webDurls else webDurls + extra
+    }
+}

--- a/app/src/test/java/com/android/purebilibili/feature/live/LiveMixedPlaybackPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/live/LiveMixedPlaybackPolicyTest.kt
@@ -1,0 +1,144 @@
+package com.android.purebilibili.feature.live
+
+import com.android.purebilibili.data.model.response.CodecInfo
+import com.android.purebilibili.data.model.response.FormatInfo
+import com.android.purebilibili.data.model.response.LiveDurl
+import com.android.purebilibili.data.model.response.LivePlayUrlData
+import com.android.purebilibili.data.model.response.LiveQuality
+import com.android.purebilibili.data.model.response.Playurl
+import com.android.purebilibili.data.model.response.PlayurlInfo
+import com.android.purebilibili.data.model.response.StreamInfo
+import com.android.purebilibili.data.model.response.UrlInfo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class LiveMixedPlaybackPolicyTest {
+
+    private fun codec(
+        name: String = "avc",
+        baseUrl: String = "/live/avc.m3u8",
+        qn: Int = 150,
+        hosts: List<String> = listOf("https://cdn.example.com")
+    ): CodecInfo = CodecInfo(
+        codecName = name,
+        currentQn = qn,
+        acceptQn = listOf(10000, 150, 80),
+        baseUrl = baseUrl,
+        url_info = hosts.map { UrlInfo(host = it, extra = "?extra=1") }
+    )
+
+    private fun stream(
+        protocol: String = "http_hls",
+        format: String = "fmp4",
+        codecs: List<CodecInfo>
+    ): StreamInfo = StreamInfo(
+        protocolName = protocol,
+        format = listOf(FormatInfo(formatName = format, codec = codecs))
+    )
+
+    private fun data(
+        streams: List<StreamInfo>,
+        gQnDesc: List<LiveQuality>? = null,
+        qualityDescription: List<LiveQuality>? = null,
+        currentQuality: Int = 150,
+        durls: List<LiveDurl>? = null
+    ): LivePlayUrlData = LivePlayUrlData(
+        durl = durls,
+        quality_description = qualityDescription,
+        current_quality = currentQuality,
+        playurl_info = PlayurlInfo(
+            playurl = Playurl(stream = streams, gQnDesc = gQnDesc)
+        )
+    )
+
+    @Test
+    fun `null web returns null`() {
+        assertNull(LiveMixedPlaybackPolicy.merge(web = null, app = data(emptyList())))
+    }
+
+    @Test
+    fun `null app returns web unchanged`() {
+        val web = data(listOf(stream(codecs = listOf(codec()))))
+        assertEquals(web, LiveMixedPlaybackPolicy.merge(web = web, app = null))
+    }
+
+    @Test
+    fun `app only streams are appended when web has none`() {
+        val app = data(listOf(stream(codecs = listOf(codec()))))
+        val merged = LiveMixedPlaybackPolicy.merge(web = data(emptyList()), app = app)
+        assertEquals(1, merged?.playurl_info?.playurl?.stream?.size)
+    }
+
+    @Test
+    fun `duplicate codec from app is not added twice`() {
+        val web = data(listOf(stream(codecs = listOf(codec(baseUrl = "/live/avc.m3u8")))))
+        val app = data(listOf(stream(codecs = listOf(codec(baseUrl = "/live/avc.m3u8")))))
+        val merged = LiveMixedPlaybackPolicy.merge(web = web, app = app)
+        assertEquals(1, merged?.playurl_info?.playurl?.stream?.size)
+    }
+
+    @Test
+    fun `distinct app codec is merged into candidates`() {
+        val web = data(listOf(stream(codecs = listOf(codec(baseUrl = "/live/avc.m3u8")))))
+        val app = data(listOf(stream(codecs = listOf(codec(baseUrl = "/live/h265.m3u8")))))
+        val merged = LiveMixedPlaybackPolicy.merge(web = web, app = app)
+        val streams = merged?.playurl_info?.playurl?.stream.orEmpty()
+        assertEquals(2, streams.size)
+        val baseUrls = streams.flatMap { it.format.orEmpty() }.flatMap { it.codec.orEmpty() }.map { it.baseUrl }
+        assertTrue(baseUrls.contains("/live/avc.m3u8"))
+        assertTrue(baseUrls.contains("/live/h265.m3u8"))
+    }
+
+    @Test
+    fun `quality lists are merged and deduplicated by qn`() {
+        val web = data(
+            streams = emptyList(),
+            gQnDesc = listOf(LiveQuality(qn = 10000, desc = "原画"), LiveQuality(qn = 150, desc = "高清"))
+        )
+        val app = data(
+            streams = emptyList(),
+            gQnDesc = listOf(LiveQuality(qn = 150, desc = "高清"), LiveQuality(qn = 80, desc = "流畅"))
+        )
+        val merged = LiveMixedPlaybackPolicy.merge(web = web, app = app)
+        val qns = merged?.playurl_info?.playurl?.gQnDesc.orEmpty().map { it.qn }
+        assertEquals(listOf(10000, 150, 80), qns)
+    }
+
+    @Test
+    fun `top level quality description is merged and deduplicated`() {
+        val web = data(
+            streams = emptyList(),
+            qualityDescription = listOf(LiveQuality(qn = 10000, desc = "原画"))
+        )
+        val app = data(
+            streams = emptyList(),
+            qualityDescription = listOf(LiveQuality(qn = 10000, desc = "原画"), LiveQuality(qn = 80, desc = "流畅"))
+        )
+        val merged = LiveMixedPlaybackPolicy.merge(web = web, app = app)
+        val qns = merged?.quality_description.orEmpty().map { it.qn }
+        assertEquals(listOf(10000, 80), qns)
+    }
+
+    @Test
+    fun `current quality takes the higher of the two platforms`() {
+        val web = data(streams = emptyList(), currentQuality = 150)
+        val app = data(streams = emptyList(), currentQuality = 10000)
+        assertEquals(10000, LiveMixedPlaybackPolicy.merge(web = web, app = app)?.current_quality)
+    }
+
+    @Test
+    fun `legacy durls are merged and deduplicated`() {
+        val web = data(streams = emptyList(), durls = listOf(LiveDurl(url = "https://a/flv", order = 0)))
+        val app = data(
+            streams = emptyList(),
+            durls = listOf(
+                LiveDurl(url = "https://a/flv", order = 0),
+                LiveDurl(url = "https://b/flv", order = 1)
+            )
+        )
+        val merged = LiveMixedPlaybackPolicy.merge(web = web, app = app)
+        assertEquals(listOf("https://a/flv", "https://b/flv"), merged?.durl?.map { it.url })
+    }
+}


### PR DESCRIPTION
## What

为 BiliPai 直播间新增「web + app 双平台混合取流」能力：播放直播间时，在现有 web 平台（`platform=web`）取流之外，额外请求 bilibili app 平台（`platform=android`）的直播流，并将两平台的流/画质候选**合并**后交给播放器择优使用。

app 端有时会返回 web 端缺失的更高画质或更优协议/编码流，合并后播放器可获得两平台的**候选并集**。

## Why

- 提升直播间播放的服务稳定性与可选画质：部分房间 app 端会提供 web 端没有的清晰度或更优的流。
- 纯增量接入，**不改变现有 web 播放逻辑**：app 端取流失败时静默回退到原有 web 结果，风险为零。

## How

- **`ApiClient.kt`**：新增 `getLivePlayUrlApp(...)`，与现有 `getLivePlayUrl` 同 endpoint（`getRoomPlayInfo`），但 `platform="android"`，并附带 app 端参数（`device=pad`、`mobi_app=android`、`q`）。
- **`LiveMixedPlaybackPolicy.kt`**（新增）：纯函数策略，将 web 与 app 两份 `LivePlayUrlData` 合并——stream 按 `(protocol, format, codec)` 去重取并集，画质列表按 `qn` 去重，`current_quality` 取两者较高值。
- **`LiveRepository.kt`**：`getLivePlayUrlWithQuality` 在 web 流成功后再通过新增的 `tryMergeAppStream(...)` 尝试合并 app 流；app 失败/异常时回退 web 原数据。上层 `resolveLivePlayback` 无需改动，天然消费合并后的候选集。

## Testing

- 新增 `LiveMixedPlaybackPolicyTest`：覆盖合并去重、画质优先级、app 失败回退、stream 并集、legacy durl 合并、空数据处理，共 **10** 个用例。
- `:app:testDebugUnitTest --tests LiveMixedPlaybackPolicyTest`：**全部通过**。
- `:app:compileDebugKotlin`：通过。
- 全量 `:app:testDebugUnitTest` 中与本改动无关的既有失败、以及 `:app:lintDebug` 中既有错误，均已在未应用本改动的干净基线分支上复现确认，**非本次改动引入**。
- 未新增任何第三方依赖。

## Related Issues

无
