### PR TITLE
fix(video): 合集内选集播放完毕后自动连播回跳到原集的问题

### DIFF
--- a/app/src/main/java/com/android/purebilibili/feature/video/screen/VideoDetailScreenStateHolder.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/screen/VideoDetailScreenStateHolder.kt
@@ -2675,6 +2675,18 @@ internal fun VideoDetailScreenStateHolder(
             presentationState.switchVideo(managerBvid, managerCid)
             return@LaunchedEffect
         }
+        if (
+            shouldSkipInternalBvidSyncForPlayerInitiatedAdvance(
+                loadedBvid = success.info.bvid,
+                inPageInitiatedBvid = viewModel.peekInPageInitiatedPlaybackIdentityBvid()
+            )
+        ) {
+            // 播放器内部已自动推进（合集/队列下一集等）：身份错位是预期状态。
+            // 既不能像“presentation 领先”那样重载旧视频，也不能把 presentation 同步到新集数——
+            // 后者会中途改写 bvid 键控的 UI 状态（封面揭示/控制层），而此时没有新的首帧事件可恢复。
+            // 保持 presentation 原样与直开场景的行为一致。
+            return@LaunchedEffect
+        }
         if (!shouldSyncMainPlayerToInternalBvid(
                 isPortraitFullscreen = isPortraitFullscreen,
                 routeBvid = bvid,

--- a/app/src/main/java/com/android/purebilibili/feature/video/screen/VideoDetailSessionPolicy.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/screen/VideoDetailSessionPolicy.kt
@@ -285,6 +285,22 @@ internal fun shouldSyncMainPlayerToInternalBvid(
     return resolvedLoadedCid != targetCid
 }
 
+/**
+ * Whether a mismatch between the presentation identity and the freshly loaded player identity is
+ * the *expected* result of a player-initiated in-page advance (season/playlist auto-continue).
+ * In that case the detail screen must neither reload the old video nor sync presentation:
+ * auto-advance keeps the presentation identity stale exactly like route-driven playback does,
+ * and syncing mid-playback would restart bvid-keyed UI state (cover reveal, controls) that the
+ * screen has no fresh first-frame event to recover from.
+ */
+internal fun shouldSkipInternalBvidSyncForPlayerInitiatedAdvance(
+    loadedBvid: String,
+    inPageInitiatedBvid: String?
+): Boolean {
+    val pendingBvid = inPageInitiatedBvid?.trim().takeUnless { it.isNullOrEmpty() } ?: return false
+    return pendingBvid == loadedBvid.trim()
+}
+
 internal fun resolveVideoDetailPlaybackTargetCid(
     routeBvid: String,
     routeCid: Long,

--- a/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/VideoPlaybackViewModel.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/video/viewmodel/VideoPlaybackViewModel.kt
@@ -1736,6 +1736,25 @@ class VideoPlaybackViewModel(application: Application) : AndroidViewModel(applic
     private var pageSwitchGeneration: Long = 0L
     private var pendingPageSwitchCid: Long? = null
     private var onPageIdentityCommitted: ((String, Long) -> Unit)? = null
+
+    /**
+     * 最近一次由播放器内部发起的原地换片身份（bvid to cid，如合集/队列自动连播）。
+     * 详情页 presentation 守卫用它区分“VM 自己推进了身份”（预期错位：既不重载旧视频，
+     * 也不同步 presentation，保持与直开场景一致的陈旧 identity）
+     * 与“presentation 领先于 VM”（如从子详情页返回，应恢复旧视频）。
+     * UI 发起的切换（合集面板选集等）在调用 loadVideo 前已同步 presentation，不打此标记。
+     */
+    @Volatile
+    private var inPageInitiatedPlaybackIdentity: Pair<String, Long>? = null
+
+    internal fun peekInPageInitiatedPlaybackIdentityBvid(): String? {
+        return inPageInitiatedPlaybackIdentity?.first
+    }
+
+    private fun markInPageInitiatedPlayback(bvid: String, cid: Long) {
+        inPageInitiatedPlaybackIdentity = bvid to cid
+    }
+
     private var playerInfoJob: Job? = null
     private var aiSummaryJob: Job? = null
     private var videoNoteJob: Job? = null
@@ -2438,6 +2457,7 @@ class VideoPlaybackViewModel(application: Application) : AndroidViewModel(applic
                 toast("正在播放: ${nextItem.title}")
             }
             // 加载新视频 (Auto-play next always forces true)
+            markInPageInitiatedPlayback(nextItem.bvid, nextItem.cid)
             loadVideo(
                 nextItem.bvid,
                 cid = nextItem.cid,
@@ -2495,6 +2515,7 @@ class VideoPlaybackViewModel(application: Application) : AndroidViewModel(applic
         }
 
         val target = PlaylistManager.playAt(nextIndex) ?: return false
+        markInPageInitiatedPlayback(target.bvid, target.cid)
         loadVideo(
             target.bvid,
             cid = target.cid,
@@ -2521,6 +2542,7 @@ class VideoPlaybackViewModel(application: Application) : AndroidViewModel(applic
         if (previousIndex !in items.indices) return false
 
         val target = PlaylistManager.playAt(previousIndex) ?: return false
+        markInPageInitiatedPlayback(target.bvid, target.cid)
         loadVideo(
             target.bvid,
             cid = target.cid,
@@ -2637,6 +2659,7 @@ class VideoPlaybackViewModel(application: Application) : AndroidViewModel(applic
                 viewModelScope.launch {
                     toast("播放合集下一集: ${nextEpisode.title}")
                 }
+                markInPageInitiatedPlayback(nextEpisode.bvid, nextEpisode.cid)
                 loadVideo(
                     nextEpisode.bvid,
                     autoPlay = true,
@@ -2701,6 +2724,7 @@ class VideoPlaybackViewModel(application: Application) : AndroidViewModel(applic
                 viewModelScope.launch {
                     toast("播放合集上一集: ${previousEpisode.title}")
                 }
+                markInPageInitiatedPlayback(previousEpisode.bvid, previousEpisode.cid)
                 loadVideo(
                     previousEpisode.bvid,
                     autoPlay = true,
@@ -2853,6 +2877,7 @@ class VideoPlaybackViewModel(application: Application) : AndroidViewModel(applic
         viewModelScope.launch {
             toast("正在播放: ${item.title}")
         }
+        markInPageInitiatedPlayback(item.bvid, item.cid)
         loadVideo(
             bvid = item.bvid,
             cid = item.cid,
@@ -2869,6 +2894,7 @@ class VideoPlaybackViewModel(application: Application) : AndroidViewModel(applic
             viewModelScope.launch {
                 toast("正在播放: ${prevItem.title}")
             }
+            markInPageInitiatedPlayback(prevItem.bvid, prevItem.cid)
             loadVideo(
                 prevItem.bvid,
                 cid = prevItem.cid,
@@ -7430,6 +7456,7 @@ class VideoPlaybackViewModel(application: Application) : AndroidViewModel(applic
             }
         }
 
+        markInPageInitiatedPlayback(suggestion.targetBvid, suggestion.targetCid)
         loadVideo(
             bvid = suggestion.targetBvid,
             cid = suggestion.targetCid,

--- a/app/src/test/java/com/android/purebilibili/feature/video/screen/VideoDetailInternalBvidSyncPolicyTest.kt
+++ b/app/src/test/java/com/android/purebilibili/feature/video/screen/VideoDetailInternalBvidSyncPolicyTest.kt
@@ -145,6 +145,52 @@ class VideoDetailInternalBvidSyncPolicyTest {
     }
 
     @Test
+    fun loadedVideoMatchesInPageInitiatedBvid_shouldSkipInternalSync() {
+        assertTrue(
+            shouldSkipInternalBvidSyncForPlayerInitiatedAdvance(
+                loadedBvid = "BV_NEXT",
+                inPageInitiatedBvid = "BV_NEXT"
+            )
+        )
+    }
+
+    @Test
+    fun loadedVideoDiffersFromInPageInitiatedBvid_shouldKeepRestoreGuard() {
+        assertFalse(
+            shouldSkipInternalBvidSyncForPlayerInitiatedAdvance(
+                loadedBvid = "BV_CHILD",
+                inPageInitiatedBvid = "BV_NEXT"
+            )
+        )
+    }
+
+    @Test
+    fun blankOrMissingInPageInitiatedBvid_shouldKeepRestoreGuard() {
+        assertFalse(
+            shouldSkipInternalBvidSyncForPlayerInitiatedAdvance(
+                loadedBvid = "BV_NEXT",
+                inPageInitiatedBvid = null
+            )
+        )
+        assertFalse(
+            shouldSkipInternalBvidSyncForPlayerInitiatedAdvance(
+                loadedBvid = "BV_NEXT",
+                inPageInitiatedBvid = " "
+            )
+        )
+    }
+
+    @Test
+    fun inPageInitiatedBvidComparison_shouldTrimWhitespace() {
+        assertTrue(
+            shouldSkipInternalBvidSyncForPlayerInitiatedAdvance(
+                loadedBvid = "BV_NEXT",
+                inPageInitiatedBvid = " BV_NEXT "
+            )
+        )
+    }
+
+    @Test
     fun normalInternalSync_shouldRespectUserSettingByNotForcingAutoplay() {
         assertEquals(
             null,


### PR DESCRIPTION
## 问题

在一个视频(如a1)的视频详情页内通过**合集面板**切换到同合集的另一集（如 a5）后，该集播放完毕不会自动连播到下一集：画面会短暂跳到下一集（a6，约 0.5s），随后跳回原集(a5)并从头播放。直接打开合集内视频时的自动连播不受影响。

## 根因

详情页有一个 presentation 身份守卫（`VideoDetailScreenStateHolder` 中以 `shouldSyncMainPlayerToInternalBvid` 为核心的同步 effect）：当"屏幕记录的 bvid ≠ 播放器实际加载的 bvid"且屏幕身份不等于路由视频时，会重载屏幕记录的旧视频——其本意是**从子详情页返回时恢复父页面自己的播放**。

合集面板选集走的是"页内换片"（`switchVideoInCurrentDetailPage`，不压新导航栈），会把屏幕身份切到 a5；此后播放器内部自动连播到 a6 时，上述守卫把这次身份变化误判为"屏幕领先于播放器"，触发对 a5 的重载，造成回跳。

## 修复方案

- 播放器内部发起的原地换片（合集上/下一集、播放队列、推荐队列、音频模式切歌、跨视频续播建议）在提交身份时打上 `inPageInitiatedPlaybackIdentity` 标记（`VideoPlaybackViewModel`）。
- 详情页守卫在"已加载 bvid 与标记匹配"时视为**预期错位**：既不重载旧视频，也不同步 presentation，与直接打开视频时自动连播的既有行为保持一致（新增纯函数 `VideoDetailSessionPolicy.shouldSkipInternalBvidSyncForPlayerInitiatedAdvance`）。
- 分P 切换原本就有独立的身份同步（`onPageIdentityCommitted`），不受影响。

## 验证

- 新增策略测试 5 个用例（`VideoDetailInternalBvidSyncPolicyTest`）；`PlaybackCompletionPolicyTest`（15/15）、`PlaybackCoordinatorTest` 通过；`:app:compileDebugKotlin` 通过
- 真机（通过 `:app:assembleDev` 构建的测试安装包）自动化验证：合集视频第 110 集 → 播完自动连播至 111 集，无回跳，稳定停留在新集
- 分支已 rebase 到 main 最新（beta.21），与上游 17 个新提交无冲突

## By the way：本次排查中发现的另外两个独立问题（未包含在本 PR 中）

1. **"自动播放下一个"设置与"视频播完后"语义重叠**：该开关仅在"视频播完后 = 自动连播"时控制分P/合集是否续播；其余四种行为（播完暂停/顺序播放/单个循环/列表循环）均不读取它，且列表/收藏夹已有独立的"连续播放"开关。建议后续将其移除或并入"视频播完后"选择器（本次保持原样未动）。
2. **非 release 的测试构建包上，自动连播切换集数后点击播放器无响应**：通过仓库自带的 `:app:assembleDev` 任务构建的测试安装包（applicationId 带 `.dev` 后缀的变体）在合集自动连播切换集数后，单击播放器中间无法唤出控制层（双击播放/暂停、拖拽手势正常）；用**未修改的 main 代码**构建同样的测试包也能复现，release 正式包不受影响——与本次修改无关。建议另开任务排查（首发怀疑方向：全新安装的默认设置差异）。