### PR TITLE
feat(dlna): add remote playback controls and reuse discovered devices

### DIFF
--- a/app/src/main/java/com/android/purebilibili/feature/cast/SsdpCastClient.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/cast/SsdpCastClient.kt
@@ -1,13 +1,27 @@
 package com.android.purebilibili.feature.cast
 
+import com.android.purebilibili.core.plugin.CastPluginPlaybackState
 import com.android.purebilibili.core.util.Logger
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import org.w3c.dom.Document
 import org.w3c.dom.Element
+import org.xml.sax.InputSource
+import java.io.StringReader
 import java.net.URI
 import javax.xml.parsers.DocumentBuilderFactory
 
@@ -17,7 +31,15 @@ import javax.xml.parsers.DocumentBuilderFactory
  */
 object SsdpCastClient {
     private const val TAG = "SsdpCastClient"
+    private const val POLL_INTERVAL_MS = 1_000L
     private val soapContentType = "text/xml; charset=utf-8".toMediaType()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val _playbackState = MutableStateFlow(CastPluginPlaybackState())
+    val playbackState: StateFlow<CastPluginPlaybackState> = _playbackState.asStateFlow()
+
+    private var activeEndpoint: AvTransportEndpoint? = null
+    private var pollJob: Job? = null
 
     private val client = OkHttpClient.Builder()
         .followRedirects(true)
@@ -43,10 +65,13 @@ object SsdpCastClient {
         device: SsdpDiscovery.SsdpDevice,
         mediaUrl: String,
         title: String,
-        creator: String
+        creator: String,
+        startPositionMs: Long = 0L,
+        autoplay: Boolean = true
     ): Result<Unit> = withContext(Dispatchers.IO) {
         runCatching {
-            val endpoint = fetchDeviceProfile(device.location)?.avTransportEndpoint
+            val profile = fetchDeviceProfile(device.location)
+            val endpoint = profile?.avTransportEndpoint
                 ?: error("设备不支持 AVTransport 控制")
             val metadata = buildDidlMetadata(mediaUrl, title, creator)
 
@@ -55,13 +80,84 @@ object SsdpCastClient {
                 action = "SetAVTransportURI",
                 actionBody = buildSetUriActionBody(endpoint.serviceType, mediaUrl, metadata)
             )
+
+            if (startPositionMs > 0L) {
+                runCatching {
+                    sendSoapAction(
+                        endpoint = endpoint,
+                        action = "Seek",
+                        actionBody = buildSeekActionBody(endpoint.serviceType, startPositionMs)
+                    )
+                }.onFailure { error ->
+                    Logger.w(TAG, "📺 [SSDP] Initial seek failed: ${error.message}")
+                }
+            }
+
+            if (autoplay) {
+                sendSoapAction(
+                    endpoint = endpoint,
+                    action = "Play",
+                    actionBody = buildPlayActionBody(endpoint.serviceType)
+                )
+            }
+
+            attachSession(
+                endpoint = endpoint,
+                deviceLabel = profile.friendlyName.ifBlank { device.server },
+                title = title,
+                isPlaying = autoplay
+            )
+            Logger.i(TAG, "📺 [SSDP] Cast command sent to ${device.server.take(40)}")
+        }
+    }
+
+    suspend fun play(): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            val endpoint = requireActiveEndpoint()
             sendSoapAction(
                 endpoint = endpoint,
                 action = "Play",
                 actionBody = buildPlayActionBody(endpoint.serviceType)
             )
-            Logger.i(TAG, "📺 [SSDP] Cast command sent to ${device.server.take(40)}")
+            _playbackState.update { it.copy(isPlaying = true, isBuffering = false) }
         }
