### PR TITLE
fix(space): 修复主页播放全部误入音频模式的问题

### DIFF
--- a/app/src/main/java/com/android/purebilibili/feature/space/SpaceScreen.kt
+++ b/app/src/main/java/com/android/purebilibili/feature/space/SpaceScreen.kt
@@ -199,7 +199,6 @@ fun SpaceScreen(
     onLiveClick: (Long, String, String) -> Unit = { _, _, _ -> },
     onUserClick: (Long) -> Unit = {},
     onTopicClick: (Long) -> Unit = {},
-    onPlayAllAudioClick: ((String, Long) -> Unit)? = null,
     onDynamicDetailClick: (String) -> Unit = {},
     onArticleClick: (Long, String) -> Unit = { _, _ -> },
     onViewAllClick: (String, Long, Long, String, String) -> Unit = { _, _, _, _, _ -> },
@@ -282,8 +281,7 @@ fun SpaceScreen(
         )
         com.android.purebilibili.feature.video.player.PlaylistManager
             .setPlayMode(com.android.purebilibili.feature.video.player.PlayMode.SEQUENTIAL)
-        onPlayAllAudioClick?.invoke(startBvid, playbackTarget.resumePositionMs)
-            ?: onVideoClick(startBvid, playbackTarget.cid, playbackTarget.resumePositionMs)
+        onVideoClick(startBvid, playbackTarget.cid, playbackTarget.resumePositionMs)
     }
     val playedVideoBvid = targetBvid?.trim().orEmpty()
     val playedVideoLocatePromptEnabled by com.android.purebilibili.core.store.SettingsManager
@@ -561,7 +559,6 @@ fun SpaceScreen(
                             onLiveClick = onLiveClick,
                             onUserClick = onUserClick,
                             onTopicClick = onTopicClick,
-                            onPlayAllAudioClick = onPlayAllAudioClick,
                             onDynamicDetailClick = onDynamicDetailClick,
                             onArticleClick = onArticleClick,
                             onViewAllClick = onViewAllClick,
@@ -895,7 +892,6 @@ private fun SpaceContent(
     onLiveClick: (Long, String, String) -> Unit,
     onUserClick: (Long) -> Unit,
     onTopicClick: (Long) -> Unit,
-    onPlayAllAudioClick: ((String, Long) -> Unit)?,
     onDynamicDetailClick: (String) -> Unit,
     onArticleClick: (Long, String) -> Unit,
     onViewAllClick: (String, Long, Long, String, String) -> Unit,

--- a/app/src/main/java/com/android/purebilibili/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/android/purebilibili/navigation/AppNavigation.kt
@@ -3472,16 +3472,6 @@ fun AppNavigation(
                                             )
                                         }
                                     },
-                                    onPlayAllAudioClick = { bvid, resumePositionMs ->
-                                        navigateToVideoInNavigation3(
-                                            bvid = bvid,
-                                            cid = 0L,
-                                            coverUrl = "",
-                                            startAudio = true,
-                                            resumePositionMs = resumePositionMs,
-                                            sourceRoute = spaceKey.toLegacyRoute()
-                                        )
-                                    },
                                     onDynamicDetailClick = { dynamicId ->
                                         pushNavigation3Key(BiliPaiNavKey.DynamicDetail(dynamicId))
                                     },


### PR DESCRIPTION
## 问题

在一个 UP 主的主页（投稿页）点击菜单中的**「播放全部」**后，进入的是**音频播放界面**（听视频模式），只播放音频；需要手动点击返回才能回到**视频播放界面**。播放列表本身按当前排序正常生成（最高播放/最新发布等均受影响，顺序无问题）。且音频界面与视频界面**共享同一进度条**：在音频界面把进度拖到 5 分钟，返回视频界面后进度同样停在 5 分钟。直接点击单个视频播放不受影响。

## 根因

「播放全部」的处理 lambda **`playAllSpaceVideos`**（`SpaceScreen.kt`）中保留了音频优先的 Elvis 写法：**`onPlayAllAudioClick?.invoke(...) ?: onVideoClick(...)`**。

Git 历史溯源：**v6.3.1**（`7b4390a7f`）曾同时提供「播放全部」（视频）与独立**「全部听」**按钮（音频），音频回调优先的语义属于「全部听」。**v7.9.0** 重构（`56129dcf9`）删除「全部听」入口时，其 lambda 体被原样并入「播放全部」，音频优先语义被错误带入。而 `AppNavigation` 始终为 SpaceScreen 接线 `onPlayAllAudioClick`（**`startAudio = true`**，永不为 null），因此「播放全部」永远走**音频路径**。

音频模式与视频模式共享**同一播放会话**（同一 ExoPlayer 实例），进度互通与「返回回到视频界面」均为同一根因的衍生现象，不涉及进度同步缺陷。

## 修复方案

- `playAllSpaceVideos` 直接调用 **`onVideoClick(...)`**，进入视频播放界面；`PlaylistManager` 外部队列注入（`source = SPACE`）与 **`SEQUENTIAL`** 播放模式设置保持不变。
- 移除因此失去唯一消费者的 **`onPlayAllAudioClick` 参数链**（SpaceScreen 外层参数、向 SpaceContent 的下传与形参）及 `AppNavigation` 中对应的 `startAudio = true` 接线，避免同类误导再次引发回归。
- 不改动任何**播放、队列、自动连播逻辑**；稍后再看、收藏夹等各自独立的「全部听」入口不受影响。

## 验证

- **`:app:compileDebugKotlin` 通过**（rebase 后复验通过；仅两处与本次无关的既有警告）。
- `:app:assembleDev` 构建的 dev 测试包**真机安装验证**：投稿页「播放全部」直接进入**视频播放界面**并按当前排序连播；单个视频点击仍建立整个投稿队列。
- 分支已 **rebase 到 main 最新**（beta.22），与上游 17 个新提交无冲突。