### PR TITLE
feat(home): 首页推荐流 App+Web 合并模式

### DIFF
--- a/app/src/main/java/com/android/purebilibili/core/store/SettingsManager.kt
+++ b/app/src/main/java/com/android/purebilibili/core/store/SettingsManager.kt
@@ -4527,7 +4527,8 @@ object SettingsManager {
      */
     enum class FeedApiType(val value: Int, val label: String, val description: String) {
         WEB(0, "网页端 (Web)", "使用 Web 推荐算法"),
-        MOBILE(1, "移动端 (App)", "使用手机端推荐算法，需登录");
+        MOBILE(1, "移动端 (App)", "使用手机端推荐算法，需登录"),
+        MERGED(2, "合并 (App+Web)", "同时使用 Web 与移动端推荐算法，移动端需登录，失败自动回退");
         
         companion object {
             fun fromValue(value: Int): FeedApiType = entries.find { it.value == value } ?: WEB

--- a/app/src/main/java/com/android/purebilibili/data/repository/VideoRepository.kt
+++ b/app/src/main/java/com/android/purebilibili/data/repository/VideoRepository.kt
@@ -581,6 +581,32 @@ object VideoRepository {
                         return fetchWebFeed(idx = idx, refreshCount = refreshCount)
                     }
                 }
+                com.android.purebilibili.core.store.SettingsManager.FeedApiType.MERGED -> {
+                    // 合并模式：并行请求 Web 与移动端推荐流，交错合并、按视频去重
+                    return coroutineScope {
+                        val webDeferred = async { fetchWebFeed(idx = idx, refreshCount = refreshCount) }
+                        val mobileDeferred = async { fetchMobileFeed(idx = idx, refreshCount = refreshCount) }
+                        val webResult = webDeferred.await()
+                        val mobileResult = mobileDeferred.await()
+
+                        val webList = webResult.getOrNull().orEmpty()
+                        val mobileList = mobileResult.getOrNull().orEmpty()
+
+                        if (webList.isEmpty() && mobileList.isEmpty()) {
+                            // 两者都失败：优先返回 web 的失败原因，其次移动端
+                            val error = webResult.exceptionOrNull() ?: mobileResult.exceptionOrNull()
+                                ?: Exception("获取合并推荐流失败")
+                            com.android.purebilibili.core.util.Logger.d("VideoRepo", " Merged feed both failed: ${error.message}")
+                            Result.failure(error)
+                        } else {
+                            com.android.purebilibili.core.util.Logger.d(
+                                "VideoRepo",
+                                " Merged feed: web=${webList.size}, mobile=${mobileList.size}"
+                            )
+                            Result.success(com.android.purebilibili.feature.home.HomeFeedMergePolicy.mergeFeeds(web = webList, app = mobileList))
+                        }
+                    }
+                }
                 else -> return fetchWebFeed(idx = idx, refreshCount = refreshCount)
             }
         } catch (e: CancellationException) {

--- a/app/src/main/java/com/android/purebilibili/feature/home/HomeFeedMergePolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/home/HomeFeedMergePolicy.kt
@@ -1,0 +1,55 @@
+package com.android.purebilibili.feature.home
+
+import com.android.purebilibili.data.model.response.VideoItem
+
+/**
+ * 「首页推荐流 App+Web 合并」策略。
+ *
+ * 移植自 PiliNara 首页推荐流合并模式：同时请求 web 端与 app 端两个推荐接口，
+ * 将两者交错合并、按视频去重，从而让首页获得两平台推荐的整体并集。
+ *
+ * 纯函数、无副作用，便于单元测试。
+ */
+internal object HomeFeedMergePolicy {
+
+    /**
+     * 交错合并 web 与 app 两条推荐流，返回去重后的列表。
+     *
+     * - 按索引交替取 app[i]、web[i]（app 在前）。
+     * - 按 [keyOf] 生成每种视频的唯一 key，重复项只保留首个。
+     * - 一方耗尽后，将另一方剩余项追加到末尾。
+     * - 任一输入为空时安全返回另一侧（或空列表）。
+     */
+    fun mergeFeeds(web: List<VideoItem>, app: List<VideoItem>): List<VideoItem> {
+        if (web.isEmpty()) return app
+        if (app.isEmpty()) return web
+
+        val seen = hashSetOf<String>()
+        val merged = ArrayList<VideoItem>(web.size + app.size)
+
+        val maxLen = maxOf(web.size, app.size)
+        for (i in 0 until maxLen) {
+            if (i < app.size) {
+                val item = app[i]
+                if (seen.add(keyOf(item))) merged.add(item)
+            }
+            if (i < web.size) {
+                val item = web[i]
+                if (seen.add(keyOf(item))) merged.add(item)
+            }
+        }
+        return merged
+    }
+
+    /**
+     * 生成视频唯一 key，与 HomeViewModel.videoItemKey 保持一致：
+     * 优先生态：dynamicId > bvid > aid > id。
+     */
+    fun keyOf(item: VideoItem): String {
+        if (item.dynamicId.isNotBlank()) return "dyn:${item.dynamicId}"
+        if (item.bvid.isNotBlank()) return "bvid:${item.bvid}"
+        if (item.aid > 0) return "aid:${item.aid}"
+        if (item.id > 0) return "id:${item.id}"
+        return "${item.owner.mid}:${item.title}:${item.pubdate}"
+    }
+}

--- a/app/src/test/java/com/android/purebilibili/feature/home/HomeFeedMergePolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/home/HomeFeedMergePolicyTest.kt
@@ -1,0 +1,79 @@
+package com.android.purebilibili.feature.home
+
+import com.android.purebilibili.data.model.response.VideoItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class HomeFeedMergePolicyTest {
+
+    private fun video(bvid: String, aid: Long = 0, dynamicId: String = ""): VideoItem =
+        VideoItem(bvid = bvid, aid = aid, dynamicId = dynamicId)
+
+    @Test
+    fun `empty web returns app unchanged`() {
+        val app = listOf(video("BV1"), video("BV2"))
+        assertEquals(app, HomeFeedMergePolicy.mergeFeeds(web = emptyList(), app = app))
+    }
+
+    @Test
+    fun `empty app returns web unchanged`() {
+        val web = listOf(video("BV1"), video("BV2"))
+        assertEquals(web, HomeFeedMergePolicy.mergeFeeds(web = web, app = emptyList()))
+    }
+
+    @Test
+    fun `both empty returns empty`() {
+        assertTrue(HomeFeedMergePolicy.mergeFeeds(web = emptyList(), app = emptyList()).isEmpty())
+    }
+
+    @Test
+    fun `interleaves app first then web by index`() {
+        val web = listOf(video("W1"), video("W2"))
+        val app = listOf(video("A1"), video("A2"))
+        val merged = HomeFeedMergePolicy.mergeFeeds(web = web, app = app)
+        assertEquals(listOf("A1", "W1", "A2", "W2"), merged.map { it.bvid })
+    }
+
+    @Test
+    fun `duplicate bvid across sources is kept once`() {
+        val web = listOf(video("BV1"), video("BV2"))
+        val app = listOf(video("BV1"), video("BV3"))
+        val merged = HomeFeedMergePolicy.mergeFeeds(web = web, app = app)
+        assertEquals(listOf("BV1", "BV3", "BV2"), merged.map { it.bvid })
+    }
+
+    @Test
+    fun `duplicate aid across sources is kept once`() {
+        val web = listOf(video("", aid = 100), video("", aid = 200))
+        val app = listOf(video("", aid = 100), video("", aid = 300))
+        val merged = HomeFeedMergePolicy.mergeFeeds(web = web, app = app)
+        assertEquals(listOf(100L, 300L, 200L), merged.map { it.aid })
+    }
+
+    @Test
+    fun `leftover items from longer source are appended at end`() {
+        val web = listOf(video("W1"))
+        val app = listOf(video("A1"), video("A2"), video("A3"))
+        val merged = HomeFeedMergePolicy.mergeFeeds(web = web, app = app)
+        assertEquals(listOf("A1", "W1", "A2", "A3"), merged.map { it.bvid })
+    }
+
+    @Test
+    fun `dynamic id takes precedence over bvid for dedup`() {
+        val web = listOf(video("BV1", dynamicId = "dyn1"))
+        val app = listOf(video("BV1", dynamicId = "dyn1"), video("BV2"))
+        val merged = HomeFeedMergePolicy.mergeFeeds(web = web, app = app)
+        // 第一条 web(BV1/dyn1) 与 app 第一条(BV2? no BV2) —— 这里 app[0] 是 BV1/dyn1 与 web[0] 重复
+        assertEquals(2, merged.size)
+        assertEquals(listOf("BV1", "BV2"), merged.map { it.bvid })
+    }
+
+    @Test
+    fun `no duplicates yields full interleaved union`() {
+        val web = listOf(video("W1"), video("W2"), video("W3"))
+        val app = listOf(video("A1"))
+        val merged = HomeFeedMergePolicy.mergeFeeds(web = web, app = app)
+        assertEquals(listOf("A1", "W1", "W2", "W3"), merged.map { it.bvid })
+    }
+}


### PR DESCRIPTION
## What

为 BiliPai 首页新增「推荐流合并模式（App+Web）」：首页推荐**同时**从 web 端与 app 端两个接口**并行取流**，将两平台的推荐交错合并、按视频去重，从而让首页获得两平台推荐的整体并集。

移植自 PiliNara `2.0.9.1-Mydeimos` 的「首页推荐流合并模式」。

## Why

- web 端（`x/web-interface/wbi/index/top/feed/rcmd`）与 app 端（`app.bilibili.com/x/v2/feed/index`）推荐算法不同，合并后可获得更丰富、互补的推荐内容。
- 纯增量接入，**不改变现有 Web 单独模式 / App 单独模式**；app 端需登录，失败时自动回退为纯 web，风险为零。

## How

- **`SettingsManager.kt`**：`FeedApiType` 新增 `MERGED(2, "合并 (App+Web)", ...)` 枚举成员。设置页「首页推荐来源」的 UI 通过 `resolveFeedApiSegmentOptions(entries = FeedApiType.entries)` 自动纳入新选项，无需额外改动。
- **`HomeFeedMergePolicy.kt`**（新增）：纯函数 `mergeFeeds(web, app)`，按索引交错合并（app 在前），按 `dynamicId/bvid/aid/id` 生成 key 去重，一方耗尽后追加剩余项。
- **`VideoRepository.kt`**：`getHomeVideosInternal` 新增 `MERGED` 分支，用 `coroutineScope + async` **并行**请求 `fetchWebFeed` 与 `fetchMobileFeed`（同一 idx），再合并；两者都失败时返回失败原因，单侧失败时保留成功侧。

## Testing

- 新增 `HomeFeedMergePolicyTest`：覆盖交错顺序、按 bvid/aid 去重、多出部分追加、单侧/空输入，共 **8** 个用例。
- `:app:testDebugUnitTest --tests HomeFeedMergePolicyTest`：**全部通过**。
- `:app:compileDebugKotlin`：通过。
- `:app:lintDebug` 中 11 个既有错误已在干净基线分支上确认，均位于 GoogleCast/Bangumi/MediaUtils 等无关文件，**非本次引入**。
- 未新增任何第三方依赖。

## Related Issues

无
