### PR TITLE
feat(plugin): 新增推荐流过滤插件(移植自 PiliNara)

### DIFF
--- a/app/src/main/java/com/android/purebilibili/app/PureApplication.kt
+++ b/app/src/main/java/com/android/purebilibili/app/PureApplication.kt
@@ -232,7 +232,9 @@ class PureApplication : Application(), ImageLoaderFactory, ComponentCallbacks2 {
         PluginManager.register(HomeFeedAnonymizerPlugin())
         PluginManager.register(DlnaCastPlugin())
         PluginManager.register(GoogleCastPlugin())
-        Logger.d(PureApplicationRuntimeConfig.TAG, " Plugin system initialized with 10 built-in plugins")
+        //  [PiliNara 移植] 推荐流过滤(默认关闭, 可在插件中心启用)
+        PluginManager.register(com.android.purebilibili.feature.plugin.PiliNaraFeedFilterPlugin())
+        Logger.d(PureApplicationRuntimeConfig.TAG, " Plugin system initialized with 11 built-in plugins")
 
         com.android.purebilibili.core.plugin.json.JsonPluginManager.initialize(this)
         Logger.d(PureApplicationRuntimeConfig.TAG, " JSON plugin system initialized")

--- a/app/src/main/java/com/android/purebilibili/core/plugin/FeedPlugin.kt
+++ b/app/src/main/java/com/android/purebilibili/core/plugin/FeedPlugin.kt
@@ -20,4 +20,29 @@ interface FeedPlugin : Plugin {
      * @return true 表示显示，false 表示隐藏
      */
     fun shouldShowItem(item: VideoItem): Boolean
+
+    /**
+     * 带信息流来源的判断(默认委托给 [shouldShowItem] 以保持向后兼容)。
+     *
+     * 需要按来源区分行为(如 PiliNara 的「过滤器也应用于热门/排行/搜索」开关)时覆写此方法。
+     */
+    fun shouldShowItem(item: VideoItem, feedKind: FeedKind): Boolean = shouldShowItem(item)
+}
+
+/**
+ * 信息流来源类型，供 FeedPlugin 按来源区分过滤行为。
+ */
+enum class FeedKind {
+    /** 未标注来源(默认) */
+    GENERIC,
+    /** 首页推荐流 */
+    HOME_RECOMMEND,
+    /** 热门 */
+    HOME_POPULAR,
+    /** 排行榜 */
+    HOME_RANK,
+    /** 分区 */
+    HOME_REGION,
+    /** 搜索结果 */
+    SEARCH
 }

--- a/app/src/main/java/com/android/purebilibili/core/plugin/PluginManager.kt
+++ b/app/src/main/java/com/android/purebilibili/core/plugin/PluginManager.kt
@@ -186,15 +186,20 @@ object PluginManager {
     /**
      *  使用所有启用的 FeedPlugin 过滤视频列表
      * 用于首页推荐和搜索结果
+     *
+     * @param feedKind 信息流来源(首页推荐/热门/排行/分区/搜索), 默认 GENERIC
      */
-    fun filterFeedItems(items: List<com.android.purebilibili.data.model.response.VideoItem>): List<com.android.purebilibili.data.model.response.VideoItem> {
+    fun filterFeedItems(
+        items: List<com.android.purebilibili.data.model.response.VideoItem>,
+        feedKind: FeedKind = FeedKind.GENERIC
+    ): List<com.android.purebilibili.data.model.response.VideoItem> {
         val feedPlugins = getEnabledFeedPlugins()
         if (feedPlugins.isEmpty()) return items
         
         return items.filter { item ->
             feedPlugins.all { plugin ->
                 try {
-                    plugin.shouldShowItem(item)
+                    plugin.shouldShowItem(item, feedKind)
                 } catch (e: Exception) {
                     Logger.e(TAG, " Feed plugin failed: ${plugin.name}", e)
                     true

--- a/app/src/main/java/com/android/purebilibili/data/model/response/ListModels.kt
+++ b/app/src/main/java/com/android/purebilibili/data/model/response/ListModels.kt
@@ -198,6 +198,7 @@ data class VideoItem(
     val view_at: Long = 0,
     val pubdate: Long = 0,
     val isVertical: Boolean = false,  //  是否为竖屏视频
+    val isFollowed: Boolean = false,  //  是否已关注该 UP 主(web 推荐接口的 is_followed)
     val isCollectionResource: Boolean = false,
     val collectionId: Long = 0,
     val collectionMid: Long = 0,
@@ -316,7 +317,11 @@ data class RecommendItem(
     val tname: String = "",
     //  [新增] 视频尺寸信息 (用于判断竖屏视频)
     val dimension: Dimension? = null,
-    val rights: VideoRights? = null
+    val rights: VideoRights? = null,
+    //  [新增] 是否已关注该 UP 主(推荐流过滤已关注豁免用; 接口返回 0/1 整数)
+    @SerialName("is_followed")
+    @Serializable(with = FlexibleBooleanSerializer::class)
+    val isFollowed: Boolean = false
 ) {
     fun toVideoItem(): VideoItem {
         return VideoItem(
@@ -338,6 +343,7 @@ data class RecommendItem(
             duration = duration ?: 0,
             pubdate = pubdate ?: 0L,
             isVertical = dimension?.isVertical == true,
+            isFollowed = isFollowed,
             rights = rights
         )
     }

--- a/app/src/main/java/com/android/purebilibili/feature/home/HomeViewModel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/home/HomeViewModel.kt
@@ -4,6 +4,7 @@ package com.android.purebilibili.feature.home
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.android.purebilibili.core.plugin.FeedKind
 import com.android.purebilibili.core.plugin.PluginManager
 import com.android.purebilibili.core.plugin.RecommendationCreatorSignal
 import com.android.purebilibili.core.plugin.RecommendationFeedbackSignals
@@ -92,6 +93,20 @@ internal fun resolveRecommendFeedRequestIndex(
         currentRefreshIndex + 1
     } else {
         0
+    }
+}
+
+/**
+ * 首页分类 → 插件信息流来源(供 FeedPlugin 按来源区分过滤行为)。
+ */
+internal fun HomeCategory.toFeedKind(popularSubCategory: PopularSubCategory? = null): FeedKind {
+    return when (this) {
+        HomeCategory.RECOMMEND -> FeedKind.HOME_RECOMMEND
+        HomeCategory.POPULAR -> when (popularSubCategory) {
+            PopularSubCategory.RANKING -> FeedKind.HOME_RANK
+            else -> FeedKind.HOME_POPULAR
+        }
+        else -> FeedKind.HOME_REGION
     }
 }
 
@@ -390,10 +405,11 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     // [Feature] Re-filter all content when block list changes
     private fun reFilterAllContent() {
         val oldState = _uiState.value
-        val newCategoryStates = oldState.categoryStates.mapValues { (_, content) ->
+        val newCategoryStates = oldState.categoryStates.mapValues { (category, content) ->
             content.copy(
                 videos = PluginManager.filterFeedItems(
-                    filterHomeFeedbackVideos(content.videos.filter { it.owner.mid !in blockedMids })
+                    filterHomeFeedbackVideos(content.videos.filter { it.owner.mid !in blockedMids }),
+                    feedKind = category.toFeedKind(popularSubCategory.value)
                 ).toImmutableList(),
                 // Filter live rooms if possible (assuming uid matches mid)
                 liveRooms = content.liveRooms.filter { it.uid !in blockedMids }.toImmutableList(),
@@ -1304,7 +1320,10 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
             //  [Feature] 应用屏蔽 + 原生插件 + JSON 规则插件过滤器
             val blockedFiltered = validVideos.filter { video -> video.owner.mid !in blockedMids }
             val feedbackFiltered = filterHomeFeedbackVideos(blockedFiltered)
-            val builtinFiltered = PluginManager.filterFeedItems(feedbackFiltered)
+            val builtinFiltered = PluginManager.filterFeedItems(
+                feedbackFiltered,
+                feedKind = currentCategory.toFeedKind(popularSubCategory)
+            )
             val filteredVideos = com.android.purebilibili.core.plugin.json.JsonPluginManager
                 .filterVideos(builtinFiltered)
             

--- a/app/src/main/java/com/android/purebilibili/feature/plugin/PiliNaraFeedFilterPlugin.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/plugin/PiliNaraFeedFilterPlugin.kt
@@ -1,0 +1,486 @@
+// 文件路径: feature/plugin/PiliNaraFeedFilterPlugin.kt
+package com.android.purebilibili.feature.plugin
+
+import android.util.Log
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.android.purebilibili.core.plugin.FeedKind
+import com.android.purebilibili.core.plugin.FeedPlugin
+import com.android.purebilibili.core.plugin.PluginManager
+import com.android.purebilibili.core.plugin.PluginStore
+import com.android.purebilibili.core.ui.AppAlertDialog
+import com.android.purebilibili.core.ui.AppDialogAction
+import com.android.purebilibili.core.ui.components.AppNativeSegmentedControl
+import com.android.purebilibili.core.ui.components.AppOutlinedTextField
+import com.android.purebilibili.core.ui.components.AppSegmentOption
+import com.android.purebilibili.core.ui.components.AppSwitchPreference
+import com.android.purebilibili.core.ui.components.AppText
+import com.android.purebilibili.data.model.response.VideoItem
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * 推荐流过滤插件(移植自 PiliNara 的「推荐流设置」RecommendFilter)。
+ *
+ * 过滤规则: 白名单豁免 → 视频时长 → 播放量/点赞率 → 标题关键词 → 本地屏蔽用户 →
+ * 分区关键词(tname)。已关注 UP 主可豁免(推荐流)。
+ *
+ * 默认关闭, 可在插件中心启用; 各规则阈值与 PiliNara 默认值一致(0 = 不过滤)。
+ */
+class PiliNaraFeedFilterPlugin : FeedPlugin {
+
+    override val id = "pilinara_feed_filter"
+    override val name = "推荐流过滤"
+    override val description = "移植自 PiliNara 的推荐流过滤: 时长/播放量/点赞率/标题关键词/屏蔽用户/白名单"
+    override val version = "1.0.0"
+    override val author = "qyo123oyq"
+
+    private var config = PiliNaraFeedFilterConfig()
+
+    // 编译期组装的正则(配置变更时重建)
+    private var rcmdRegExp: Regex? = null       // 标题关键词
+    private var zoneRegExp: Regex? = null       // 分区关键词(tname)
+
+    override suspend fun onEnable() {
+        loadConfig(PluginManager.getContext())
+        rebuildRegexes()
+        Log.d(TAG, "推荐流过滤已启用")
+    }
+
+    override suspend fun onDisable() {
+        Log.d(TAG, "推荐流过滤已禁用")
+    }
+
+    // ==================== 过滤规则(还原 PiliNara RecommendFilter) ====================
+
+    override fun shouldShowItem(item: VideoItem): Boolean = shouldShowItem(item, FeedKind.HOME_RECOMMEND)
+
+    override fun shouldShowItem(item: VideoItem, feedKind: FeedKind): Boolean {
+        return shouldShowFeedItem(
+            config = config,
+            item = item,
+            feedKind = feedKind,
+            rcmdRegExp = rcmdRegExp,
+            zoneRegExp = zoneRegExp
+        )
+    }
+
+    // ==================== 配置持久化 ====================
+
+    private suspend fun loadConfig(context: android.content.Context) {
+        try {
+            val json = PluginStore.getConfigJson(context, id)
+            if (json != null) {
+                config = Json.decodeFromString(PiliNaraFeedFilterConfig.serializer(), json)
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "加载配置失败, 使用默认值: ${e.message}")
+        }
+    }
+
+    private fun rebuildRegexes() {
+        rcmdRegExp = parseBanWordToRegex(config.banWordForRecommend)?.let { Regex(it, RegexOption.IGNORE_CASE) }
+        zoneRegExp = parseBanWordToRegex(config.banWordForZone)?.let { Regex(it, RegexOption.IGNORE_CASE) }
+    }
+
+    private fun persistConfig(context: android.content.Context, next: PiliNaraFeedFilterConfig) {
+        config = next
+        rebuildRegexes()
+        com.android.purebilibili.core.coroutines.AppScope.ioScope.launch {
+            PluginStore.setConfigJson(context, id, Json.encodeToString(PiliNaraFeedFilterConfig.serializer(), next))
+        }
+    }
+
+    // ==================== 设置 UI ====================
+
+    @Composable
+    override fun SettingsContent() {
+        FeedFilterSettingsContent(Modifier.padding(16.dp))
+    }
+
+    @Composable
+    override fun SettingsContent(modifier: Modifier) {
+        FeedFilterSettingsContent(modifier)
+    }
+
+    @Composable
+    private fun FeedFilterSettingsContent(modifier: Modifier = Modifier) {
+        val context = androidx.compose.ui.platform.LocalContext.current
+        val scope = rememberCoroutineScope()
+        var loaded by remember { mutableStateOf(false) }
+        var cfg by remember { mutableStateOf(config) }
+
+        LaunchedEffect(Unit) {
+            loadConfig(context)
+            cfg = config
+            loaded = true
+        }
+        if (!loaded) return
+
+        fun persist(next: PiliNaraFeedFilterConfig) {
+            cfg = next
+            config = next
+            rebuildRegexes()
+            scope.launch {
+                PluginStore.setConfigJson(context, id, Json.encodeToString(PiliNaraFeedFilterConfig.serializer(), next))
+            }
+        }
+
+        Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            FilterSection("过滤规则") {
+                NumericCustomSelect(
+                    title = "视频时长过滤",
+                    subtitle = "隐藏时长小于该值的视频(秒)",
+                    presets = listOf(
+                        0L to "不过滤",
+                        30L to "30 秒",
+                        60L to "60 秒",
+                        90L to "90 秒",
+                        120L to "120 秒",
+                    ),
+                    selected = cfg.minDurationForRcmd,
+                    customMarker = -1L,
+                    parse = { it.toLongOrNull()?.coerceAtLeast(0L) },
+                    onSelect = { persist(cfg.copy(minDurationForRcmd = it)) }
+                )
+                NumericCustomSelect(
+                    title = "播放量过滤",
+                    subtitle = "隐藏播放量低于该值的视频",
+                    presets = listOf(
+                        0L to "不过滤",
+                        50L to "50",
+                        100L to "100",
+                        500L to "500",
+                        1000L to "1000",
+                    ),
+                    selected = cfg.minPlayForRcmd,
+                    customMarker = -1L,
+                    parse = { it.toLongOrNull()?.coerceAtLeast(0L) },
+                    onSelect = { persist(cfg.copy(minPlayForRcmd = it)) }
+                )
+                NumericCustomSelect(
+                    title = "点赞率过滤",
+                    subtitle = "隐藏点赞率低于该值的视频(%)",
+                    presets = listOf(
+                        0 to "不过滤",
+                        1 to "1%",
+                        2 to "2%",
+                        3 to "3%",
+                        4 to "4%",
+                    ),
+                    selected = cfg.minLikeRatioForRecommend,
+                    customMarker = -1,
+                    parse = { it.toIntOrNull()?.coerceAtLeast(0) },
+                    onSelect = { persist(cfg.copy(minLikeRatioForRecommend = it)) }
+                )
+                AppSwitchPreference(
+                    title = "已关注 UP 主豁免",
+                    subtitle = "推荐流中已关注的 UP 主不受过滤影响",
+                    checked = cfg.exemptFilterForFollowed,
+                    onCheckedChange = { persist(cfg.copy(exemptFilterForFollowed = it)) }
+                )
+            }
+
+            FilterSection("关键词过滤") {
+                KeywordField(
+                    title = "标题关键词",
+                    subtitle = "每行一个关键词, 支持正则",
+                    value = cfg.banWordForRecommend,
+                    onValue = { persist(cfg.copy(banWordForRecommend = it)) }
+                )
+                KeywordField(
+                    title = "分区关键词",
+                    subtitle = "按视频分区名(tname)过滤, 每行一个, 支持正则",
+                    value = cfg.banWordForZone,
+                    onValue = { persist(cfg.copy(banWordForZone = it)) }
+                )
+            }
+
+            FilterSection("屏蔽用户 / 白名单") {
+                KeywordField(
+                    title = "屏蔽用户",
+                    subtitle = "每行一个 UID, 推荐流中隐藏其视频",
+                    value = config.recommendBlockedMids.toEditorText(),
+                    onValue = {
+                        persist(cfg.copy(recommendBlockedMids = parseUidMap(it)))
+                    }
+                )
+                KeywordField(
+                    title = "白名单用户",
+                    subtitle = "每行一个 UID, 白名单用户完全豁免过滤",
+                    value = config.whitelistMids.toEditorText(),
+                    onValue = {
+                        persist(cfg.copy(whitelistMids = parseUidMap(it)))
+                    }
+                )
+            }
+
+            FilterSection("应用于其他信息流") {
+                AppSwitchPreference(
+                    title = "过滤器也应用于热门视频",
+                    checked = cfg.applyToHotVideos,
+                    onCheckedChange = { persist(cfg.copy(applyToHotVideos = it)) }
+                )
+                AppSwitchPreference(
+                    title = "过滤器也应用于排行榜",
+                    checked = cfg.applyToRankVideos,
+                    onCheckedChange = { persist(cfg.copy(applyToRankVideos = it)) }
+                )
+                AppSwitchPreference(
+                    title = "过滤器也应用于搜索结果",
+                    checked = cfg.applyToSearch,
+                    onCheckedChange = { persist(cfg.copy(applyToSearch = it)) }
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun FilterSection(title: String, content: @Composable ColumnScope.() -> Unit) {
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            AppText(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Surface(
+                modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(16.dp)),
+                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.38f),
+            ) {
+                Column(content = content)
+            }
+        }
+    }
+
+    @Composable
+    private fun <T : Number> NumericCustomSelect(
+        title: String,
+        subtitle: String,
+        presets: List<Pair<T, String>>,
+        selected: T,
+        customMarker: T,
+        parse: (String) -> T?,
+        onSelect: (T) -> Unit,
+    ) {
+        val isCustom = presets.none { it.first == selected }
+        var showDialog by remember { mutableStateOf(false) }
+        var draft by remember { mutableStateOf("") }
+        val options = presets.map { AppSegmentOption(it.first, it.second) } +
+            AppSegmentOption(customMarker, "自定义")
+
+        Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 8.dp)) {
+            AppText(
+                text = "$title($subtitle)",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            AppNativeSegmentedControl(
+                options = options,
+                selectedValue = if (isCustom) customMarker else selected,
+                modifier = Modifier.padding(top = 6.dp),
+                onSelectionChange = { value ->
+                    if (value == customMarker) {
+                        draft = "$selected"
+                        showDialog = true
+                    } else {
+                        onSelect(value)
+                    }
+                }
+            )
+            if (isCustom) {
+                AppText(
+                    text = "当前值: $selected",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+            }
+        }
+
+        if (showDialog) {
+            AppAlertDialog(
+                onDismissRequest = { showDialog = false },
+                title = { AppText("自定义$title") },
+                text = {
+                    AppOutlinedTextField(
+                        value = draft,
+                        onValueChange = { draft = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                    )
+                },
+                confirmButton = {
+                    AppDialogAction(onClick = {
+                        parse(draft.trim())?.let { onSelect(it) }
+                        showDialog = false
+                    }) { AppText("确定") }
+                },
+                dismissButton = {
+                    AppDialogAction(onClick = { showDialog = false }) { AppText("取消") }
+                }
+            )
+        }
+    }
+
+    @Composable
+    private fun KeywordField(
+        title: String,
+        subtitle: String,
+        value: String,
+        onValue: (String) -> Unit,
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            AppText(
+                text = title,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            if (subtitle.isNotEmpty()) {
+                AppText(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            AppOutlinedTextField(
+                value = value,
+                onValueChange = onValue,
+                modifier = Modifier.fillMaxWidth().padding(top = 6.dp),
+                minLines = 2,
+                maxLines = 6,
+            )
+        }
+    }
+
+    internal companion object {
+        const val TAG = "PiliNaraFeedFilterPlugin"
+
+        /**
+         * 移植 PiliNara Pref.parseBanWordToRegex:
+         * 换行分隔、trim、去空; 含 `|` 且不以 `(` 开头的项包成 `(item)`; 最后用 `|` 连接。
+         */
+        fun parseBanWordToRegex(stored: String): String? {
+            val items = stored.split('\n')
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .toMutableList()
+            if (items.isEmpty()) return null
+            val normalized = items.map { item ->
+                if (item.contains('|') && !item.startsWith("(")) "($item)" else item
+            }
+            return normalized.joinToString("|")
+        }
+
+        /** 纯数字行 → mid; 其余行按 "名称 (UID)" 或 "UID" 解析 */
+        fun parseUidMap(text: String): Map<Long, String> {
+            val result = LinkedHashMap<Long, String>()
+            for (line in text.split('\n')) {
+                val trimmed = line.trim()
+                if (trimmed.isEmpty()) continue
+                val mid = extractMid(trimmed)
+                if (mid != null) result[mid] = trimmed
+            }
+            return result
+        }
+
+        private fun extractMid(line: String): Long? {
+            // 支持 "名称 (123456)" 与纯数字 "123456"
+            Regex("(\\d+)").find(line)?.groupValues?.get(1)?.toLongOrNull()?.let { return it }
+            return line.toLongOrNull()
+        }
+    }
+}
+
+/** 插件配置(默认值对齐 PiliNara) */
+@Serializable
+data class PiliNaraFeedFilterConfig(
+    val minDurationForRcmd: Long = 0,                  // 最小时长(秒), 0 不过滤
+    val minPlayForRcmd: Long = 0,                      // 最小播放量, 0 不过滤
+    val minLikeRatioForRecommend: Int = 0,             // 最小点赞率(%), 0 不过滤
+    val banWordForRecommend: String = "",              // 标题关键词(换行分隔)
+    val banWordForZone: String = "",                   // 分区关键词(tname, 换行分隔)
+    val recommendBlockedMids: Map<Long, String> = emptyMap(), // 本地推荐屏蔽用户
+    val whitelistMids: Map<Long, String> = emptyMap(), // 白名单用户
+    val exemptFilterForFollowed: Boolean = true,       // 已关注豁免
+    val applyToHotVideos: Boolean = false,             // 应用于热门
+    val applyToRankVideos: Boolean = false,            // 应用于排行榜
+    val applyToSearch: Boolean = false                 // 应用于搜索
+)
+
+private fun Map<Long, String>.toEditorText(): String = entries.joinToString("\n") { (mid, name) ->
+    if (name.isBlank() || name == "UID:$mid") mid.toString() else "$name ($mid)"
+}
+
+/**
+ * 推荐流过滤规则(纯函数, 便于单元测试)。
+ * 还原 PiliNara RecommendFilter: 白名单 → 时长 → 播放量/点赞率 → 标题关键词 → 屏蔽用户 → 分区关键词。
+ * 返回 true 表示显示, false 表示隐藏。
+ */
+internal fun shouldShowFeedItem(
+    config: PiliNaraFeedFilterConfig,
+    item: VideoItem,
+    feedKind: FeedKind,
+    rcmdRegExp: Regex?,
+    zoneRegExp: Regex?
+): Boolean {
+    // 按来源开关: PiliNara 的「过滤器也应用于热门/排行/搜索」
+    val allowedByKind = when (feedKind) {
+        FeedKind.HOME_POPULAR -> config.applyToHotVideos
+        FeedKind.HOME_RANK -> config.applyToRankVideos
+        FeedKind.SEARCH -> config.applyToSearch
+        else -> true
+    }
+    if (!allowedByKind) return true
+
+    val mid = item.owner.mid
+    // 白名单: 最高优先级豁免
+    if (mid > 0L && config.whitelistMids.containsKey(mid)) return true
+
+    // 已关注豁免(仅推荐流, 与 PiliNara filter() 一致; 其余来源用 filterAll 无豁免)
+    if (feedKind == FeedKind.HOME_RECOMMEND && item.isFollowed && config.exemptFilterForFollowed) {
+        return true
+    }
+
+    // 时长过滤: duration > 0 && < minDuration
+    if (item.duration > 0 && item.duration < config.minDurationForRcmd) return false
+
+    // 播放量 / 点赞率(整数乘法, 避免浮点)
+    val view = item.stat.view.toLong()
+    val like = item.stat.like.toLong()
+    if (view >= 0 && (view < config.minPlayForRcmd ||
+            (like > -1 && like * 100L < config.minLikeRatioForRecommend * view))) {
+        return false
+    }
+
+    // 标题关键词
+    if (rcmdRegExp != null && rcmdRegExp.containsMatchIn(item.title)) return false
+
+    // 本地屏蔽用户
+    if (mid > 0L && config.recommendBlockedMids.isNotEmpty() && config.recommendBlockedMids.containsKey(mid)) {
+        return false
+    }
+
+    // 分区关键词(tname)
+    if (item.tname.isNotEmpty() && zoneRegExp != null && zoneRegExp.containsMatchIn(item.tname)) {
+        return false
+    }
+
+    return true
+}

--- a/app/src/main/java/com/android/purebilibili/feature/search/SearchViewModel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/search/SearchViewModel.kt
@@ -12,6 +12,7 @@ import com.android.purebilibili.data.model.response.SearchTopicItem
 import com.android.purebilibili.data.model.response.VideoItem
 import com.android.purebilibili.data.model.response.SearchUpItem
 import com.android.purebilibili.data.model.response.SearchType
+import com.android.purebilibili.core.plugin.FeedKind
 import com.android.purebilibili.data.model.response.BangumiSearchItem
 import com.android.purebilibili.data.model.response.LiveRoomSearchItem
 import com.android.purebilibili.data.repository.SearchRepository
@@ -555,7 +556,7 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
                     result.onSuccess { (videos, pageInfo) ->
                         if (!shouldApplySearchResult(searchSessionId, activeSearchSessionId, normalizedKeyword, _uiState.value.query, searchType, _uiState.value.searchType)) return@onSuccess
                         val nativeFiltered = videos.filter { it.owner.mid !in blockedMids }
-                        val builtinFiltered = com.android.purebilibili.core.plugin.PluginManager.filterFeedItems(nativeFiltered)
+                        val builtinFiltered = com.android.purebilibili.core.plugin.PluginManager.filterFeedItems(nativeFiltered, feedKind = FeedKind.SEARCH)
                         val filteredVideos = com.android.purebilibili.core.plugin.json.JsonPluginManager.filterVideos(builtinFiltered)
                         _uiState.update {
                             it.copy(
@@ -936,7 +937,7 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
                         if (!shouldApplySearchResult(searchSessionId, activeSearchSessionId, state.query, _uiState.value.query, state.searchType, _uiState.value.searchType)) return@onSuccess
                         val nativeFiltered = videos.filter { it.owner.mid !in blockedMids }
                         val builtinFiltered = com.android.purebilibili.core.plugin.PluginManager
-                            .filterFeedItems(nativeFiltered)
+                            .filterFeedItems(nativeFiltered, feedKind = FeedKind.SEARCH)
                         val filteredVideos = com.android.purebilibili.core.plugin.json.JsonPluginManager
                             .filterVideos(builtinFiltered)
 

--- a/app/src/test/java/com/android/purebilibili/feature/plugin/PiliNaraFeedFilterPluginTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/plugin/PiliNaraFeedFilterPluginTest.kt
@@ -1,0 +1,215 @@
+package com.android.purebilibili.feature.plugin
+
+import com.android.purebilibili.core.plugin.FeedKind
+import com.android.purebilibili.data.model.response.Owner
+import com.android.purebilibili.data.model.response.Stat
+import com.android.purebilibili.data.model.response.VideoItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * 推荐流过滤规则测试(纯函数, 对齐 PiliNara RecommendFilter)。
+ */
+class PiliNaraFeedFilterPluginTest {
+
+    private fun video(
+        title: String = "普通视频",
+        mid: Long = 1001,
+        duration: Int = 300,
+        view: Int = 100_000,
+        like: Int = 5_000,
+        tname: String = "",
+        isFollowed: Boolean = false
+    ) = VideoItem(
+        bvid = "BV1",
+        title = title,
+        owner = Owner(mid = mid, name = "UP$mid"),
+        stat = Stat(view = view, like = like),
+        duration = duration,
+        tname = tname,
+        isFollowed = isFollowed
+    )
+
+    private fun rules(
+        minDuration: Long = 0,
+        minPlay: Long = 0,
+        minLikeRatio: Int = 0,
+        banWords: String = "",
+        zoneWords: String = "",
+        blockedMids: Map<Long, String> = emptyMap(),
+        whitelistMids: Map<Long, String> = emptyMap(),
+        exemptFollowed: Boolean = true,
+        applyHot: Boolean = false,
+        applyRank: Boolean = false,
+        applySearch: Boolean = false
+    ): PiliNaraFeedFilterConfig = PiliNaraFeedFilterConfig(
+        minDurationForRcmd = minDuration,
+        minPlayForRcmd = minPlay,
+        minLikeRatioForRecommend = minLikeRatio,
+        banWordForRecommend = banWords,
+        banWordForZone = zoneWords,
+        recommendBlockedMids = blockedMids,
+        whitelistMids = whitelistMids,
+        exemptFilterForFollowed = exemptFollowed,
+        applyToHotVideos = applyHot,
+        applyToRankVideos = applyRank,
+        applyToSearch = applySearch
+    )
+
+    private fun show(
+        cfg: PiliNaraFeedFilterConfig,
+        item: VideoItem,
+        kind: FeedKind = FeedKind.HOME_RECOMMEND
+    ): Boolean = shouldShowFeedItem(
+        config = cfg,
+        item = item,
+        feedKind = kind,
+        rcmdRegExp = PiliNaraFeedFilterPlugin.parseBanWordToRegex(cfg.banWordForRecommend)
+            ?.let { Regex(it, RegexOption.IGNORE_CASE) },
+        zoneRegExp = PiliNaraFeedFilterPlugin.parseBanWordToRegex(cfg.banWordForZone)
+            ?.let { Regex(it, RegexOption.IGNORE_CASE) }
+    )
+
+    // ==================== 基础规则 ====================
+
+    @Test
+    fun `default config shows everything`() {
+        assertTrue(show(rules(), video()))
+    }
+
+    @Test
+    fun `hides short videos below min duration`() {
+        val cfg = rules(minDuration = 60)
+        assertFalse(show(cfg, video(duration = 30)))
+        assertTrue(show(cfg, video(duration = 120)))
+    }
+
+    @Test
+    fun `unknown duration is not filtered`() {
+        // duration <= 0 视为无数据, 不拦截
+        assertTrue(show(rules(minDuration = 60), video(duration = 0)))
+    }
+
+    @Test
+    fun `hides low play videos`() {
+        val cfg = rules(minPlay = 1000)
+        assertFalse(show(cfg, video(view = 500)))
+        assertTrue(show(cfg, video(view = 5000)))
+    }
+
+    @Test
+    fun `hides low like ratio videos`() {
+        val cfg = rules(minLikeRatio = 2)
+        // 点赞率 100/100000 = 0.1% < 2% → 隐藏
+        assertFalse(show(cfg, video(view = 100_000, like = 100)))
+        // like*100=10000 < 2*10000=20000 → 隐藏
+        assertFalse(show(cfg, video(view = 10_000, like = 100)))
+        // 点赞率 5000/100000 = 5% >= 2% → 显示
+        assertTrue(show(cfg, video(view = 100_000, like = 5_000)))
+    }
+
+    @Test
+    fun `hides titles matching keywords`() {
+        val cfg = rules(banWords = "广告\n震惊")
+        assertFalse(show(cfg, video(title = "震惊!必看")))
+        assertFalse(show(cfg, video(title = "免费广告引流")))
+        assertTrue(show(cfg, video(title = "正常视频")))
+    }
+
+    @Test
+    fun `hides blocked users`() {
+        val cfg = rules(blockedMids = mapOf(2001L to "屏蔽UP"))
+        assertFalse(show(cfg, video(mid = 2001)))
+        assertTrue(show(cfg, video(mid = 3001)))
+    }
+
+    @Test
+    fun `whitelist exempts all rules`() {
+        val cfg = rules(banWords = "广告", blockedMids = mapOf(2001L to "UP"), whitelistMids = mapOf(2001L to "白名单"))
+        assertTrue(show(cfg, video(mid = 2001, title = "广告标题")))
+    }
+
+    @Test
+    fun `zone keywords filter by tname`() {
+        val cfg = rules(zoneWords = "游戏")
+        assertFalse(show(cfg, video(tname = "游戏区")))
+        assertTrue(show(cfg, video(tname = "音乐区")))
+    }
+
+    // ==================== 已关注豁免 ====================
+
+    @Test
+    fun `followed videos exempt in recommend feed`() {
+        val cfg = rules(minDuration = 60)
+        assertTrue(show(cfg, video(duration = 10, isFollowed = true)))
+        assertFalse(show(cfg, video(duration = 10, isFollowed = false)))
+    }
+
+    @Test
+    fun `followed exemption can be disabled`() {
+        val cfg = rules(minDuration = 60, exemptFollowed = false)
+        assertFalse(show(cfg, video(duration = 10, isFollowed = true)))
+    }
+
+    @Test
+    fun `followed exemption only applies to recommend feed`() {
+        // 需开启热门过滤, 规则才会真正执行
+        val cfg = rules(minDuration = 60, applyHot = true)
+        // 推荐流: 已关注豁免生效
+        assertTrue(show(cfg, video(duration = 10, isFollowed = true), kind = FeedKind.HOME_RECOMMEND))
+        // 热门: 无已关注豁免(filterAll 语义), 时长短被过滤
+        assertFalse(show(cfg, video(duration = 10, isFollowed = true), kind = FeedKind.HOME_POPULAR))
+    }
+
+    // ==================== 按来源开关 ====================
+
+    @Test
+    fun `hot feed filtered only when applyToHotVideos on`() {
+        val cfg = rules(minDuration = 60, applyHot = false)
+        assertTrue(show(cfg, video(duration = 10), kind = FeedKind.HOME_POPULAR))
+
+        val cfgOn = rules(minDuration = 60, applyHot = true)
+        assertFalse(show(cfgOn, video(duration = 10), kind = FeedKind.HOME_POPULAR))
+    }
+
+    @Test
+    fun `search filtered only when applyToSearch on`() {
+        val cfg = rules(banWords = "广告", applySearch = false)
+        assertTrue(show(cfg, video(title = "广告"), kind = FeedKind.SEARCH))
+
+        val cfgOn = rules(banWords = "广告", applySearch = true)
+        assertFalse(show(cfgOn, video(title = "广告"), kind = FeedKind.SEARCH))
+    }
+
+    @Test
+    fun `rank filtered only when applyToRankVideos on`() {
+        val cfg = rules(minDuration = 60, applyRank = false)
+        assertTrue(show(cfg, video(duration = 10), kind = FeedKind.HOME_RANK))
+
+        val cfgOn = rules(minDuration = 60, applyRank = true)
+        assertFalse(show(cfgOn, video(duration = 10), kind = FeedKind.HOME_RANK))
+    }
+
+    // ==================== 工具函数 ====================
+
+    @Test
+    fun `parseBanWordToRegex joins lines with pipe`() {
+        assertEquals("广告|震惊", PiliNaraFeedFilterPlugin.parseBanWordToRegex("广告\n震惊"))
+        assertEquals("(a|b)|c", PiliNaraFeedFilterPlugin.parseBanWordToRegex("a|b\nc"))
+        assertEquals(null, PiliNaraFeedFilterPlugin.parseBanWordToRegex(""))
+        assertEquals(null, PiliNaraFeedFilterPlugin.parseBanWordToRegex("\n  \n"))
+    }
+
+    @Test
+    fun `parseUidMap parses plain and named uids`() {
+        val map = PiliNaraFeedFilterPlugin.parseUidMap("123456\n某某UP (789012)")
+        assertEquals(setOf(123456L, 789012L), map.keys)
+    }
+
+    @Test
+    fun `parseUidMap ignores empty lines`() {
+        assertTrue(PiliNaraFeedFilterPlugin.parseUidMap("\n\n").isEmpty())
+    }
+}


### PR DESCRIPTION
## What

新增「推荐流过滤」原生插件(移植自 PiliNara 的 RecommendFilter / 推荐流设置),**默认关闭**,可在 设置 → 插件中心 启用,不影响原有功能。

**改动文件与内容(8 个文件,+768 行):**

| 文件 | 修改部分 | 更改方面 |
|---|---|---|
| `feature/plugin/PiliNaraFeedFilterPlugin.kt`(新增) | 插件主体 | 过滤规则:白名单豁免 → 时长 → 播放量/点赞率(整数乘法) → 标题关键词(正则) → 本地屏蔽用户 → 分区关键词(tname);已关注 UP 豁免(推荐流);时长/播放量/点赞率支持**自定义数值**;按来源开关(热门/排行/搜索);完整设置页(关键词/UID 编辑等) |
| `core/plugin/FeedPlugin.kt` | 新增 `FeedKind` 枚举 + `shouldShowItem(item, feedKind)` | 让插件能按信息流来源区分行为(默认委托旧方法,**向后兼容**,AdFilterPlugin 不受影响) |
| `core/plugin/PluginManager.kt` | `filterFeedItems` 增加 `feedKind` 参数 | 把来源传给插件(默认 GENERIC,向后兼容) |
| `data/model/response/ListModels.kt` | `VideoItem` 新增 `isFollowed` | 解析 web 推荐接口的 `is_followed`(用既有 `FlexibleBooleanSerializer` 兼容 0/1/true/false),支撑已关注豁免 |
| `feature/home/HomeViewModel.kt` | 两处 `filterFeedItems` 传入 `FeedKind` + `HomeCategory.toFeedKind()` | 推荐/热门/排行/分区来源区分 |
| `feature/search/SearchViewModel.kt` | 两处 `filterFeedItems` 传入 `FeedKind.SEARCH` | 搜索来源区分 |
| `app/PureApplication.kt` | 注册插件 | 默认关闭,插件中心可开关 |
| `feature/plugin/PiliNaraFeedFilterPluginTest.kt`(新增) | 17 个单元测试 | 覆盖全部规则/豁免/来源开关/工具函数 |

## Why

- PiliNara 的「推荐流设置」提供了时长/播放量/点赞率/标题关键词/屏蔽用户/白名单等过滤能力,移植为原生插件让 BiliPai 用户可选启用。
- 做成**默认关闭的插件**,避免影响原有功能;按 PiliNara 语义还原各规则的触发条件(含整数乘法避免浮点、白名单最高优先级豁免、已关注豁免仅推荐流等)。

## How

- `FeedKind` 扩展让插件能区分 推荐/热门/排行/分区/搜索,从而还原 PiliNara 的「过滤器也应用于热门/排行/搜索」开关(默认仅推荐流生效)。
- 阈值控件支持「自定义」输入(弹窗填任意数值),超出预设档位时显示当前值。
- 配置持久化走 `PluginStore`(@Serializable),标题/分区关键词用 `parseBanWordToRegex`(换行分隔、`|` 分组、不区分大小写)。

## Testing

- 单元测试:`PiliNaraFeedFilterPluginTest` 17 个用例全部通过(时长/播放量/点赞率/关键词/屏蔽用户/白名单/已关注豁免/按来源开关/parseUidMap/parseBanWordToRegex)。
- `:app:compileDebugKotlin` / `:app:assembleDebug` 通过。
- ⚠️ **既有失败(与本次改动无关)**:`FrameBudgetLintTest#settingsSyncCallSitesDoNotGrow` 在 **origin/main 基线上同样失败**(上游新提交新增了 `SettingsManager.*Sync` 调用,超出棘轮上限 89;main 当前 CI 已红)。本次改动未新增任何 `SettingsManager.*Sync` 调用(过滤插件使用 `PluginStore`),故未调整该棘轮,交由上游提交者处理。

## Related Issues

无