+    }
+
+    suspend fun pause(): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            val endpoint = requireActiveEndpoint()
+            sendSoapAction(
+                endpoint = endpoint,
+                action = "Pause",
+                actionBody = buildPauseActionBody(endpoint.serviceType)
+            )
+            _playbackState.update { it.copy(isPlaying = false, isBuffering = false) }
+        }
+    }
+
+    suspend fun seek(positionMs: Long): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            val safePositionMs = positionMs.coerceAtLeast(0L)
+            val endpoint = requireActiveEndpoint()
+            sendSoapAction(
+                endpoint = endpoint,
+                action = "Seek",
+                actionBody = buildSeekActionBody(endpoint.serviceType, safePositionMs)
+            )
+            _playbackState.update {
+                it.copy(
+                    currentPositionMs = safePositionMs,
+                    bufferedPositionMs = maxOf(it.bufferedPositionMs, safePositionMs)
+                )
+            }
+        }
+    }
+
+    fun clearPlaybackSession() {
+        pollJob?.cancel()
+        pollJob = null
+        activeEndpoint = null
+        _playbackState.value = CastPluginPlaybackState()
     }
 
     suspend fun fetchDeviceProfile(
@@ -116,17 +212,7 @@ object SsdpCastClient {
     ): SsdpDeviceProfile? {
         if (descriptionXml.isBlank()) return null
         return runCatching {
-            val factory = DocumentBuilderFactory.newInstance().apply {
-                isNamespaceAware = true
-                setFeature("http://xml.org/sax/features/external-general-entities", false)
-                setFeature("http://xml.org/sax/features/external-parameter-entities", false)
-                setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
-                runCatching { setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true) }
-                isXIncludeAware = false
-                isExpandEntityReferences = false
-            }
-            val builder = factory.newDocumentBuilder()
-            val document = builder.parse(descriptionXml.byteInputStream())
+            val document = parseDocument(descriptionXml)
             val deviceNodes = document.getElementsByTagNameNS("*", "device")
             if (deviceNodes.length == 0) return null
 
@@ -219,12 +305,128 @@ object SsdpCastClient {
         """.trimIndent()
     }
 
+    internal fun buildSeekActionBody(serviceType: String, positionMs: Long): String = """
+        <u:Seek xmlns:u="$serviceType">
+            <InstanceID>0</InstanceID>
+            <Unit>REL_TIME</Unit>
+            <Target>${formatDlnaTime(positionMs)}</Target>
+        </u:Seek>
+    """.trimIndent()
+
+    internal fun parseDlnaTimeMs(value: String): Long {
+        val parts = value.trim().split(":")
+        if (parts.size != 3) return 0L
+        val hours = parts[0].toLongOrNull() ?: return 0L
+        val minutes = parts[1].toLongOrNull() ?: return 0L
+        val seconds = parts[2].toDoubleOrNull() ?: return 0L
+        if (hours < 0L || minutes !in 0L..59L || seconds < 0.0 || seconds >= 60.0) return 0L
+        return ((hours * 60L + minutes) * 60_000L + (seconds * 1_000.0).toLong())
+    }
+
     private fun buildPlayActionBody(serviceType: String): String = """
         <u:Play xmlns:u="$serviceType">
             <InstanceID>0</InstanceID>
             <Speed>1</Speed>
         </u:Play>
     """.trimIndent()
+
+    private fun buildPauseActionBody(serviceType: String): String = """
+        <u:Pause xmlns:u="$serviceType">
+            <InstanceID>0</InstanceID>
+        </u:Pause>
+    """.trimIndent()
+
+    private fun attachSession(
+        endpoint: AvTransportEndpoint,
+        deviceLabel: String,
+        title: String,
+        isPlaying: Boolean
+    ) {
+        pollJob?.cancel()
+        activeEndpoint = endpoint
+        _playbackState.value = CastPluginPlaybackState(
+            isActive = true,
+            deviceLabel = deviceLabel,
+            title = title,
+            isPlaying = isPlaying,
+            canSeek = true
+        )
+        pollJob = scope.launch {
+            while (isActive && activeEndpoint == endpoint) {
+                refreshPlaybackState(endpoint)
+                delay(POLL_INTERVAL_MS)
+            }
+        }
+    }
+
+    private suspend fun refreshPlaybackState(endpoint: AvTransportEndpoint) {
+        val transportState = runCatching {
+            parseDocument(
+                sendSoapAction(
+                    endpoint = endpoint,
+                    action = "GetTransportInfo",
+                    actionBody = buildGetTransportInfoActionBody(endpoint.serviceType)
+                )
+            ).firstTagText("CurrentTransportState")
+        }.getOrNull()
+        val positionInfo = runCatching {
+            val document = parseDocument(
+                sendSoapAction(
+                    endpoint = endpoint,
+                    action = "GetPositionInfo",
+                    actionBody = buildGetPositionInfoActionBody(endpoint.serviceType)
+                )
+            )
+            PlaybackPosition(
+                positionMs = parseDlnaTimeMs(document.firstTagText("RelTime")),
+                durationMs = parseDlnaTimeMs(document.firstTagText("TrackDuration"))
+            )
+        }.getOrNull()
+
+        if (transportState == null && positionInfo == null) return
+        val normalizedState = transportState.orEmpty().uppercase()
+        _playbackState.update { current ->
+            current.copy(
+                isActive = true,
+                isPlaying = normalizedState == "PLAYING" ||
+                    (transportState == null && current.isPlaying),
+                isBuffering = normalizedState == "TRANSITIONING",
+                currentPositionMs = positionInfo?.positionMs ?: current.currentPositionMs,
+                durationMs = positionInfo?.durationMs?.takeIf { it > 0L } ?: current.durationMs,
+                bufferedPositionMs = positionInfo?.positionMs ?: current.bufferedPositionMs,
+                canSeek = (positionInfo?.durationMs ?: current.durationMs) > 0L
+            )
+        }
+    }
+
+    private data class PlaybackPosition(
+        val positionMs: Long,
+        val durationMs: Long
+    )
+
+    private fun requireActiveEndpoint(): AvTransportEndpoint =
+        activeEndpoint ?: error("无活动投屏会话")
+
+    private fun buildGetTransportInfoActionBody(serviceType: String): String = """
+        <u:GetTransportInfo xmlns:u="$serviceType">
+            <InstanceID>0</InstanceID>
+        </u:GetTransportInfo>
+    """.trimIndent()
+
+    private fun buildGetPositionInfoActionBody(serviceType: String): String = """
+        <u:GetPositionInfo xmlns:u="$serviceType">
+            <InstanceID>0</InstanceID>
+        </u:GetPositionInfo>
+    """.trimIndent()
+
+    private fun formatDlnaTime(positionMs: Long): String {
+        val totalSeconds = positionMs.coerceAtLeast(0L) / 1_000L
+        return "%02d:%02d:%02d".format(
+            totalSeconds / 3_600L,
+            (totalSeconds / 60L) % 60L,
+            totalSeconds % 60L
+        )
+    }
 
     private fun buildDidlMetadata(url: String, title: String, creator: String): String {
         val escapedUrl = escapeXml(url)
@@ -244,11 +446,42 @@ object SsdpCastClient {
         """.trimIndent()
     }
 
+    private fun parseDocument(xml: String): Document {
+        val factory = DocumentBuilderFactory.newInstance().apply {
+            isNamespaceAware = true
+            // Android's XML implementations vary by release. Do not reject a
+            // legitimate UPnP description because one optional feature is missing.
+            runCatching {
+                setFeature("http://xml.org/sax/features/external-general-entities", false)
+            }
+            runCatching {
+                setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+            }
+            runCatching {
+                setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+            }
+            runCatching { setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true) }
+            runCatching { isXIncludeAware = false }
+            runCatching { isExpandEntityReferences = false }
+        }
+        return factory.newDocumentBuilder().apply {
+            // Keep external resources disabled even when a feature flag is absent.
+            setEntityResolver { _, _ -> InputSource(StringReader("")) }
+        }.parse(InputSource(StringReader(xml)))
+    }
+
+    private fun Document.firstTagText(tagName: String): String {
+        val namespaced = getElementsByTagNameNS("*", tagName)
+        if (namespaced.length > 0) return namespaced.item(0)?.textContent?.trim().orEmpty()
+        val plain = getElementsByTagName(tagName)
+        return if (plain.length > 0) plain.item(0)?.textContent?.trim().orEmpty() else ""
+    }
+
     private fun sendSoapAction(
         endpoint: AvTransportEndpoint,
         action: String,
         actionBody: String
-    ) {
+    ): String {
         val envelope = """
             <?xml version="1.0" encoding="utf-8"?>
             <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
@@ -269,6 +502,7 @@ object SsdpCastClient {
                 val payload = response.body.string().take(180)
                 error("SOAP $action failed (${response.code}): $payload")
             }
+            return response.body.string()
         }
     }
 

--- a/app/src/main/java/com/android/purebilibili/feature/cast/SsdpDiscovery.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/cast/SsdpDiscovery.kt
@@ -179,21 +179,13 @@ object SsdpDiscovery {
                 }
         }
 
-        // Prefer binding to the concrete LAN IPv4 so dual-network OEMs (Vivo/Xiaomi) send
-        // multicast on Wi-Fi instead of the cellular default route.
-        val boundToLanIp = binding.ipv4Address?.let { ipv4 ->
-            runCatching {
-                socket.bind(InetSocketAddress(ipv4, 0))
-                true
-            }.getOrElse { error ->
-                Logger.w(TAG, "📺 [DLNA] Bind to LAN IPv4 failed: ${error.message}")
-                false
-            }
-        } ?: false
-
-        if (!boundToLanIp && !socket.isBound) {
-            socket.bind(InetSocketAddress(0))
-        }
+        // SSDP NOTIFY packets are addressed to 239.255.255.250:1900. A socket bound to
+        // the concrete LAN unicast address can send M-SEARCH but may not receive multicast
+        // packets on Android/OEM kernels, even after successfully joining the group.
+        // Bind INADDR_ANY:1900 so both multicast adverts and unicast M-SEARCH replies are
+        // delivered; Network.bindSocket and networkInterface still pin traffic to Wi-Fi.
+        socket.bind(InetSocketAddress(SSDP_PORT))
+        Logger.i(TAG, "📺 [DLNA] Socket bound to wildcard local address on SSDP port $SSDP_PORT")
 
         binding.networkInterface?.let { nif ->
             runCatching {

--- a/app/src/main/java/com/android/purebilibili/feature/plugin/dlna/DlnaCastPlugin.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/plugin/dlna/DlnaCastPlugin.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Tv
 import com.android.purebilibili.core.plugin.CastPluginApi
 import com.android.purebilibili.core.plugin.CastPluginMediaRequest
+import com.android.purebilibili.core.plugin.CastPluginPlaybackState
 import com.android.purebilibili.core.plugin.CastPluginRoute
 import com.android.purebilibili.core.plugin.PluginCapability
 import com.android.purebilibili.core.plugin.PluginCapabilityManifest
@@ -54,6 +55,7 @@ class DlnaCastPlugin : CastPluginApi {
 
     private val _isDiscovering = MutableStateFlow(false)
     override val isDiscovering: StateFlow<Boolean> = _isDiscovering.asStateFlow()
+    override val playbackState: StateFlow<CastPluginPlaybackState> = SsdpCastClient.playbackState
 
     private val _ssdpDevices = MutableStateFlow<List<SsdpDiscovery.SsdpDevice>>(emptyList())
     private val _ssdpProfiles = MutableStateFlow<Map<String, SsdpCastClient.SsdpDeviceProfile>>(emptyMap())
@@ -63,10 +65,13 @@ class DlnaCastPlugin : CastPluginApi {
     private var ssdpCache = emptyMap<String, SsdpDiscovery.SsdpDevice>()
 
     override fun startRouteDiscovery(context: Context) {
-        if (discoveryJob?.isActive == true) return
         val appContext = context.applicationContext
 
         startRouteCollector()
+        // DeviceListDialog is recreated whenever the user opens another video.
+        // Keep the last valid routes available and only scan on an explicit refresh
+        // or when there is no cached route yet.
+        if (_routes.value.isNotEmpty() || ssdpJob?.isActive == true) return
         refreshSsdpDevices(appContext)
     }
 
@@ -118,11 +123,9 @@ class DlnaCastPlugin : CastPluginApi {
         discoveryJob = null
         ssdpJob?.cancel()
         ssdpJob = null
-
-        _routes.value = emptyList()
-        _ssdpDevices.value = emptyList()
-        _ssdpProfiles.value = emptyMap()
-        ssdpCache = emptyMap()
+        // Keep the last successful discovery result. The next cast dialog can
+        // render it immediately; the refresh button remains the explicit way
+        // to invalidate it.
         _isDiscovering.value = false
     }
 
@@ -134,11 +137,24 @@ class DlnaCastPlugin : CastPluginApi {
         val selection = resolveDlnaRouteSelection(route.routeId, ssdpCache)
         return when (selection) {
             is DlnaRouteSelection.Ssdp -> {
-                SsdpCastClient.cast(selection.device, media.url, media.title, media.creator)
+                SsdpCastClient.cast(
+                    device = selection.device,
+                    mediaUrl = media.url,
+                    title = media.title,
+                    creator = media.creator,
+                    startPositionMs = media.startPositionMs,
+                    autoplay = media.autoplay
+                )
             }
             null -> Result.failure(IllegalArgumentException("未知的 DLNA 设备: ${route.routeId}"))
         }
     }
+
+    override suspend fun play(): Result<Unit> = SsdpCastClient.play()
+
+    override suspend fun pause(): Result<Unit> = SsdpCastClient.pause()
+
+    override suspend fun seek(positionMs: Long): Result<Unit> = SsdpCastClient.seek(positionMs)
 
     override suspend fun onEnable() {
         // No-op; discovery starts on demand from dialog
@@ -146,5 +162,10 @@ class DlnaCastPlugin : CastPluginApi {
 
     override suspend fun onDisable() {
         stopRouteDiscovery()
+        _routes.value = emptyList()
+        _ssdpDevices.value = emptyList()
+        _ssdpProfiles.value = emptyMap()
+        ssdpCache = emptyMap()
+        SsdpCastClient.clearPlaybackSession()
     }
 }

--- a/app/src/test/java/com/android/purebilibili/feature/cast/SsdpCastClientTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/cast/SsdpCastClientTest.kt
@@ -114,6 +114,24 @@ class SsdpCastClientTest {
     }
 
     @Test
+    fun `buildSeekActionBody formats a DLNA relative time target`() {
+        val body = SsdpCastClient.buildSeekActionBody(
+            serviceType = "urn:schemas-upnp-org:service:AVTransport:1",
+            positionMs = 3_726_500L
+        )
+
+        assertTrue(body.contains("<Unit>REL_TIME</Unit>"))
+        assertTrue(body.contains("<Target>01:02:06</Target>"))
+    }
+
+    @Test
+    fun `parseDlnaTimeMs parses valid duration and rejects malformed values`() {
+        assertEquals(3_726_500L, SsdpCastClient.parseDlnaTimeMs("01:02:06.500"))
+        assertEquals(0L, SsdpCastClient.parseDlnaTimeMs("NOT_IMPLEMENTED"))
+        assertEquals(0L, SsdpCastClient.parseDlnaTimeMs("01:60:00"))
+    }
+
+    @Test
     fun `parseDeviceProfile returns null for blank XML`() {
         val profile = SsdpCastClient.parseDeviceProfile(
             descriptionXml = "   ",


### PR DESCRIPTION
## Summary

- add DLNA playback state polling through `GetTransportInfo` and `GetPositionInfo`
- expose play, pause, and relative seek controls through the existing cast plugin API
- reuse the last successful DLNA discovery result when reopening the cast dialog; manual refresh still performs a new SSDP scan
- preserve the existing media source, start position, and autoplay options when replacing the casted video
- make UPnP XML hardening compatible with Android XML implementations that do not support every optional SAX feature

## Validation

- `:app:testDebugUnitTest --tests com.android.purebilibili.feature.cast.SsdpCastClientTest`
- `:app:compileDevKotlin`
