### PR TITLE
fix: make DLNA discovery resilient to Android XML parsers

### DIFF
--- a/app/src/main/java/com/android/purebilibili/feature/cast/SsdpCastClient.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/cast/SsdpCastClient.kt
@@ -8,6 +8,9 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.w3c.dom.Element
+import org.xml.sax.InputSource
+import org.xml.sax.SAXException
+import java.io.StringReader
 import java.net.URI
 import javax.xml.parsers.DocumentBuilderFactory
 
@@ -116,17 +119,9 @@ object SsdpCastClient {
     ): SsdpDeviceProfile? {
         if (descriptionXml.isBlank()) return null
         return runCatching {
-            val factory = DocumentBuilderFactory.newInstance().apply {
-                isNamespaceAware = true
-                setFeature("http://xml.org/sax/features/external-general-entities", false)
-                setFeature("http://xml.org/sax/features/external-parameter-entities", false)
-                setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
-                runCatching { setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true) }
-                isXIncludeAware = false
-                isExpandEntityReferences = false
-            }
-            val builder = factory.newDocumentBuilder()
-            val document = builder.parse(descriptionXml.byteInputStream())
+            val document = newDeviceDescriptionBuilder().parse(
+                InputSource(StringReader(descriptionXml))
+            )
             val deviceNodes = document.getElementsByTagNameNS("*", "device")
             if (deviceNodes.length == 0) return null
 
@@ -156,6 +151,29 @@ object SsdpCastClient {
             Logger.w(TAG, "📺 [SSDP] Parse description failed: ${error.message}")
             null
         }
+    }
+
+    /**
+     * Android XML parser implementations do not expose the same optional JAXP/SAX
+     * feature set.  A missing hardening flag must not make a valid UPnP device
+     * description undiscoverable; the EntityResolver is the portable security boundary.
+     */
+    private fun newDeviceDescriptionBuilder() = DocumentBuilderFactory.newInstance().apply {
+        isNamespaceAware = true
+        disableFeatureIfSupported("http://xml.org/sax/features/external-general-entities")
+        disableFeatureIfSupported("http://xml.org/sax/features/external-parameter-entities")
+        disableFeatureIfSupported("http://apache.org/xml/features/nonvalidating/load-external-dtd")
+        runCatching { isXIncludeAware = false }
+        runCatching { isExpandEntityReferences = false }
+    }.newDocumentBuilder().apply {
+        setEntityResolver { _, systemId ->
+            throw SAXException("External XML entity resolution is disabled: $systemId")
+        }
+    }
+
+    private fun DocumentBuilderFactory.disableFeatureIfSupported(feature: String) {
+        runCatching { setFeature(feature, false) }
+            .onFailure { Logger.d(TAG, "📺 [SSDP] XML feature unavailable: $feature") }
     }
 
     /**

--- a/app/src/main/java/com/android/purebilibili/feature/cast/SsdpDiscovery.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/cast/SsdpDiscovery.kt
@@ -179,11 +179,12 @@ object SsdpDiscovery {
                 }
         }
 
-        // Prefer binding to the concrete LAN IPv4 so dual-network OEMs (Vivo/Xiaomi) send
-        // multicast on Wi-Fi instead of the cellular default route.
+        // SSDP NOTIFY advertisements are sent to 239.255.255.250:1900.  Listening on
+        // an ephemeral port only receives direct M-SEARCH replies, so retain port 1900
+        // while the network/interface selection below controls the LAN route.
         val boundToLanIp = binding.ipv4Address?.let { ipv4 ->
             runCatching {
-                socket.bind(InetSocketAddress(ipv4, 0))
+                socket.bind(InetSocketAddress(ipv4, SSDP_PORT))
                 true
             }.getOrElse { error ->
                 Logger.w(TAG, "📺 [DLNA] Bind to LAN IPv4 failed: ${error.message}")
@@ -192,7 +193,7 @@ object SsdpDiscovery {
         } ?: false
 
         if (!boundToLanIp && !socket.isBound) {
-            socket.bind(InetSocketAddress(0))
+            socket.bind(InetSocketAddress(SSDP_PORT))
         }
 
         binding.networkInterface?.let { nif ->


### PR DESCRIPTION
## Purpose

Fix DLNA renderers that are present on the LAN but do not appear in the cast sheet on Android 16 devices.

解决安卓16设备上投屏找不到设备的问题

## Changes

- Bind the SSDP receive socket to UDP port 1900, so multicast `NOTIFY` advertisements addressed to `239.255.255.250:1900` are received instead of only direct M-SEARCH replies.
- Make UPnP device-description parsing tolerant of unavailable optional JAXP/SAX feature flags.
- Keep external XML entity resolution fail-closed with `EntityResolver`, independent of optional parser features.

## Why this is needed

On a physical Android 16 (API 36) device, setting `http://xml.org/sax/features/external-general-entities` threw an unsupported-feature exception. The resulting null profile hid an otherwise discovered DLNA renderer.

Android's `DocumentBuilderFactory` documentation says implementation-defined features may throw `ParserConfigurationException` when unsupported, and also notes that `XMLConstants.FEATURE_SECURE_PROCESSING` is unsupported on Android. This change therefore treats those flags as optional hardening instead of a prerequisite for parsing a valid UPnP description:
https://developer.android.com/reference/javax/xml/parsers/DocumentBuilderFactory#setFeature(java.lang.String,%20boolean)

## Verification

- `:app:testDebugUnitTest --tests 'com.android.purebilibili.feature.cast.SsdpCastClientTest'`
- Physical Android 16 device + DLNA TV: renderer discovery was verified after the fix.
